### PR TITLE
chore: Improve validation errors

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -55,10 +55,6 @@ open class GenerateJavaTask : DefaultTask() {
         WebhooksBuilder().buildWebhooks(main, "$packageNamePrefix.rest", "$packageNamePrefix.rest.webhooks", test)
         SchemasBuilder().buildSchemas(main, "$packageNamePrefix.rest.schemas")
 
-        // Validate JSON references
-        val json = ObjectMapper().readTree(swaggerSpec)
-        JsonRefValidator(142).validate(json, listOf(main, test))
-
         // Format generated Java code
         val javaFiles = getJavaFiles(main)
         val testJavaFiles = getJavaFiles(test)
@@ -67,6 +63,10 @@ open class GenerateJavaTask : DefaultTask() {
             val formatted = formatter.apply(f.readText())
             f.writeText(formatted)
         }
+
+        // Validate JSON references
+        val json = ObjectMapper().readTree(swaggerSpec)
+        JsonRefValidator(142).validate(json, listOf(main, test))
     }
 
     private fun getJavaFiles(dir: File): List<File> {


### PR DESCRIPTION
We detected errors first and then formatted code.
So line numbers were sometimes very wrong.

This change flips the order and makes the validator account for newlines in the regex.
