### PR TITLE
chore: Drop kotlin plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ javapoet = "0.6.0"
 glassfishJson = "1.1.4"
 jsonApi = "1.1.4"
 junit = "5.11.4"
-kotlin = "2.1.20"
 ktlint = "12.2.0"
 lombok = "1.18.36"
 mockito = "5.16.1"
@@ -63,7 +62,6 @@ springBoot = ["springBootTest", "springBootWeb", "springBootWebflux"]
 dgs = { id = "com.netflix.dgs.codegen", version.ref = "dgs" }
 download = { id = "de.undercouch.download", version.ref = "download" }
 javaLibrary = { id = "java-library" }
-kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 pitest = { id = "info.solidsoft.pitest", version.ref = "pitestPlugin" }
 testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }


### PR DESCRIPTION
It's not needed since the plugin uses the kotlin-dsl plugin.