### PR TITLE
chore: Extract MAX_WORKERS as an env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: "Build with Gradle"
     runs-on: ubuntu-24.04-arm
+    env:
+      MAX_WORKERS: 2
 
     permissions:
       security-events: write
@@ -61,7 +63,7 @@ jobs:
 
     - name: Build Main Project
       if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
-      run: ./gradlew build :pulpogato-rest-fpt:pitest --max-workers=2 --continue
+      run: ./gradlew build :pulpogato-rest-fpt:pitest --max-workers=$MAX_WORKERS --continue
 
     - name: Build Snapshot
       if: github.ref == 'refs/heads/main'
@@ -70,7 +72,7 @@ jobs:
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-      run: ./gradlew build snapshot --max-workers=2
+      run: ./gradlew build snapshot --max-workers=$MAX_WORKERS
 
     - name: Build Candidate
       if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')
@@ -79,7 +81,7 @@ jobs:
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-      run: ./gradlew -Prelease.useLastTag=true build candidate --max-workers=2
+      run: ./gradlew -Prelease.useLastTag=true build candidate --max-workers=$MAX_WORKERS
 
     - name: Build Final
       if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc')
@@ -88,7 +90,7 @@ jobs:
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-      run: ./gradlew -Prelease.useLastTag=true build final --max-workers=2
+      run: ./gradlew -Prelease.useLastTag=true build final --max-workers=$MAX_WORKERS
 
     - uses: actions/attest-build-provenance@v3
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'


### PR DESCRIPTION
This allows all tasks that use `--max-workers` to be synchronized.
