### PR TITLE
refactor: Use SuperBuilder instead of Builder

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -17,6 +17,12 @@ object Annotations {
      */
     fun lombok(name: String): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", name)).build()
 
+    fun superBuilder() =
+        AnnotationSpec
+            .builder(ClassName.get("lombok.experimental", "SuperBuilder"))
+            .addMember("toBuilder", "true")
+            .build()
+
     /*
      Jackson Annotations
      */

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -15,6 +15,7 @@ import io.github.pulpogato.restcodegen.Annotations.jsonValue
 import io.github.pulpogato.restcodegen.Annotations.lombok
 import io.github.pulpogato.restcodegen.Annotations.serializerAnnotation
 import io.github.pulpogato.restcodegen.Annotations.singleValueAsArray
+import io.github.pulpogato.restcodegen.Annotations.superBuilder
 import io.github.pulpogato.restcodegen.Annotations.typeGenerated
 import io.github.pulpogato.restcodegen.Context
 import io.github.pulpogato.restcodegen.MarkdownHelper
@@ -253,7 +254,7 @@ private fun Map.Entry<String, Schema<*>>.buildFancyObject(
             .addType(serializer)
             .addAnnotation(deserializerAnnotation(className, deserializer))
             .addAnnotation(serializerAnnotation(className, serializer))
-            .addAnnotation(lombok("Builder"))
+            .addAnnotation(superBuilder())
             .addAnnotation(lombok("NoArgsConstructor"))
             .addAnnotation(lombok("AllArgsConstructor"))
 
@@ -400,7 +401,7 @@ private fun Map.Entry<String, Schema<*>>.buildSimpleObject(
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(generated(0))
             .addAnnotation(lombok("Data"))
-            .addAnnotation(lombok("Builder"))
+            .addAnnotation(superBuilder())
             .addAnnotation(lombok("NoArgsConstructor"))
             .addAnnotation(lombok("AllArgsConstructor"))
             .addAnnotation(jsonIncludeNonNull())

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testCreateRepositoryInOrgWithExtendedCustomProperties.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testCreateRepositoryInOrgWithExtendedCustomProperties.yml
@@ -10,7 +10,7 @@
         "name" : "rsomasunderam-custom-props-demo",
         "description" : "create demo",
         "custom_properties" : {
-          "custom_boolean_prop" : "false"
+          "custom_boolean_prop" : false
         }
       }
   response:
@@ -138,7 +138,7 @@
         "merge_commit_message" : "PR_TITLE",
         "merge_commit_title" : "MERGE_MESSAGE",
         "custom_properties" : {
-          "custom_boolean_prop" : "false"
+          "custom_boolean_prop" : false
         },
         "organization" : {
           "login" : "example",

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
@@ -146,6 +146,7 @@ public class ProxyController {
                 "Last-Modified",
                 "Referrer-Policy",
                 "Server",
+                "Set-Cookie",
                 "Strict-Transport-Security",
                 "Vary",
                 "X-.+"

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
 
     testImplementation(project(":${rootProject.name}-rest-tests"))
     testImplementation(libs.bundles.springBoot)
+    testCompileOnly(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
 }
 
 fun getUrl(projectVariant: String): String {


### PR DESCRIPTION
This allows customizing `extraProperties` from the schema.

The example in the tests is `ReposApi.CreateInOrgRequestBody`. It introduces a typed `TestCustomProperties`.

It's not easy, but the example solves that problem reasonably.