### PR TITLE
chore: Trigger build manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     tags:
     - 'v[0-9]+.[0-9]+.[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+-rc.[1-9][0-9]*'
+  repository_dispatch:
+    types:
+    - create-pull-request
 
 jobs:
   build:

--- a/.github/workflows/update-schema-version.yml
+++ b/.github/workflows/update-schema-version.yml
@@ -51,3 +51,13 @@ jobs:
           else
             gh pr list --base main --head update-schema-version | cat -
           fi
+
+      - name: Run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            https://api.github.com/repos/pulpogato/pulpogato/dispatches \
+            -d '{"event_type": "create-pull-request"}'


### PR DESCRIPTION
GHA doesn't run PR builds when PRs are created using an action. See https://github.com/orgs/community/discussions/65321

This works around that.