### PR TITLE
fix: Fix more schema refs

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -67,7 +67,7 @@ open class GenerateJavaTask : DefaultTask() {
 
         // Validate JSON references
         val json = ObjectMapper().readTree(swaggerSpec)
-        JsonRefValidator(140).validate(json, listOf(main, test))
+        JsonRefValidator(2).validate(json, listOf(main, test))
     }
 
     private fun getJavaFiles(dir: File): List<File> {

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -295,7 +295,8 @@ private fun processSubSchema(
         if (rad.second != null) {
             val builder = rad.second!!.toBuilder()
             if (rad.first is ClassName) {
-                addProperties(context, entry, rad.first as ClassName, builder)
+                val parentStack = context.schemaStack.dropLast(2).toTypedArray()
+                addProperties(context.withSchemaStack(*parentStack), entry, rad.first as ClassName, builder)
             }
             theType.addType(builder.addModifiers(Modifier.STATIC).build())
         }


### PR DESCRIPTION
This goes from 140 to 2.

For fancy types, the parent properties are being set too.
But the ref was incorrect. This fixes that.
