### PR TITLE
refactor: Organize generated code better

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
@@ -13,7 +13,7 @@ class RestCodegenPlugin : Plugin<Project> {
         downloadSchema.configure {
             apiVersion.set(extension.apiVersion)
             projectVariant.set(extension.projectVariant)
-            schemaFile.set(target.layout.buildDirectory.file("generated/resources/main/schema.json"))
+            schemaFile.set(target.layout.buildDirectory.file("generated-src/main/resources/schema.json"))
         }
 
         val generateJava = target.tasks.register("generateJava", GenerateJavaTask::class.java)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
@@ -6,6 +6,7 @@ import com.palantir.javapoet.TypeName
 import io.github.pulpogato.restcodegen.ext.pascalCase
 import tools.jackson.databind.ObjectMapper
 import java.io.File
+import java.io.FileWriter
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.TreeMap
@@ -55,7 +56,9 @@ object TestBuilder {
                     val jsonFile = File(testResourcesDir, fileName)
 
                     // Write the formatted JSON to the file
-                    jsonFile.writeText(formatted)
+                    FileWriter(jsonFile).use { writer ->
+                        writer.write(formatted)
+                    }
 
                     // Generate test that reads from the JSON file
                     MethodSpec

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -31,10 +31,21 @@ description = "REST types for $variant"
 
 codegen {
     packageName.set("io.github.pulpogato")
-    mainDir.set(file("${project.layout.buildDirectory.get()}/generated/sources/rest-codegen"))
-    testDir.set(file("${project.layout.buildDirectory.get()}/generated/sources/test"))
+    mainDir.set(file("${project.layout.buildDirectory.get()}/generated-src/main/java"))
+    testDir.set(file("${project.layout.buildDirectory.get()}/generated-src/test/java"))
     apiVersion.set(project.ext.get("gh.api.version").toString())
     projectVariant.set(variant)
+}
+
+sourceSets {
+    named("main") {
+        java.srcDir("${project.layout.buildDirectory.get()}/generated-src/main/java")
+        resources.srcDir("${project.layout.buildDirectory.get()}/generated-src/main/resources")
+    }
+    named("test") {
+        java.srcDir("${project.layout.buildDirectory.get()}/generated-src/test/java")
+        resources.srcDir("${project.layout.buildDirectory.get()}/generated-src/test/resources")
+    }
 }
 
 val downloadSchema = tasks.named("downloadSchema")
@@ -54,17 +65,6 @@ tasks.processResources {
 }
 tasks.processTestResources {
     dependsOn(generateJava)
-}
-
-sourceSets {
-    named("main") {
-        java.srcDir("${project.layout.buildDirectory.get()}/generated/sources/rest-codegen")
-        resources.srcDir("${project.layout.buildDirectory.get()}/generated/resources/main")
-    }
-    named("test") {
-        java.srcDir("${project.layout.buildDirectory.get()}/generated/sources/test")
-        resources.srcDir("${project.layout.buildDirectory.get()}/generated/sources/resources")
-    }
 }
 
 // Exclude schema.json from the main jar


### PR DESCRIPTION
Also, ensure `example-$hash.json` file is flushed and closed before ending `generateJava` task.
