### PR TITLE
chore: Run pitest only for fpt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Build Main Project
       if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
-      run: ./gradlew build pitest --max-workers=2 --continue
+      run: ./gradlew build :pulpogato-rest-fpt:pitest --max-workers=2 --continue
 
     - name: Build Snapshot
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
If it runs for fpt, it will run for other variants.
