### PR TITLE
chore: Use commons-lang-3 to generate toString methods

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 annotations = "26.0.2-1"
 assertj = "3.27.6"
 commonmark = "0.26.0"
+commons-lang3 = "3.13.0"
 commons-text = "1.14.0"
 dgs = "8.1.1"
 download = "5.6.0"
@@ -33,6 +34,7 @@ annotations = { group = "org.jetbrains", name = "annotations", version.ref = "an
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 commonmarkTables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
+commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
 commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commons-text" }
 glassfishJson = { group = "org.glassfish", name = "javax.json", version.ref = "glassfishJson" }
 httpclient5 = { group = "org.apache.httpcomponents.client5", name = "httpclient5", version.ref = "httpclient5" }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
@@ -59,6 +59,8 @@ object Types {
     // Utility types
     val LIST: ClassName = ClassName.get(List::class.java)
     val MAP: ClassName = ClassName.get(Map::class.java)
+    val TO_STRING_BUILDER: ClassName = ClassName.get("org.apache.commons.lang3.builder", "ToStringBuilder")
+    val TO_STRING_STYLE: ClassName = ClassName.get("org.apache.commons.lang3.builder", "ToStringStyle")
 
     // Common Parameterized Types
     val MAP_STRING_OBJECT: ParameterizedTypeName = ParameterizedTypeName.get(MAP, STRING, OBJECT)

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     compileOnly(libs.springWeb)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
+    implementation(libs.commonsLang3)
 
     api(project(":${rootProject.name}-common"))
 


### PR DESCRIPTION
Prior to this we were using Lombok's toString and it was harder to read for the larger models.
This renders it more like JSON and should make it easier.
