### PR TITLE
refactor: Extract versions to libs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ dgs = "7.0.3"
 download = "5.6.0"
 jackson = "2.18.3"
 javapoet = "0.6.0"
+glassfishJson = "1.1.4"
+jsonApi = "1.1.4"
 junit = "5.8.2"
 kotlin = "2.1.10"
 ktlint = "12.2.0"
@@ -31,10 +33,12 @@ assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 commonmarkTables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
 commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commons-text" }
+glassfishJson = { group = "org.glassfish", name = "javax.json", version.ref = "glassfishJson" }
 jacksonCore = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
 jacksonTime = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 jacksonYaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson" }
 javapoet = { group = "com.palantir.javapoet", name = "javapoet", version.ref = "javapoet" }
+jsonApi = { group = "javax.json", name = "javax.json-api", version.ref = "jsonApi" }
 junit = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }

--- a/pulpogato-rest-tests/build.gradle.kts
+++ b/pulpogato-rest-tests/build.gradle.kts
@@ -9,8 +9,8 @@ dependencies {
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 
-    implementation("javax.json:javax.json-api:1.1.4")
-    implementation("org.glassfish:javax.json:1.1.4")
+    implementation(libs.jsonApi)
+    implementation(libs.glassfishJson)
     implementation(project(":${rootProject.name}-common"))
 
     implementation(libs.reflections)


### PR DESCRIPTION
There were two remaining dependencies not in libs.versions.toml.

This change extracts them.