### PR TITLE
chore: Rename github.api.version to gh.api.version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Extract GitHub API Version
       id: api-version
-      run: echo "version=$(grep 'github.api.version' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+      run: echo "version=$(grep 'gh.api.version' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
 
     - name: Cache Downloaded Schemas
       id: schema-cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Code generation is core to the project:
 - Parallel builds enabled (`org.gradle.parallel=true`)
 - Custom JVM args for compilation with module exports
 - Memory allocated: 4GB (`-Xmx4g`)
-- GitHub API version tracked in `gradle.properties` as `github.api.version`
+- GitHub API version tracked in `gradle.properties` as `gh.api.version`
 
 ## Testing Approach
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,12 +65,12 @@ tasks.register("updateRestSchemaVersion") {
         val json = ObjectMapper().readTree(branches)
         val sha = json.get("commit").get("sha").asText().take(7)
         val oldProps = project.file("gradle.properties").readText()
-        val newProps = oldProps.replace(Regex("github.api.version=.*"), "github.api.version=$sha")
+        val newProps = oldProps.replace(Regex("gh.api.version=.*"), "gh.api.version=$sha")
         project.file("gradle.properties").writeText(newProps)
-        if (project.ext.get("github.api.version") != sha) {
-            println("Updated github.api.version from ${project.ext.get("github.api.version")} to $sha")
+        if (project.ext.get("gh.api.version") != sha) {
+            println("Updated gh.api.version from ${project.ext.get("gh.api.version")} to $sha")
         } else {
-            println("github.api.version is already up to date")
+            println("gh.api.version is already up to date")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx4g \
 org.gradle.parallel=true
 
 # GitHub REST API Description SHA
-github.api.version=dee4dc2
+gh.api.version=dee4dc2

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
 fun getUrl(projectVariant: String): String {
     val path = if (projectVariant == "fpt") "api.github.com" else projectVariant
-    val ref = project.ext.get("github.api.version")
+    val ref = project.ext.get("gh.api.version")
     return "https://github.com/github/rest-api-description/raw/$ref/descriptions-next/$path/$path.json"
 }
 
@@ -37,7 +37,7 @@ description = "REST types for $projectVariant"
 
 val downloadSchema = tasks.register("downloadSchema") {
     val schemaLocation = file("${project.layout.buildDirectory.get()}/generated/resources/main/schema.json")
-    inputs.property("github.api.version", project.ext.get("github.api.version"))
+    inputs.property("gh.api.version", project.ext.get("gh.api.version"))
     outputs.file(schemaLocation)
 
     doLast {
@@ -171,7 +171,7 @@ publishing {
                     val propertiesNode = root.get("properties") as groovy.util.NodeList
                     if (propertiesNode.isNotEmpty()) {
                         val propNode = propertiesNode.first() as groovy.util.Node
-                        propNode.appendNode("github.api.version", project.ext.get("github.api.version").toString())
+                        propNode.appendNode("gh.api.version", project.ext.get("gh.api.version").toString())
                         propNode.appendNode("github.api.sha256", project.ext.get("github.api.sha256").toString())
                     }
                 }

--- a/update-schema-version.sh
+++ b/update-schema-version.sh
@@ -16,11 +16,11 @@ else
     git checkout main
 fi
 
-OLD_SHA=$(grep github.api.version gradle.properties | cut -d'=' -f2)
+OLD_SHA=$(grep gh.api.version gradle.properties | cut -d'=' -f2)
 export OLD_SHA
 
 ./gradlew updateRestSchemaVersion
-NEW_SHA=$(grep github.api.version gradle.properties | cut -d'=' -f2)
+NEW_SHA=$(grep gh.api.version gradle.properties | cut -d'=' -f2)
 export NEW_SHA
 
 BRANCH_NAME=update-schema-version


### PR DESCRIPTION
'github.api.version in a workflow file confuses IntelliJ.
