### PR TITLE
chore: Limit fetch depth for dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        submodules: 'recursive'
+        fetch-depth: 1
     - uses: actions/setup-java@v5
       with:
         distribution: zulu


### PR DESCRIPTION
This reduces clone time
