### PR TITLE
refactor: Replace `Quad` with less generic `SchemaRefMatch`

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemaRefMatch.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemaRefMatch.kt
@@ -1,0 +1,18 @@
+package io.github.pulpogato.restcodegen
+
+import java.io.File
+
+/**
+ * Represents a match of a schema reference in a Java file.
+ *
+ * @property file The Java file containing the reference
+ * @property lineNumber The line number where the schema reference was found
+ * @property schemaRef The actual schema reference value (e.g., "#/path/to/definition")
+ * @property sourceFile The source file name (e.g., "schema.json")
+ */
+data class SchemaRefMatch(
+    val file: File,
+    val lineNumber: Int,
+    val schemaRef: String,
+    val sourceFile: String,
+)


### PR DESCRIPTION
This makes the code easier to understand.
