### PR TITLE
chore: Add reason for code_scanning_delagated_alert_dismissal

### DIFF
--- a/gradle/pulpogato-rest-codegen/build.gradle.kts
+++ b/gradle/pulpogato-rest-codegen/build.gradle.kts
@@ -58,7 +58,7 @@ testlogger {
     slowThreshold = 5000
 
     showPassed = false
-    showSkipped = true
+    showSkipped = false
     showFailed = true
 }
 

--- a/pulpogato-common/build.gradle.kts
+++ b/pulpogato-common/build.gradle.kts
@@ -53,6 +53,6 @@ testlogger {
     slowThreshold = 5000
 
     showPassed = false
-    showSkipped = true
+    showSkipped = false
     showFailed = true
 }

--- a/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
+++ b/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
@@ -497,7 +497,7 @@
     - fpt
     - ghec
 - example: "#/components/examples/code-security-configuration-list/value"
-  reason: "TODO: Diagnose this"
+  reason: "https://github.com/github/rest-api-description/issues/5659"
   versions:
     - fpt
     - ghec

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -92,7 +92,7 @@ testlogger {
     slowThreshold = 5000
 
     showPassed = false
-    showSkipped = true
+    showSkipped = false
     showFailed = true
 }
 


### PR DESCRIPTION
Also, stop logging skipped tests.
