### PR TITLE
refactor: Use builders for generated types

### DIFF
--- a/buildSrc/src/main/kotlin/codegen/Annotations.kt
+++ b/buildSrc/src/main/kotlin/codegen/Annotations.kt
@@ -15,11 +15,11 @@ object Annotations {
 
     fun setter(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", "Setter")).build()
 
-    fun lombokAccessors(): AnnotationSpec =
-        AnnotationSpec.builder(ClassName.get("lombok.experimental", "Accessors"))
-            .addMember("chain", "true")
-            .addMember("fluent", "false")
-            .build()
+    fun lombokBuilder(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", "Builder")).build()
+
+    fun noArgsConstructor(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", "NoArgsConstructor")).build()
+
+    fun allArgsConstructor(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", "AllArgsConstructor")).build()
 
     /*
      Jackson Annotations

--- a/buildSrc/src/main/kotlin/codegen/JsonRefValidator.kt
+++ b/buildSrc/src/main/kotlin/codegen/JsonRefValidator.kt
@@ -21,9 +21,9 @@ object JsonRefValidator {
                     .flatMap {
                         it.readLines().mapIndexed { lineNumber, line -> Triple(it, lineNumber, line) }
                             .filter { l -> l.third.matches(Regex(" +from = \".+\",")) }
-                            .map { Triple(it.first, it.second, it.third.replace(Regex(" +from = \"(.+)\","), "$1")) }
+                            .map { x -> Triple(x.first, x.second, x.third.replace(Regex(" +from = \"(.+)\","), "$1")) }
                     }
-                    .toSortedSet(Comparator { o1, o2 -> o1.toString().compareTo(o2.toString()) })
+                    .toSortedSet { o1, o2 -> o1.toString().compareTo(o2.toString()) }
                     .count { hasError(json, it) }
             }
         if (count > 0) {

--- a/buildSrc/src/main/kotlin/codegen/TestBuilder.kt
+++ b/buildSrc/src/main/kotlin/codegen/TestBuilder.kt
@@ -61,7 +61,7 @@ object TestBuilder {
         return methodSpec
     }
 
-    fun String.quote() = "\"$this\""
+    private fun String.quote() = "\"$this\""
 
-    fun String.blockQuote() = "\n${this.replace("\\", "\\\\")}\n".quote().quote().quote()
+    private fun String.blockQuote() = "\n${this.replace("\\", "\\\\")}\n".quote().quote().quote()
 }

--- a/buildSrc/src/main/kotlin/codegen/Types.kt
+++ b/buildSrc/src/main/kotlin/codegen/Types.kt
@@ -8,42 +8,42 @@ import com.palantir.javapoet.TypeName
 
 object Types {
     // Almost Primitives
-    val BOOLEAN = ClassName.get("java.lang", "Boolean")
-    val INTEGER = ClassName.get("java.lang", "Integer")
-    val LONG = ClassName.get("java.lang", "Long")
-    val FLOAT = ClassName.get("java.lang", "Float")
-    val DOUBLE = ClassName.get("java.lang", "Double")
-    val STRING = ClassName.get("java.lang", "String")
-    val BIG_DECIMAL = ClassName.get("java.math", "BigDecimal")
-    val BYTE_ARRAY = ArrayTypeName.of(TypeName.BYTE)
-    val URI = ClassName.get("java.net", "URI")
-    val UUID = ClassName.get("java.util", "UUID")
-    val VOID = ClassName.get("java.lang", "Void")
+    val BOOLEAN: ClassName = ClassName.get("java.lang", "Boolean")
+    val INTEGER: ClassName = ClassName.get("java.lang", "Integer")
+    val LONG: ClassName = ClassName.get("java.lang", "Long")
+    val FLOAT: ClassName = ClassName.get("java.lang", "Float")
+    val DOUBLE: ClassName = ClassName.get("java.lang", "Double")
+    val STRING: ClassName = ClassName.get("java.lang", "String")
+    val BIG_DECIMAL: ClassName = ClassName.get("java.math", "BigDecimal")
+    val BYTE_ARRAY: ArrayTypeName = ArrayTypeName.of(TypeName.BYTE)
+    val URI: ClassName = ClassName.get("java.net", "URI")
+    val UUID: ClassName = ClassName.get("java.util", "UUID")
+    val VOID: ClassName = ClassName.get("java.lang", "Void")
 
     // Time types
-    val EPOCH_TIME =
+    val EPOCH_TIME: TypeName =
         ClassName.get("java.time", "OffsetDateTime")
             .annotated(jsonFormat("NUMBER_INT"))
-    val LOCAL_DATE =
+    val LOCAL_DATE: TypeName =
         ClassName.get("java.time", "LocalDate")
             .annotated(jsonFormat("STRING", "yyyy-MM-dd"))
-    val OFFSET_DATE_TIME =
+    val OFFSET_DATE_TIME: TypeName =
         ClassName.get("java.time", "OffsetDateTime")
             .annotated(jsonFormat("STRING", "yyyy-MM-dd'T'HH:mm:ssXXX"))
 
     // Common Types
-    val EMPTY_OBJECT = ClassName.get("io.github.pulpogato.common", "EmptyObject")
-    val OBJECT = ClassName.get("java.lang", "Object")
-    val STRING_OBJECT_OR_INTEGER = ClassName.get("io.github.pulpogato.common", "StringObjectOrInteger")
-    val STRING_OR_INTEGER = ClassName.get("io.github.pulpogato.common", "StringOrInteger")
-    val STRING_OR_OBJECT = ClassName.get("io.github.pulpogato.common", "StringOrObject")
-    val TODO = ClassName.get("io.github.pulpogato.common", "Todo")
+    val EMPTY_OBJECT: ClassName = ClassName.get("io.github.pulpogato.common", "EmptyObject")
+    val OBJECT: ClassName = ClassName.get("java.lang", "Object")
+    val STRING_OBJECT_OR_INTEGER: ClassName = ClassName.get("io.github.pulpogato.common", "StringObjectOrInteger")
+    val STRING_OR_INTEGER: ClassName = ClassName.get("io.github.pulpogato.common", "StringOrInteger")
+    val STRING_OR_OBJECT: ClassName = ClassName.get("io.github.pulpogato.common", "StringOrObject")
+    val TODO: ClassName = ClassName.get("io.github.pulpogato.common", "Todo")
 
     // Utility types
-    val LIST = ClassName.get("java.util", "List")
-    val MAP = ClassName.get("java.util", "Map")
+    val LIST: ClassName = ClassName.get("java.util", "List")
+    val MAP: ClassName = ClassName.get("java.util", "Map")
 
     // Common Parameterized Types
-    val LIST_OF_STRINGS = ParameterizedTypeName.get(LIST, ClassName.get("java.lang", "String"))
-    val MAP_STRING_OBJECT = ParameterizedTypeName.get(MAP, ClassName.get("java.lang", "String"), ClassName.get("java.lang", "Object"))
+    val LIST_OF_STRINGS: ParameterizedTypeName = ParameterizedTypeName.get(LIST, ClassName.get("java.lang", "String"))
+    val MAP_STRING_OBJECT: ParameterizedTypeName = ParameterizedTypeName.get(MAP, ClassName.get("java.lang", "String"), ClassName.get("java.lang", "Object"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=false
+org.gradle.jvmargs=-Xmx4g


### PR DESCRIPTION
The earlier code used Accessors. This makes it easier for users.