### PR TITLE
refactor: Use MockMVC Tests instead of full integration tests

### DIFF
--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -1,55 +1,12 @@
 package io.github.pulpogato.rest.api;
 
-import io.github.pulpogato.test.ProxyApplication;
-import org.junit.jupiter.api.BeforeEach;
+import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.support.WebClientAdapter;
-import org.springframework.web.service.invoker.HttpServiceProxyFactory;
-import reactor.netty.http.client.HttpClient;
-
-import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        classes = {ProxyApplication.class},
-        properties = {
-                "spring.application.name=pulpogato-demo",
-                "logging.level.org.springframework.web.client.RestTemplate=DEBUG",
-                "logging.level.org.apache.http.wire=DEBUG",
-        }
-)
-class UsersApiIntegrationTest {
-
-    @LocalServerPort
-    int randomServerPort;
-
-    HttpServiceProxyFactory factory;
-
-    @BeforeEach
-    void setUp(TestInfo testInfo) {
-        HttpClient httpClient = HttpClient.create();
-
-        String classPart = testInfo.getTestClass().map(Class::getName).map(name -> name.replace(".", "/")).orElseThrow();
-        String methodPart = testInfo.getTestMethod().map(Method::getName).orElseThrow();
-
-        final var webClient = WebClient.builder()
-                .baseUrl("http://localhost:" + randomServerPort)
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .defaultHeader("TapeName", classPart + "/" + methodPart)
-                .build();
-
-        factory = HttpServiceProxyFactory.builder()
-                .exchangeAdapter(WebClientAdapter.create(webClient))
-                .build();
-    }
+class UsersApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAuthenticatedPublic() {

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetAuthenticatedPrivate.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetAuthenticatedPrivate.yml
@@ -3,7 +3,7 @@
     uri: /user
     protocol: HTTP/1.1
     headers:
-      accept: application/json
+      Accept: application/json
     body: null
   response:
     statusCode: 200

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetAuthenticatedPublic.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetAuthenticatedPublic.yml
@@ -3,7 +3,7 @@
     uri: /user
     protocol: HTTP/1.1
     headers:
-      accept: application/json
+      Accept: application/json
     body: null
   response:
     statusCode: 200

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
@@ -1,0 +1,49 @@
+package io.github.pulpogato.test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.client.MockMvcHttpConnector;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.lang.reflect.Method;
+
+@SpringBootTest(
+        classes = {ProxyController.class},
+        properties = {
+                "logging.level.org.springframework.web.client.RestTemplate=DEBUG",
+                "logging.level.org.apache.http.wire=DEBUG",
+        }
+)
+public class BaseIntegrationTest {
+    @SuppressWarnings("unused")
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    protected HttpServiceProxyFactory factory;
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        String classPart = testInfo.getTestClass().map(Class::getName)
+                .map(name -> name.replace(".", "/"))
+                .orElseThrow();
+        String methodPart = testInfo.getTestMethod().map(Method::getName)
+                .orElseThrow();
+
+        var mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        final var webClient = WebClient.builder()
+                .clientConnector(new MockMvcHttpConnector(mockMvc))
+                .defaultHeader("TapeName", classPart + "/" + methodPart)
+                .build();
+
+        factory = HttpServiceProxyFactory.builder()
+                .exchangeAdapter(WebClientAdapter.create(webClient))
+                .build();
+    }
+}

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
@@ -22,9 +22,15 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
-@SuppressWarnings("unused")
 @RestController
 @Slf4j
 public class ProxyController {
@@ -33,6 +39,7 @@ public class ProxyController {
     private static final int port = 443;
 
     @RequestMapping("/**")
+    @SuppressWarnings("unused")
     public ResponseEntity<String> mirrorRest(@RequestBody(required = false) String body, HttpMethod method, HttpServletRequest request) throws URISyntaxException, IOException {
         var pathName = request.getHeaders("TapeName").nextElement();
         var resourceName = "tapes/" + pathName + ".yml";


### PR DESCRIPTION
Prior to this change, we used full Integration tests that spin up a full application. That takes a lot of time and needs to allocate a random port.

This change switches to MockMvc test - that's much faster.

Also, this extracts all the test configuration to `BaseIntegrationTest` so more tests can be written.