### PR TITLE
feat: When types is a list with `null`, create Object

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -107,7 +107,7 @@ fun referenceAndDefinition(
 
         types == null -> Pair(Types.OBJECT.annotated(typeGenerated()), null)
 
-        types.isEmpty() -> null
+        types.isEmpty() -> Pair(Types.OBJECT.annotated(typeGenerated()), null)
 
         types.size == 1 ->
             when (types.first()) {


### PR DESCRIPTION
Prior to this we were not creating a field.
Now we create an `Object` field.
