### PR TITLE
fix: Make signature header optional

### DIFF
--- a/buildSrc/src/main/kotlin/codegen/WebhooksBuilder.kt
+++ b/buildSrc/src/main/kotlin/codegen/WebhooksBuilder.kt
@@ -72,7 +72,9 @@ object WebhooksBuilder {
                     val type = schema.className()
                     writer.write("    ResponseEntity<T> $methodName(\n")
                     operation.parameters.filter { it.`in` == "header" }.forEach {
-                        writer.write("        @RequestHeader(name = \"${it.name}\") String ${it.name.camelCase()},\n")
+                        val required = !it.name.startsWith("X-Hub-Signature")
+                        writer.write("""        @RequestHeader(required = ${required},name = "${it.name}") String ${it.name.camelCase()},""")
+                        writer.write("\n")
                     }
                     writer.write("        @RequestBody ${type} requestBody\n")
                     writer.write("    );\n")


### PR DESCRIPTION
It is present only when a secret is specified.