### PR TITLE
feat: Add `suspended_at` to private-user and public-user in 3.17

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -84,6 +84,7 @@ object Annotations {
     fun generated(
         offset: Int,
         context: Context,
+        sourceFile: String = "schema.json",
     ): AnnotationSpec {
         val builder =
             AnnotationSpec
@@ -95,9 +96,11 @@ object Annotations {
         } else {
             throw IllegalArgumentException("SchemaRef is empty")
         }
-        return builder
-            .addMember("codeRef", $$"$S", codeRef(offset))
-            .build()
+        builder.addMember("codeRef", $$"$S", codeRef(offset))
+        if (sourceFile != "schema.json") {
+            builder.addMember("sourceFile", $$"$S", sourceFile)
+        }
+        return builder.build()
     }
 
     fun typeGenerated(): AnnotationSpec =

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
@@ -6,6 +6,7 @@ data class Context(
     val openAPI: OpenAPI,
     val version: String,
     val schemaStack: List<String>,
+    val addedProperties: Map<String, Set<String>> = emptyMap(),
 ) {
     // Cached schema stack reference to avoid repeated string operations
     private val cachedSchemaStackRef: String by lazy {
@@ -22,4 +23,9 @@ data class Context(
     }
 
     fun getSchemaStackRef() = cachedSchemaStackRef
+
+    fun isAddedProperty(
+        schemaName: String,
+        propertyName: String,
+    ): Boolean = addedProperties[schemaName]?.contains(propertyName) == true
 }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -675,11 +675,29 @@ private fun addFieldIfNew(
 ) {
     val fieldName = p.key.unkeywordize().camelCase()
     if (!knownFields.contains(fieldName)) {
+        // Check if this property was added from additions.schema.json
+        val schemaName =
+            if (context.schemaStack.size >= 4 &&
+                context.schemaStack[0] == "#" &&
+                context.schemaStack[1] == "components" &&
+                context.schemaStack[2] == "schemas"
+            ) {
+                context.schemaStack[3]
+            } else {
+                null
+            }
+        val sourceFile =
+            if (schemaName != null && context.isAddedProperty(schemaName, p.key)) {
+                "additions.schema.json"
+            } else {
+                "schema.json"
+            }
+
         val builder =
             FieldSpec
                 .builder(typeName, fieldName, Modifier.PRIVATE)
                 .addAnnotation(jsonProperty(p.key))
-                .addAnnotation(generated(0, context.withSchemaStack("properties", p.key)))
+                .addAnnotation(generated(0, context.withSchemaStack("properties", p.key), sourceFile))
 
         schemaJavadoc(p).let {
             if (it.isNotBlank()) {

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/JsonRefValidatorTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/JsonRefValidatorTest.kt
@@ -203,19 +203,19 @@ class JsonRefValidatorTest {
 
     @Test
     fun `validate with valid json references - File1`() {
-        JsonRefValidator().validate(json, getJavaFiles(root1))
+        JsonRefValidator().validate(mapOf("schema.json" to json), getJavaFiles(root1))
     }
 
     @Test
     fun `validate with valid json references - File2`() {
-        JsonRefValidator().validate(json, getJavaFiles(root2))
+        JsonRefValidator().validate(mapOf("schema.json" to json), getJavaFiles(root2))
     }
 
     @Test
     fun `validate with invalid json references`() {
         val exception =
             assertThrows<IllegalStateException> {
-                JsonRefValidator().validate(json, getJavaFiles(root2, root3))
+                JsonRefValidator().validate(mapOf("schema.json" to json), getJavaFiles(root2, root3))
             }
         Assertions.assertThat(exception).hasMessage("Found 2 errors in 4 JSON references")
     }
@@ -223,12 +223,12 @@ class JsonRefValidatorTest {
     @Test
     fun `validate with threshold allows some errors`() {
         // Should not throw with threshold of 2
-        JsonRefValidator(2).validate(json, getJavaFiles(root2, root3))
+        JsonRefValidator(2).validate(mapOf("schema.json" to json), getJavaFiles(root2, root3))
 
         // Should throw with threshold of 1
         val exception =
             assertThrows<IllegalStateException> {
-                JsonRefValidator(1).validate(json, getJavaFiles(root2, root3))
+                JsonRefValidator(1).validate(mapOf("schema.json" to json), getJavaFiles(root2, root3))
             }
         Assertions.assertThat(exception).hasMessage("Found 2 errors in 4 JSON references")
     }
@@ -252,7 +252,7 @@ class JsonRefValidatorTest {
         }
 
         try {
-            JsonRefValidator().validate(json, getJavaFiles(tempDir))
+            JsonRefValidator().validate(mapOf("schema.json" to json), getJavaFiles(tempDir))
         } finally {
             tempDir.deleteRecursively()
         }
@@ -278,7 +278,7 @@ class JsonRefValidatorTest {
         try {
             val exception =
                 assertThrows<IllegalStateException> {
-                    JsonRefValidator(0).validate(json, getJavaFiles(tempDir))
+                    JsonRefValidator(0).validate(mapOf("schema.json" to json), getJavaFiles(tempDir))
                 }
             Assertions.assertThat(exception).hasMessage("Found 1 errors in 1 JSON references")
         } finally {
@@ -289,12 +289,12 @@ class JsonRefValidatorTest {
     @Test
     fun `validate with multiple roots`() {
         // Should validate all valid references across multiple roots
-        JsonRefValidator().validate(json, getJavaFiles(root1, root2))
+        JsonRefValidator().validate(mapOf("schema.json" to json), getJavaFiles(root1, root2))
 
         // Should count errors across all roots
         val exception =
             assertThrows<IllegalStateException> {
-                JsonRefValidator(0).validate(json, getJavaFiles(root1, root3, root4))
+                JsonRefValidator(0).validate(mapOf("schema.json" to json), getJavaFiles(root1, root3, root4))
             }
         Assertions.assertThat(exception).hasMessage("Found 3 errors in 9 JSON references")
     }

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/Generated.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/Generated.java
@@ -24,4 +24,9 @@ public @interface Generated {
      * @return The file and line that generated the type
      */
     String codeRef();
+    /**
+     * The source file from which this element was generated
+     * @return The source file name (e.g., "schema.json" or "additions.schema.json")
+     */
+    String sourceFile() default "schema.json";
 }

--- a/pulpogato-rest-ghes-3.17/src/main/resources/additions.schema.json
+++ b/pulpogato-rest-ghes-3.17/src/main/resources/additions.schema.json
@@ -1,0 +1,36 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Additions Schema",
+        "version": "1.0.0"
+    },
+    "components": {
+        "schemas": {
+            "public-user": {
+                "properties": {
+                    "suspended_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time",
+                        "description": "https://github.com/github/rest-api-description/issues/5667"
+                    }
+                }
+            },
+            "private-user": {
+                "properties": {
+                    "suspended_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time",
+                        "description": "https://github.com/github/rest-api-description/issues/5667"
+                    }
+                }
+            }
+        }
+    },
+    "paths": {}
+}

--- a/pulpogato-rest-ghestest/build.gradle.kts
+++ b/pulpogato-rest-ghestest/build.gradle.kts
@@ -1,0 +1,31 @@
+import com.adarshr.gradle.testlogger.theme.ThemeType
+
+plugins {
+    java
+    alias(libs.plugins.testLogger)
+}
+
+dependencies {
+    testImplementation(project(":${rootProject.name}-rest-ghes-3.17"))
+    testImplementation(project(":${rootProject.name}-rest-tests"))
+    testImplementation(libs.bundles.springBoot)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+testlogger {
+    theme = if (System.getProperty("idea.active") == "true") ThemeType.PLAIN_PARALLEL else ThemeType.MOCHA_PARALLEL
+    slowThreshold = 5000
+
+    showPassed = false
+    showSkipped = false
+    showFailed = true
+}

--- a/pulpogato-rest-ghestest/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-ghestest/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -1,0 +1,68 @@
+package io.github.pulpogato.rest.api;
+
+import io.github.pulpogato.test.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsersApiIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    void testGetById() {
+        UsersApi api = new RestClients(webClient).getUsersApi();
+
+        var response = api.getById(14513L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        assertThat(response.getBody()).isNotNull();
+        var body = response.getBody();
+
+        assertThat(body.getPrivateUser()).isNotNull();
+        assertThat(body.getPublicUser()).isNull();
+
+        var user = body.getPrivateUser();
+
+        assertThat(user.getLogin()).isEqualTo("user1");
+        assertThat(user.getName()).isEqualTo("User One");
+        assertThat(user.getCompany()).isNull();
+        assertThat(user.getLocation()).isEqualTo("City, ST");
+        assertThat(user.getEmail()).isEqualTo("user1@example.com");
+        assertThat(user.getPublicRepos()).isEqualTo(0);
+        assertThat(user.getPublicGists()).isEqualTo(0);
+        assertThat(user.getFollowers()).isEqualTo(0);
+        assertThat(user.getFollowing()).isEqualTo(0);
+        assertThat(user.getSuspendedAt()).isNull();
+    }
+
+    @Test
+    void testGetSuspendedById() {
+        UsersApi api = new RestClients(webClient).getUsersApi();
+
+        var response = api.getById(90L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        assertThat(response.getBody()).isNotNull();
+        var body = response.getBody();
+
+        assertThat(body.getPrivateUser()).isNotNull();
+        assertThat(body.getPublicUser()).isNull();
+
+        var user = body.getPrivateUser();
+
+        assertThat(user.getLogin()).isEqualTo("user2");
+        assertThat(user.getName()).isEqualTo("User Two");
+        assertThat(user.getCompany()).isNull();
+        assertThat(user.getLocation()).isNull();
+        assertThat(user.getEmail()).isEqualTo("user2@example.com");
+        assertThat(user.getPublicRepos()).isEqualTo(0);
+        assertThat(user.getPublicGists()).isEqualTo(0);
+        assertThat(user.getFollowers()).isEqualTo(0);
+        assertThat(user.getFollowing()).isEqualTo(0);
+        assertThat(user.getSuspendedAt()).isNotNull();
+
+    }
+}

--- a/pulpogato-rest-ghestest/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetById.yml
+++ b/pulpogato-rest-ghestest/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetById.yml
@@ -1,0 +1,50 @@
+- request:
+    method: GET
+    uri: /user/14513
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+    body: null
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Connection: keep-alive
+    body: |-
+      {
+        "login" : "user1",
+        "id" : 14513,
+        "node_id" : "MDQ6VXNlcjE0NTEz",
+        "avatar_url" : "https://github.example.com/avatars/u/14513?",
+        "gravatar_id" : "",
+        "url" : "https://github.example.com/api/v3/users/user1",
+        "html_url" : "https://github.example.com/user1",
+        "followers_url" : "https://github.example.com/api/v3/users/user1/followers",
+        "following_url" : "https://github.example.com/api/v3/users/user1/following{/other_user}",
+        "gists_url" : "https://github.example.com/api/v3/users/user1/gists{/gist_id}",
+        "starred_url" : "https://github.example.com/api/v3/users/user1/starred{/owner}{/repo}",
+        "subscriptions_url" : "https://github.example.com/api/v3/users/user1/subscriptions",
+        "organizations_url" : "https://github.example.com/api/v3/users/user1/orgs",
+        "repos_url" : "https://github.example.com/api/v3/users/user1/repos",
+        "events_url" : "https://github.example.com/api/v3/users/user1/events{/privacy}",
+        "received_events_url" : "https://github.example.com/api/v3/users/user1/received_events",
+        "type" : "User",
+        "user_view_type" : "public",
+        "site_admin" : false,
+        "name" : "User One",
+        "company" : null,
+        "blog" : "",
+        "location" : "City, ST",
+        "email" : "user1@example.com",
+        "hireable" : null,
+        "bio" : null,
+        "twitter_username" : null,
+        "public_repos" : 0,
+        "public_gists" : 0,
+        "followers" : 0,
+        "following" : 0,
+        "created_at" : "2025-07-08T19:08:16Z",
+        "updated_at" : "2025-11-05T20:00:26Z",
+        "suspended_at" : null
+      }

--- a/pulpogato-rest-ghestest/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetSuspendedById.yml
+++ b/pulpogato-rest-ghestest/src/test/resources/tapes/io/github/pulpogato/rest/api/UsersApiIntegrationTest/testGetSuspendedById.yml
@@ -1,0 +1,50 @@
+- request:
+    method: GET
+    uri: /user/90
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+    body: null
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Connection: keep-alive
+    body: |-
+      {
+        "login" : "user2",
+        "id" : 90,
+        "node_id" : "MDQ6VXNlcjkw",
+        "avatar_url" : "https://github.example.com/avatars/u/90?",
+        "gravatar_id" : "",
+        "url" : "https://github.example.com/api/v3/users/user2",
+        "html_url" : "https://github.example.com/user2",
+        "followers_url" : "https://github.example.com/api/v3/users/user2/followers",
+        "following_url" : "https://github.example.com/api/v3/users/user2/following{/other_user}",
+        "gists_url" : "https://github.example.com/api/v3/users/user2/gists{/gist_id}",
+        "starred_url" : "https://github.example.com/api/v3/users/user2/starred{/owner}{/repo}",
+        "subscriptions_url" : "https://github.example.com/api/v3/users/user2/subscriptions",
+        "organizations_url" : "https://github.example.com/api/v3/users/user2/orgs",
+        "repos_url" : "https://github.example.com/api/v3/users/user2/repos",
+        "events_url" : "https://github.example.com/api/v3/users/user2/events{/privacy}",
+        "received_events_url" : "https://github.example.com/api/v3/users/user2/received_events",
+        "type" : "User",
+        "user_view_type" : "public",
+        "site_admin" : false,
+        "name" : "User Two",
+        "company" : null,
+        "blog" : "",
+        "location" : null,
+        "email" : "user2@example.com",
+        "hireable" : null,
+        "bio" : null,
+        "twitter_username" : null,
+        "public_repos" : 0,
+        "public_gists" : 0,
+        "followers" : 0,
+        "following" : 0,
+        "created_at" : "2024-01-12T14:33:07Z",
+        "updated_at" : "2025-07-15T22:47:50Z",
+        "suspended_at" : "2025-07-15T15:47:50.000-07:00"
+      }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,4 +38,6 @@ allVersions.forEach { ghVersion ->
     createProject("rest", ghVersion)
 }
 
+include("${rootProject.name}-rest-ghestest")
+
 includeBuild("gradle/pulpogato-rest-codegen")


### PR DESCRIPTION
This field is needed to correctly parse the objects.
However, it's not present in the schema.

This change allows contributing such fields per version.

Refs: https://github.com/github/rest-api-description/issues/5667
