### PR TITLE
chore: Drop schema.json from rest jar

### DIFF
--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -93,6 +93,11 @@ sourceSets {
     }
 }
 
+// Exclude schema.json from the main jar
+tasks.named<Jar>("jar") {
+    exclude("schema.json")
+}
+
 tasks.withType<Javadoc>().configureEach {
     isFailOnError = false
     (options as StandardJavadocDocletOptions).apply {


### PR DESCRIPTION
It's still left in the sourcesJar.
