### PR TITLE
refactor: Simplify OffsetDateTimeDeserializerTest

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/OffsetDateTimeDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/OffsetDateTimeDeserializer.java
@@ -19,6 +19,7 @@ import java.util.Objects;
  */
 public class OffsetDateTimeDeserializer extends StdDeserializer<OffsetDateTime> {
     private static final List<DateTimeFormatter> formatters = List.of(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX"),
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"),
             DateTimeFormatter.ISO_INSTANT);

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/OffsetDateTimeDeserializerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/OffsetDateTimeDeserializerTest.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.OffsetDateTime;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OffsetDateTimeDeserializerTest {
     static class Sample {
@@ -16,28 +18,23 @@ class OffsetDateTimeDeserializerTest {
         OffsetDateTime dateTime;
     }
 
+    static Stream<Arguments> params() {
+        return Stream.of(
+                Arguments.arguments("1696517280", 1696517280L),
+                Arguments.arguments("2023-10-05T14:48:00.123Z", 1696517280L),
+                Arguments.arguments("2023-10-05T14:48:00Z", 1696517280L),
+                Arguments.arguments("2023-10-05T16:48:00.123+02:00", 1696517280L),
+                Arguments.arguments("2023-10-05T16:48:00+02:00", 1696517280L),
+                Arguments.arguments("2025-06-03T05:53:24.752653000Z", 1748930004L));
+    }
+
     @ParameterizedTest
-    @ValueSource(
-            strings = {
-                // language=JSON
-                """
-                    {"dateTime": 1696517280}""",
-                // language=JSON
-                """
-                    {"dateTime": "2023-10-05T14:48:00.123Z"}""",
-                // language=JSON
-                """
-                    {"dateTime": "2023-10-05T14:48:00Z"}""",
-                // language=JSON
-                """
-                    {"dateTime": "2023-10-05T16:48:00.123+02:00"}""",
-                // language=JSON
-                """
-                    {"dateTime": "2023-10-05T16:48:00+02:00"}"""
-            })
-    void deserializeShouldParseValidDateTimeStrings(String input) throws Exception {
+    @MethodSource("params")
+    void deserializeShouldParseValidDateTimeStrings(String input, long expected) throws Exception {
         var mapper = new ObjectMapper();
-        Sample result = mapper.readValue(input, Sample.class);
-        assertThat(result.dateTime.toEpochSecond()).isEqualTo(1696517280L);
+        String quotedInput = "\"" + input + "\"";
+        var json = "{\"dateTime\": %s}".formatted(input.contains("-") ? quotedInput : input);
+        Sample result = mapper.readValue(json, Sample.class);
+        assertThat(result.dateTime.toEpochSecond()).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
Instead of constructing json in annotation, this now uses a string from a methodsource.
