### PR TITLE
chore: Write long inputs to file

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
@@ -5,7 +5,11 @@ import com.palantir.javapoet.ClassName
 import com.palantir.javapoet.MethodSpec
 import com.palantir.javapoet.TypeName
 import io.github.pulpogato.restcodegen.ext.pascalCase
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.util.TreeMap
+import javax.xml.bind.DatatypeConverter
 import kotlin.collections.get
 
 object TestBuilder {
@@ -16,6 +20,7 @@ object TestBuilder {
         key: String,
         example: Any,
         className: TypeName,
+        testResourcesDir: File,
     ): MethodSpec? {
         val om = ObjectMapper()
 
@@ -32,33 +37,70 @@ object TestBuilder {
                 }
             }
 
-        // Skip generating test if the string constant would be too large
-        if (formatted.length > MAX_STRING_LENGTH) {
-            System.err.println(
-                "Warning: Skipping test generation for '${context.getSchemaStackRef()}' due to large example size (${formatted.length} characters).",
-            )
-            return null
-        }
-
         val testUtilsClass = ClassName.get("io.github.pulpogato.test", "TestUtils")
 
         try {
+            // If the string constant would be too large, write it to a JSON file
             val methodSpec =
-                MethodSpec
-                    .methodBuilder("test${key.pascalCase()}")
-                    .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
-                    .addAnnotation(Annotations.generated(1, context))
-                    .addException(ClassName.get("com.fasterxml.jackson.core", "JsonProcessingException"))
-                    .addStatement($$"$T input = /* language=JSON */ $L", String::class.java, formatted.blockQuote())
-                    .addStatement($$"var softly = new $T()", ClassName.get("org.assertj.core.api", "SoftAssertions"))
-                    .addStatement(
-                        $$"var processed = $T.parseAndCompare(new $T<$T>() {}, input, softly)",
-                        testUtilsClass,
-                        ClassName.get("com.fasterxml.jackson.core.type", "TypeReference"),
-                        className.withoutAnnotations(),
-                    ).addStatement("softly.assertThat(processed).isNotNull()")
-                    .addStatement("softly.assertAll()")
-                    .build()
+                if (formatted.length > MAX_STRING_LENGTH) {
+                    // Create the test resources directory if it doesn't exist
+                    testResourcesDir.mkdirs()
+
+                    // Generate a filename based on the MD5
+                    val digest = MessageDigest.getInstance("SHA-256")
+                    digest.update(formatted.toByteArray(StandardCharsets.UTF_8))
+                    val hash = DatatypeConverter.printHexBinary(digest.digest()).take(7).lowercase()
+
+                    val fileName = "example-$hash.json"
+                    val jsonFile = File(testResourcesDir, fileName)
+
+                    // Write the formatted JSON to the file
+                    jsonFile.writeText(formatted)
+
+                    System.err.println(
+                        "Info: Created JSON file for large example '${context.getSchemaStackRef()}' (${formatted.length} characters) at $fileName",
+                    )
+
+                    // Generate test that reads from the JSON file
+                    MethodSpec
+                        .methodBuilder("test${key.pascalCase()}")
+                        .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
+                        .addAnnotation(Annotations.generated(1, context))
+                        .addException(ClassName.get("com.fasterxml.jackson.core", "JsonProcessingException"))
+                        .addException(ClassName.get("java.io", "IOException"))
+                        .addStatement(
+                            $$"$T input = new $T(getClass().getClassLoader().getResourceAsStream($S).readAllBytes(), $T.UTF_8)",
+                            String::class.java,
+                            String::class.java,
+                            fileName,
+                            ClassName.get("java.nio.charset", "StandardCharsets"),
+                        ).addStatement($$"var softly = new $T()", ClassName.get("org.assertj.core.api", "SoftAssertions"))
+                        .addStatement(
+                            $$"var processed = $T.parseAndCompare(new $T<$T>() {}, input, softly)",
+                            testUtilsClass,
+                            ClassName.get("com.fasterxml.jackson.core.type", "TypeReference"),
+                            className.withoutAnnotations(),
+                        ).addStatement("softly.assertThat(processed).isNotNull()")
+                        .addStatement("softly.assertAll()")
+                        .build()
+                } else {
+                    // Use inline JSON as before
+                    MethodSpec
+                        .methodBuilder("test${key.pascalCase()}")
+                        .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
+                        .addAnnotation(Annotations.generated(1, context))
+                        .addException(ClassName.get("com.fasterxml.jackson.core", "JsonProcessingException"))
+                        .addStatement($$"$T input = /* language=JSON */ $L", String::class.java, formatted.blockQuote())
+                        .addStatement($$"var softly = new $T()", ClassName.get("org.assertj.core.api", "SoftAssertions"))
+                        .addStatement(
+                            $$"var processed = $T.parseAndCompare(new $T<$T>() {}, input, softly)",
+                            testUtilsClass,
+                            ClassName.get("com.fasterxml.jackson.core.type", "TypeReference"),
+                            className.withoutAnnotations(),
+                        ).addStatement("softly.assertThat(processed).isNotNull()")
+                        .addStatement("softly.assertAll()")
+                        .build()
+                }
             return methodSpec
         } catch (e: Exception) {
             throw RuntimeException(

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -60,6 +60,7 @@ sourceSets {
     }
     named("test") {
         java.srcDir("${project.layout.buildDirectory.get()}/generated/sources/test")
+        resources.srcDir("${project.layout.buildDirectory.get()}/generated/sources/resources")
     }
 }
 


### PR DESCRIPTION
Prior to this, we ignored the tests that had very long inputs. So far, 1 test per variant.

These long inputs could not be in a java file.

This change writes these long inputs to a file and reads from the file in the test instead of inlining in the test.
