### PR TITLE
chore: Cache schemas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,19 @@ jobs:
 
     - uses: gradle/actions/setup-gradle@v4
 
+    - name: Extract GitHub API Version
+      id: api-version
+      run: echo "version=$(grep 'github.api.version' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+
+    - name: Cache Downloaded Schemas
+      id: schema-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          */build/generated/resources/main/schema.json
+          */build/resources/main/schema.graphqls
+        key: schema-cache-${{ steps.api-version.outputs.version }}
+
     - name: Build Codegen
       if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
       run: ./gradlew --project-dir gradle/pulpogato-rest-codegen check pitest


### PR DESCRIPTION
GraphQL schemas are downloaded from docs.
REST schemas are downloaded from the raw endpoint on GH.

Sometimes, these can fail.
Having a cached version on GHA can reduce build failures.
