### PR TITLE
refactor: Make context immutable

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -76,11 +76,14 @@ object Annotations {
     /*
      GH Annotations
      */
-    fun generated(offset: Int): AnnotationSpec {
+    fun generated(
+        offset: Int,
+        context: Context,
+    ): AnnotationSpec {
         val builder =
             AnnotationSpec.builder(ClassName.get("io.github.pulpogato.common", "Generated"))
-                .addMember("ghVersion", "\$S", Context.instance.get().version)
-        val schemaRef = Context.getSchemaStackRef()
+                .addMember("ghVersion", "\$S", context.version)
+        val schemaRef = context.getSchemaStackRef()
         if (schemaRef.isNotEmpty()) {
             builder.addMember("schemaRef", "\$S", schemaRef)
         }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -49,11 +49,12 @@ open class GenerateJavaTask : DefaultTask() {
         val result = OpenAPIParser().readContents(swaggerSpec, listOf(), parseOptions)
 
         val openAPI = result.openAPI
-        Context.instance.get().openAPI = openAPI
-        Context.instance.get().version = projectName.get().replace("pulpogato-rest-", "")
-        PathsBuilder().buildApis(main, "$packageNamePrefix.rest.api", test)
-        WebhooksBuilder().buildWebhooks(main, "$packageNamePrefix.rest", "$packageNamePrefix.rest.webhooks", test)
-        SchemasBuilder().buildSchemas(main, "$packageNamePrefix.rest.schemas")
+        val version = projectName.get().replace("pulpogato-rest-", "")
+
+        val context = Context(openAPI, version, emptyList())
+        PathsBuilder().buildApis(context, main, "$packageNamePrefix.rest.api", test)
+        WebhooksBuilder().buildWebhooks(context, main, "$packageNamePrefix.rest", "$packageNamePrefix.rest.webhooks", test)
+        SchemasBuilder().buildSchemas(context, main, "$packageNamePrefix.rest.schemas")
 
         // Validate JSON references
         val json = ObjectMapper().readTree(swaggerSpec)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/JsonRefValidator.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/JsonRefValidator.kt
@@ -30,7 +30,7 @@ class JsonRefValidator(private val threshold: Int = 0) {
                         val (file, lineNumber, line) = it
                         hasError(json, it).also { l ->
                             if (l) {
-                                println("${file.absolutePath}:${lineNumber + 1}: E:BAD_REF \"${line}\"\n")
+                                println("${file.absolutePath}:${lineNumber + 1}:\n\tE:BAD_REF \"${line}\"\n")
                             }
                         }
                     }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
@@ -6,15 +6,14 @@ import java.io.File
 
 class SchemasBuilder {
     fun buildSchemas(
+        context: Context,
         outputDir: File,
         packageName: String,
     ) {
-        val openAPI = Context.instance.get().openAPI
+        val openAPI = context.openAPI
         openAPI.components.schemas.forEach { entry ->
             val (_, definition) =
-                Context.withSchemaStack("#", "components", "schemas", entry.key) {
-                    referenceAndDefinition(entry, "", null)!!
-                }
+                referenceAndDefinition(context.withSchemaStack("#", "components", "schemas", entry.key), entry, "", null)!!
             definition?.let {
                 JavaFile.builder(packageName, it).build().writeTo(outputDir)
             }


### PR DESCRIPTION
Instead of being a singleton, this is now passed along in method calls.
This makes it easier to track changes to the schema stack.
