### PR TITLE
chore: Use all ETags

### DIFF
--- a/graphql.gradle.kts
+++ b/graphql.gradle.kts
@@ -27,7 +27,7 @@ val downloadSchema = tasks.register<Download>("downloadSchema") {
     dest(file("${project.layout.buildDirectory.get()}/resources/main/schema.graphqls"))
     onlyIfModified(true)
     tempAndMove(true)
-    useETag(true)
+    useETag("all")
 
     inputs.property("url", getUrl(projectVariant))
     outputs.file(file("${project.layout.buildDirectory.get()}/resources/main/schema.graphqls"))

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -32,7 +32,7 @@ val downloadSchema = tasks.register<Download>("downloadSchema") {
     dest(file("${project.layout.buildDirectory.get()}/generated/resources/main/schema.json"))
     onlyIfModified(true)
     tempAndMove(true)
-    useETag(true)
+    useETag("all")
 
     inputs.property("url", getUrl(projectVariant))
     outputs.file(file("${project.layout.buildDirectory.get()}/generated/resources/main/schema.json"))


### PR DESCRIPTION
Otherwise it logs this warning

```
Weak entity tag (ETag) encountered. Please make sure you want to compare resources based on weak ETags. If yes, set the 'useETag' flag to "all", otherwise set it to "strongOnly".
```