### PR TITLE
chore: Manage pitest versions better

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,9 @@ kotlin = "2.1.10"
 ktlint = "12.2.0"
 lombok = "1.18.36"
 mockito = "5.15.2"
-pitest = "1.15.0"
+pitest = "1.18.2"
+pitestJunit5Plugin = "1.2.1"
+pitestPlugin = "1.15.0"
 reflections = "0.10.2"
 slf4j = "2.0.17"
 spring = "6.2.3"
@@ -34,6 +36,8 @@ javapoet = { group = "com.palantir.javapoet", name = "javapoet", version.ref = "
 junit = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+pitest = { group = "org.pitest", name = "pitest", version.ref = "pitest" }
+pitestJunit5Plugin = { group = "org.pitest", name = "pitest-junit5-plugin", version.ref = "pitestJunit5Plugin" }
 reflections = { group = "org.reflections", name = "reflections", version.ref = "reflections" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 springBootTest = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "springBoot" }
@@ -53,7 +57,7 @@ download = { id = "de.undercouch.download", version.ref = "download" }
 javaLibrary = { id = "java-library" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-pitest = { id = "info.solidsoft.pitest", version.ref = "pitest" }
+pitest = { id = "info.solidsoft.pitest", version.ref = "pitestPlugin" }
 testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }
 waenaPublished = { id = "com.github.rahulsom.waena.published", version.ref = "waena" }
 waenaRoot = { id = "com.github.rahulsom.waena.root", version.ref = "waena" }

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -114,8 +114,8 @@ testlogger {
 
 pitest {
     timestampedReports = false
-    junit5PluginVersion.set("1.2.1") // Look here for latest version - https://github.com/pitest/pitest-junit5-plugin/tags
-    pitestVersion.set("1.18.2") // Look here for latest version - https://github.com/hcoles/pitest/releases
+    junit5PluginVersion.set(libs.versions.pitestJunit5Plugin) // Look here for latest version - https://github.com/pitest/pitest-junit5-plugin/tags
+    pitestVersion.set(libs.versions.pitest) // Look here for latest version - https://github.com/hcoles/pitest/releases
     mutators.set(setOf("ALL"))
     outputFormats.set(setOf("XML", "HTML"))
 }


### PR DESCRIPTION
Prior to this change, pitest versions were managed by explicitly setting them in a place renovate wouldn't know to look.

This change points `libs.versions.toml` to the manen library.

Then it pulls the version into the same place.