### PR TITLE
chore: Increase available memory for gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.caching=true
 
 # Configure JVM memory and open module exports for Java compilation
-org.gradle.jvmargs=-Xmx8g \
+org.gradle.jvmargs=-Xmx12g \
   --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \


### PR DESCRIPTION
The GitHub default instance allows up to 16 GB of memory.
This could allow more concurrency.
