### PR TITLE
fix: Handle nulls better in Webhooks

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -185,7 +185,8 @@ class WebhooksBuilder {
         val routerBuilder = StringWriter()
         val printWriter = PrintWriter(routerBuilder)
         printWriter.println(
-            """final var action = (requestBody.isObject() && requestBody.has("action")) ? requestBody.get("action").asText() : null;""",
+            //language=java
+            """final var action = (requestBody.isObject() && requestBody.has("action")) ? requestBody.get("action").asText() : "N/A";""",
         )
         printWriter.println("return switch (action) {")
         requestBodyTypes.forEach { (name, methodNameAndType) ->


### PR DESCRIPTION
The enhanced switch doesn't like nulls.
The earlier implementation was setting it to null when action was not sent.
Now it sets it to `"N/A"`.
