### PR TITLE
chore: Setup gradle/gradle-daemon-jvm.properties

### DIFF
--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,3 @@
+# This file is used to configure the JDK version used by the Gradle Daemon (Build Runtime)
+# This configuration wins over the JAVA_HOME environment variable and NEWT's configurations
+toolchainVersion=21


### PR DESCRIPTION
This ensures we use a working JVM.
