### PR TITLE
refactor: Use RestClients in Integration tests

### DIFF
--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
@@ -12,7 +12,7 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheUsage() {
-        ActionsApi api = factory.createClient(ActionsApi.class);
+        ActionsApi api = new RestClients(webClient).getActionsApi();
         ResponseEntity<ActionsCacheUsageByRepository> response = api.getActionsCacheUsage("pulpogato", "pulpogato");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -28,7 +28,7 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheList() {
-        ActionsApi api = factory.createClient(ActionsApi.class);
+        ActionsApi api = new RestClients(webClient).getActionsApi();
         ResponseEntity<ActionsCacheList> response = api.getActionsCacheList("pulpogato", "pulpogato", null, null, null, null, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -43,7 +43,7 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheListWithPagination() {
-        ActionsApi api = factory.createClient(ActionsApi.class);
+        ActionsApi api = new RestClients(webClient).getActionsApi();
         ResponseEntity<ActionsCacheList> response = api.getActionsCacheList("pulpogato", "pulpogato", 10L, 0L, null, null, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActivityApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActivityApiIntegrationTest.java
@@ -16,7 +16,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicEvents() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         ResponseEntity<List<Event>> response = api.listPublicEvents(10L, 1L);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -39,7 +39,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetFeeds() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         ResponseEntity<Feed> response = api.getFeeds();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -66,7 +66,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicOrgEvents() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         // Using GitHub's own organization as an example
         ResponseEntity<List<Event>> response = api.listPublicOrgEvents("github", 5L, 1L);
         
@@ -94,7 +94,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListRepoEvents() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         // Using a popular repository as an example
         ResponseEntity<List<Event>> response = api.listRepoEvents("octocat", "Hello-World", 5L, 1L);
         
@@ -118,7 +118,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListReposStarredByAuthenticatedUser() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         ResponseEntity<List<Repository>> response = api.listReposStarredByAuthenticatedUser(
                 null, null, 10L, 1L);
         
@@ -143,7 +143,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListWatchedReposForAuthenticatedUser() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         ResponseEntity<List<MinimalRepository>> response = api.listWatchedReposForAuthenticatedUser(10L, 1L);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -166,7 +166,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicEventsForUser() {
-        ActivityApi api = factory.createClient(ActivityApi.class);
+        ActivityApi api = new RestClients(webClient).getActivityApi();
         // Using octocat as a well-known GitHub user
         ResponseEntity<List<Event>> response = api.listPublicEventsForUser("rahulsom", 5L, 1L);
         

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CodesOfConductApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CodesOfConductApiIntegrationTest.java
@@ -13,7 +13,7 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllCodesOfConduct() {
-        CodesOfConductApi api = factory.createClient(CodesOfConductApi.class);
+        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
         ResponseEntity<List<CodeOfConduct>> response = api.getAllCodesOfConduct();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -44,7 +44,7 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContributorCovenantCodeOfConduct() {
-        CodesOfConductApi api = factory.createClient(CodesOfConductApi.class);
+        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
         ResponseEntity<CodeOfConduct> response = api.getConductCode("contributor_covenant");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -64,7 +64,7 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetCitizenCodeOfConduct() {
-        CodesOfConductApi api = factory.createClient(CodesOfConductApi.class);
+        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
         ResponseEntity<CodeOfConduct> response = api.getConductCode("citizen_code_of_conduct");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/EmojisApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/EmojisApiIntegrationTest.java
@@ -12,7 +12,7 @@ class EmojisApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        EmojisApi api = factory.createClient(EmojisApi.class);
+        EmojisApi api = new RestClients(webClient).getEmojisApi();
         ResponseEntity<Map<String, String>> response = api.get();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/GitignoreApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/GitignoreApiIntegrationTest.java
@@ -13,7 +13,7 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllTemplates() {
-        GitignoreApi api = factory.createClient(GitignoreApi.class);
+        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
         ResponseEntity<List<String>> response = api.getAllTemplates();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -29,7 +29,7 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetJavaTemplate() {
-        GitignoreApi api = factory.createClient(GitignoreApi.class);
+        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
         ResponseEntity<GitignoreTemplate> response = api.getTemplate("Java");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -47,7 +47,7 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetPythonTemplate() {
-        GitignoreApi api = factory.createClient(GitignoreApi.class);
+        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
         ResponseEntity<GitignoreTemplate> response = api.getTemplate("Python");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/LicensesApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/LicensesApiIntegrationTest.java
@@ -14,7 +14,7 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllCommonlyUsed() {
-        LicensesApi api = factory.createClient(LicensesApi.class);
+        LicensesApi api = new RestClients(webClient).getLicensesApi();
         ResponseEntity<List<LicenseSimple>> response = api.getAllCommonlyUsed(null, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -45,7 +45,7 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetMitLicense() {
-        LicensesApi api = factory.createClient(LicensesApi.class);
+        LicensesApi api = new RestClients(webClient).getLicensesApi();
         ResponseEntity<License> response = api.get("mit");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -73,7 +73,7 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetApacheLicense() {
-        LicensesApi api = factory.createClient(LicensesApi.class);
+        LicensesApi api = new RestClients(webClient).getLicensesApi();
         ResponseEntity<License> response = api.get("apache-2.0");
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -92,7 +92,7 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetFeaturedLicenses() {
-        LicensesApi api = factory.createClient(LicensesApi.class);
+        LicensesApi api = new RestClients(webClient).getLicensesApi();
         ResponseEntity<List<LicenseSimple>> response = api.getAllCommonlyUsed(true, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/MetaApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/MetaApiIntegrationTest.java
@@ -12,7 +12,7 @@ class MetaApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testRoot() {
-        MetaApi api = factory.createClient(MetaApi.class);
+        MetaApi api = new RestClients(webClient).getMetaApi();
         ResponseEntity<Root> response = api.root();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -31,7 +31,7 @@ class MetaApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        MetaApi api = factory.createClient(MetaApi.class);
+        MetaApi api = new RestClients(webClient).getMetaApi();
         ResponseEntity<ApiOverview> response = api.get();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OrgsApiIntegrationTest extends BaseIntegrationTest {
     @Test
     void testListInstallations() {
-        OrgsApi api = factory.createClient(OrgsApi.class);
+        OrgsApi api = new RestClients(webClient).getOrgsApi();
         var response = api.listAppInstallations("corp", 100L, 1L);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/RateLimitApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/RateLimitApiIntegrationTest.java
@@ -11,7 +11,7 @@ class RateLimitApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        RateLimitApi api = factory.createClient(RateLimitApi.class);
+        RateLimitApi api = new RestClients(webClient).getRateLimitApi();
         ResponseEntity<RateLimitOverview> response = api.get();
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReposApiIntegrationTest extends BaseIntegrationTest {
     @Test
     void testListTags() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.listTags("pulpogato", "pulpogato", 100L, 1L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -39,7 +39,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListCommits() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.listCommits("pulpogato", "pulpogato",
                 null, null, null, null, null, null, 10L, 1L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -57,7 +57,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetCommit() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.getCommit("pulpogato", "pulpogato", 1L, 1L, "2667e9ae0adcdbf378fe6273658b57f4e5d24a39");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -68,7 +68,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContentObject() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.getContentObject("pulpogato", "pulpogato", "README.adoc", null);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -86,7 +86,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContent() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.getContent("pulpogato", "pulpogato", "README.adoc", null);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -104,7 +104,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.get("pulpogato", "pulpogato");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -117,7 +117,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetBranch() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.getBranch("pulpogato", "pulpogato", "main");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -129,7 +129,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetBranchProtection() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.getBranchProtection("pulpogato", "pulpogato", "main");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -140,7 +140,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrg() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("pulpogato", ReposApi.CreateInOrgRequestBody.builder()
                 .name("create-demo")
                 .description("create demo")
@@ -157,7 +157,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrgWithCustomProperties() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("example", ReposApi.CreateInOrgRequestBody.builder()
                 .name("rsomasunderam-custom-props-demo")
                 .description("create demo")
@@ -217,7 +217,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrgWithExtendedCustomProperties() throws JsonProcessingException {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("example", ExtendedCreateInOrgRequestBody.builder()
                 .name("rsomasunderam-custom-props-demo")
                 .description("create demo")
@@ -242,7 +242,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValues() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
 
         var customPropertyValue = CustomPropertyValue.builder()
                 .propertyName("audit_pci")
@@ -259,7 +259,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesWithMultipleProperties() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
 
         var environmentProperty = CustomPropertyValue.builder()
                 .propertyName("some_string")
@@ -281,7 +281,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesWithArrayValue() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
 
         var tagsProperty = CustomPropertyValue.builder()
                 .propertyName("plural_value")
@@ -298,7 +298,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesEmptyProperties() {
-        ReposApi api = factory.createClient(ReposApi.class);
+        ReposApi api = new RestClients(webClient).getReposApi();
         var requestBody = ReposApi.CustomPropertiesForReposCreateOrUpdateRepositoryValuesRequestBody.builder()
                 .properties(List.of())
                 .build();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
@@ -13,7 +13,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchRepositories() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Repos200> response = api.repos("pulpogato", null, null, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -36,7 +36,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchRepositoriesWithLanguageFilter() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Repos200> response = api.repos("language:java", null, null, 10L, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -51,7 +51,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchUsers() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Users200> response = api.users("rahulsom", null, null, null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -73,7 +73,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchUsersWithLocationFilter() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Users200> response = api.users("location:california", null, null, 5L, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -91,7 +91,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchTopics() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Topics200> response = api.topics("java", null, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -113,7 +113,7 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchTopicsPopular() {
-        SearchApi api = factory.createClient(SearchApi.class);
+        SearchApi api = new RestClients(webClient).getSearchApi();
         ResponseEntity<SearchApi.Topics200> response = api.topics("machine-learning", 10L, null);
         
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetAuthenticatedPublic() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         ResponseEntity<UsersApi.GetAuthenticated200> authenticated = api.getAuthenticated();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(authenticated.getBody())
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetAuthenticatedPrivate() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         ResponseEntity<UsersApi.GetAuthenticated200> authenticated = api.getAuthenticated();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(authenticated.getBody())
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
     @Test
     @Disabled("PATCH is currently broken")
     void testUpdateAuthenticated() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var update = UsersApi.UpdateAuthenticatedRequestBody.builder()
                 .location("San Francisco Bay Area")
                 .build();
@@ -69,7 +69,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListBlockedEmpty() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var blocked = api.listBlockedByAuthenticatedUser(5L, 0L);
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -83,7 +83,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListBlockedValid() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var blocked = api.listBlockedByAuthenticatedUser(5L, 0L);
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -102,7 +102,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testCheckBlocked() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var blocked = api.checkBlocked("some-blocked-user");
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -111,7 +111,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testCheckNotBlocked() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         WebClientResponseException exception = catchThrowableOfType(WebClientResponseException.class, () -> api.checkBlocked("gooduser"));
 
         assertThat(exception).isNotNull();
@@ -121,7 +121,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testBlockUserFailed() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         WebClientResponseException exception = catchThrowableOfType(WebClientResponseException.class, () -> api.block("some-blocked-user"));
 
         assertThat(exception).isNotNull();
@@ -131,7 +131,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testBlockUserSuccess() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var blocked = api.block("gooduser");
 
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
@@ -141,7 +141,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testUnblockUserSuccess() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var blocked = api.block("gooduser");
 
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
@@ -151,7 +151,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowers() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var followers = api.listFollowersForAuthenticatedUser( 5L, 0L);
         assertThat(followers.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(followers.getBody())
@@ -170,7 +170,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListGpgKeysForAuthenticatedUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var gpgKeys = api.listGpgKeysForAuthenticatedUser(5L, 0L);
         assertThat(gpgKeys.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(gpgKeys.getBody())
@@ -189,7 +189,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetGpgKeyForAuthenticatedUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var gpgKey = api.getGpgKeyForAuthenticatedUser(175109L);
         assertThat(gpgKey.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(gpgKey.getBody())
@@ -203,7 +203,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListPublicEmailsForAuthenticatedUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var response = api.listPublicEmailsForAuthenticatedUser(5L, 0L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -227,7 +227,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListEmailsForAuthenticatedUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
         var response = api.listEmailsForAuthenticatedUser(5L, 0L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -258,7 +258,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListSocialAccountsForAuthenticatedUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
 
         var response = api.listSocialAccountsForAuthenticatedUser(5L, 0L);
 
@@ -277,7 +277,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetById() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
 
         var response = api.getById(230004L);
 
@@ -305,7 +305,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetByUsername() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
 
         var response = api.getByUsername("sghill");
 
@@ -333,7 +333,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowersForUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
 
         var response = api.listFollowersForUser("sghill", 5L, 0L);
 
@@ -354,7 +354,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowingForUser() {
-        UsersApi api = factory.createClient(UsersApi.class);
+        UsersApi api = new RestClients(webClient).getUsersApi();
 
         var response = api.listFollowingForUser("sghill", 5L, 0L);
 

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
@@ -10,8 +10,6 @@ import org.springframework.test.web.servlet.client.MockMvcHttpConnector;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.support.WebClientAdapter;
-import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 @SpringBootTest(
         classes = {ProxyController.class},
@@ -28,7 +26,7 @@ public class BaseIntegrationTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
-    protected HttpServiceProxyFactory factory;
+    protected WebClient webClient;
 
     @BeforeEach
     void setUp(TestInfo testInfo) {
@@ -40,13 +38,9 @@ public class BaseIntegrationTest {
 
         var mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 
-        final var webClient = WebClient.builder()
+        webClient = WebClient.builder()
                 .clientConnector(new MockMvcHttpConnector(mockMvc))
                 .defaultHeader("TapeName", classPart + "/" + methodPart)
-                .build();
-
-        factory = HttpServiceProxyFactory.builder()
-                .exchangeAdapter(WebClientAdapter.create(webClient))
                 .build();
 
         log.info("");


### PR DESCRIPTION
This allows centralizing more configuration.
