### PR TITLE
chore: Cache bunInstall

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,10 +42,8 @@ waena {
     publishMode.set(WaenaExtension.PublishMode.Central)
 }
 
-tasks.register("bunInstall") {
-    doLast {
-        exec {
-            commandLine("bun", "install")
-        }
-    }
+tasks.register("bunInstall", Exec::class) {
+    commandLine("bun", "install")
+    inputs.files("package.json", "bun.lock")
+    outputs.dir("node_modules")
 }


### PR DESCRIPTION
It depends on `package.json`, `bun.lock` and produces `node_modules`.