### PR TITLE
chore(intellij): Make test logger play better with IntelliJ

### DIFF
--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -103,7 +103,7 @@ tasks.withType<Test> {
 }
 
 testlogger {
-    theme = ThemeType.MOCHA
+    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN else ThemeType.MOCHA
     slowThreshold = 5000
 
     showPassed = false


### PR DESCRIPTION
By default intellij doesn't support ansi escape codes. This makes the test logger not use ansi codes when running in intellij.