### PR TITLE
chore: Replace deprecated jackson method call

### DIFF
--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestUtils.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestUtils.java
@@ -24,7 +24,7 @@ public class TestUtils {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(new JavaTimeModule())
             .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
 


### PR DESCRIPTION
setSerializationInclusion was deprecated in favor of setDefaultPropertyInclusion.
