### PR TITLE
chore: Configure testlogger to use parallel format

### DIFF
--- a/gradle/pulpogato-rest-codegen/build.gradle.kts
+++ b/gradle/pulpogato-rest-codegen/build.gradle.kts
@@ -54,7 +54,7 @@ tasks.withType<Test> {
 }
 
 testlogger {
-    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN else ThemeType.MOCHA
+    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN_PARALLEL else ThemeType.MOCHA_PARALLEL
     slowThreshold = 5000
 
     showPassed = false

--- a/pulpogato-common/build.gradle.kts
+++ b/pulpogato-common/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.adarshr.gradle.testlogger.theme.ThemeType
+
 plugins {
     alias(libs.plugins.javaLibrary)
     alias(libs.plugins.waenaPublished)
     alias(libs.plugins.spotless)
+    alias(libs.plugins.testLogger)
 }
 
 val mockitoAgent = configurations.create("mockitoAgent")
@@ -43,4 +46,13 @@ spotless {
     java {
         palantirJavaFormat()
     }
+}
+
+testlogger {
+    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN_PARALLEL else ThemeType.MOCHA_PARALLEL
+    slowThreshold = 5000
+
+    showPassed = false
+    showSkipped = true
+    showFailed = true
 }

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -88,7 +88,7 @@ tasks.withType<Test> {
 }
 
 testlogger {
-    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN else ThemeType.MOCHA
+    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN_PARALLEL else ThemeType.MOCHA_PARALLEL
     slowThreshold = 5000
 
     showPassed = false


### PR DESCRIPTION
That makes it easier to read logs.
