### PR TITLE
chore: Deduplicate build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: gradle/actions/setup-gradle@v4
 
     - name: Build
-      id: gradle
+      if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
       run: ./gradlew build
 
     - name: Build Snapshot


### PR DESCRIPTION
This works correctly:
- For final tags, run final.
- For candidate tags, run candidate.
- For main branch, run snapshot.

For each of those and for everything else, we ran `build`.

This change makes it so we don't run `build` for those but only for everything else.