### PR TITLE
chore(build): Fail when no schema is present

### DIFF
--- a/graphql.gradle.kts
+++ b/graphql.gradle.kts
@@ -46,6 +46,10 @@ val downloadSchema = tasks.register<Download>("downloadSchema") {
         val hashBytes = digest.digest(schemaBytes)
         val sha256 = hashBytes.joinToString("") { "%02x".format(it) }
         project.ext.set("github.schema.sha256", sha256)
+
+        if (!originalSchemaLocation.exists()) {
+            throw GradleException("Failed to download schema from ${getUrl(projectVariant)}")
+        }
     }
 }
 

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -49,6 +49,11 @@ val downloadSchema = tasks.register("downloadSchema") {
         val hashBytes = digest.digest(schemaBytes)
         val sha256 = hashBytes.joinToString("") { "%02x".format(it) }
         project.ext.set("github.api.sha256", sha256)
+
+        if (!schemaLocation.exists()) {
+            throw GradleException("Failed to download schema from ${getUrl(projectVariant)}")
+        }
+
     }
 }
 


### PR DESCRIPTION
Sometimes download fails, causing in a bad artifact.
