### PR TITLE
chore: Provide context when schema references invalid $ref

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -238,6 +238,9 @@ private fun buildReferenceAndDefinitionFromRef(
         context.openAPI.components.schemas
             .filter { (k, _) -> k == schemaName }
             .entries
+    if (entries.isEmpty()) {
+        throw RuntimeException("Could not find schema for ref \"${entry.value.`$ref`}\", stack: \"${context.getSchemaStackRef()}\"")
+    }
     val schema = entries.first()
     return referenceAndDefinition(context.withSchemaStack("#", "components", "schemas", schemaName), schema, "", null)!!.copy(second = null)
 }


### PR DESCRIPTION
Prior to this, we would get a `Collection was empty` message.

Now we get the schemastack and ref. E.g.

```
Could not find schema for ref "#/components/schemas/events/create-event", stack: "#/components/schemas/event/properties/payload/oneOf/0"
```
