### PR TITLE
refactor: Use var where reasonable

### DIFF
--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
@@ -4,7 +4,6 @@ import io.github.pulpogato.rest.schemas.ActionsCacheUsageByRepository;
 import io.github.pulpogato.rest.schemas.ActionsCacheList;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,15 +11,15 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheUsage() {
-        ActionsApi api = new RestClients(webClient).getActionsApi();
-        ResponseEntity<ActionsCacheUsageByRepository> response = api.getActionsCacheUsage("pulpogato", "pulpogato");
-        
+        var api = new RestClients(webClient).getActionsApi();
+        var response = api.getActionsCacheUsage("pulpogato", "pulpogato");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(ActionsCacheUsageByRepository.class);
-        
-        ActionsCacheUsageByRepository cacheUsage = response.getBody();
+
+        var cacheUsage = response.getBody();
         assertThat(cacheUsage.getFullName()).isEqualTo("pulpogato/pulpogato");
         assertThat(cacheUsage.getActiveCachesSizeInBytes()).isEqualTo(9664500682L);
         assertThat(cacheUsage.getActiveCachesCount()).isEqualTo(60);
@@ -28,33 +27,33 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheList() {
-        ActionsApi api = new RestClients(webClient).getActionsApi();
-        ResponseEntity<ActionsCacheList> response = api.getActionsCacheList("pulpogato", "pulpogato", null, null, null, null, null, null);
-        
+        var api = new RestClients(webClient).getActionsApi();
+        var response = api.getActionsCacheList("pulpogato", "pulpogato", null, null, null, null, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(ActionsCacheList.class);
-        
-        ActionsCacheList cacheList = response.getBody();
+
+        var cacheList = response.getBody();
         assertThat(cacheList.getTotalCount()).isEqualTo(60);
         assertThat(cacheList.getActionsCaches()).isNotNull().hasSize(30);
     }
 
     @Test
     void testGetActionsCacheListWithPagination() {
-        ActionsApi api = new RestClients(webClient).getActionsApi();
-        ResponseEntity<ActionsCacheList> response = api.getActionsCacheList("pulpogato", "pulpogato", 10L, 0L, null, null, null, null);
-        
+        var api = new RestClients(webClient).getActionsApi();
+        var response = api.getActionsCacheList("pulpogato", "pulpogato", 10L, 0L, null, null, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(ActionsCacheList.class);
-        
-        ActionsCacheList cacheList = response.getBody();
+
+        var cacheList = response.getBody();
         assertThat(cacheList.getTotalCount()).isEqualTo(60);
         assertThat(cacheList.getActionsCaches()).isNotNull();
-        
+
         // Verify pagination works
         assertThat(cacheList.getActionsCaches()).hasSize(10);
     }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActivityApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActivityApiIntegrationTest.java
@@ -1,12 +1,8 @@
 package io.github.pulpogato.rest.api;
 
-import io.github.pulpogato.rest.schemas.Event;
 import io.github.pulpogato.rest.schemas.Feed;
-import io.github.pulpogato.rest.schemas.MinimalRepository;
-import io.github.pulpogato.rest.schemas.Repository;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -16,20 +12,20 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicEvents() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
-        ResponseEntity<List<Event>> response = api.listPublicEvents(10L, 1L);
-        
+        var api = new RestClients(webClient).getActivityApi();
+        var response = api.listPublicEvents(10L, 1L);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<Event> events = response.getBody();
+
+        var events = response.getBody();
         assertThat(events)
                 .isNotNull()
                 .hasSize(10); // We requested max 10 per page
-        
-        Event firstEvent = events.getFirst();
+
+        var firstEvent = events.getFirst();
         assertThat(firstEvent.getId()).isEqualTo("50486820386");
         assertThat(firstEvent.getType()).isEqualTo("PushEvent");
         assertThat(firstEvent.getActor().getLogin()).isEqualTo("james2037");
@@ -39,15 +35,15 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetFeeds() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
-        ResponseEntity<Feed> response = api.getFeeds();
-        
+        var api = new RestClients(webClient).getActivityApi();
+        var response = api.getFeeds();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(Feed.class);
-        
-        Feed feed = response.getBody();
+
+        var feed = response.getBody();
         assertThat(feed.getTimelineUrl()).isEqualTo("https://github.com/timeline");
         assertThat(feed.getUserUrl()).isEqualTo("https://github.com/{user}");
         assertThat(feed.getCurrentUserPublicUrl()).isEqualTo("https://github.com/rahulsom");
@@ -57,7 +53,7 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
         // assertThat(feed.getCurrentUserActorUrl()).isNotNull();
         // assertThat(feed.getCurrentUserOrganizationUrl()).isNotNull();
         assertThat(feed.getSecurityAdvisoriesUrl()).isEqualTo("https://github.com/security-advisories");
-        
+
         // Verify URLs contain expected patterns
         assertThat(feed.getTimelineUrl()).contains("timeline");
         assertThat(feed.getUserUrl()).contains("{user}");
@@ -66,27 +62,27 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicOrgEvents() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
+        var api = new RestClients(webClient).getActivityApi();
         // Using GitHub's own organization as an example
-        ResponseEntity<List<Event>> response = api.listPublicOrgEvents("github", 5L, 1L);
-        
+        var response = api.listPublicOrgEvents("github", 5L, 1L);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<Event> events = response.getBody();
+
+        var events = response.getBody();
         assertThat(events)
                 .isNotNull()
                 .hasSize(5); // We requested max 5 per page
-        
-        Event firstEvent = events.getFirst();
+
+        var firstEvent = events.getFirst();
         assertThat(firstEvent.getId()).isEqualTo("50473417741");
         assertThat(firstEvent.getType()).isEqualTo("IssueCommentEvent");
         assertThat(firstEvent.getActor().getLogin()).isEqualTo("Sharra-writes");
         assertThat(firstEvent.getRepo().getName()).isEqualTo("github/docs");
         assertThat(firstEvent.getCreatedAt()).isNotNull();
-        
+
         // Verify this is related to the GitHub org
         assertThat(firstEvent.getOrg()).isNotNull();
         assertThat(firstEvent.getOrg().getLogin()).isEqualTo("github");
@@ -94,21 +90,21 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListRepoEvents() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
+        var api = new RestClients(webClient).getActivityApi();
         // Using a popular repository as an example
-        ResponseEntity<List<Event>> response = api.listRepoEvents("octocat", "Hello-World", 5L, 1L);
-        
+        var response = api.listRepoEvents("octocat", "Hello-World", 5L, 1L);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<Event> events = response.getBody();
+
+        var events = response.getBody();
         assertThat(events)
                 .isNotNull()
                 .hasSize(5); // We requested max 5 per page
-        
-        Event firstEvent = events.getFirst();
+
+        var firstEvent = events.getFirst();
         assertThat(firstEvent.getId()).isEqualTo("50472301049");
         assertThat(firstEvent.getType()).isEqualTo("ForkEvent");
         assertThat(firstEvent.getActor().getLogin()).isEqualTo("antoniovial");
@@ -118,22 +114,22 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListReposStarredByAuthenticatedUser() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
-        ResponseEntity<List<Repository>> response = api.listReposStarredByAuthenticatedUser(
+        var api = new RestClients(webClient).getActivityApi();
+        var response = api.listReposStarredByAuthenticatedUser(
                 null, null, 10L, 1L);
-        
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<Repository> repositories = response.getBody();
+
+        var repositories = response.getBody();
         assertThat(repositories)
                 .isNotNull()
                 .hasSize(1); // We have 1 starred repository
-        
+
         // Verify starred repositories structure
-        Repository firstRepo = repositories.getFirst();
+        var firstRepo = repositories.getFirst();
         assertThat(firstRepo.getId()).isEqualTo(825463572L);
         assertThat(firstRepo.getName()).isEqualTo("pulpogato");
         assertThat(firstRepo.getFullName()).isEqualTo("pulpogato/pulpogato");
@@ -143,21 +139,21 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListWatchedReposForAuthenticatedUser() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
-        ResponseEntity<List<MinimalRepository>> response = api.listWatchedReposForAuthenticatedUser(10L, 1L);
-        
+        var api = new RestClients(webClient).getActivityApi();
+        var response = api.listWatchedReposForAuthenticatedUser(10L, 1L);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<MinimalRepository> repositories = response.getBody();
+
+        var repositories = response.getBody();
         assertThat(repositories)
                 .isNotNull()
                 .hasSize(10); // We requested max 10 per page
-        
+
         // Verify watched repositories structure
-        MinimalRepository firstRepo = repositories.getFirst();
+        var firstRepo = repositories.getFirst();
         assertThat(firstRepo.getId()).isEqualTo(1006911L);
         assertThat(firstRepo.getName()).isEqualTo("bash-utils");
         assertThat(firstRepo.getFullName()).isEqualTo("rahulsom/bash-utils");
@@ -166,21 +162,21 @@ class ActivityApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListPublicEventsForUser() {
-        ActivityApi api = new RestClients(webClient).getActivityApi();
+        var api = new RestClients(webClient).getActivityApi();
         // Using octocat as a well-known GitHub user
-        ResponseEntity<List<Event>> response = api.listPublicEventsForUser("rahulsom", 5L, 1L);
-        
+        var response = api.listPublicEventsForUser("rahulsom", 5L, 1L);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<Event> events = response.getBody();
+
+        var events = response.getBody();
         assertThat(events)
                 .isNotNull()
                 .hasSize(5); // We requested max 5 per page
-        
-        Event firstEvent = events.getFirst();
+
+        var firstEvent = events.getFirst();
         assertThat(firstEvent.getId()).isEqualTo("50486444578");
         assertThat(firstEvent.getType()).isEqualTo("PushEvent");
         assertThat(firstEvent.getActor().getLogin()).isEqualTo("rahulsom");

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CodesOfConductApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CodesOfConductApiIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.pulpogato.rest.api;
 import io.github.pulpogato.rest.schemas.CodeOfConduct;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -13,30 +12,30 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllCodesOfConduct() {
-        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
-        ResponseEntity<List<CodeOfConduct>> response = api.getAllCodesOfConduct();
-        
+        var api = new RestClients(webClient).getCodesOfConductApi();
+        var response = api.getAllCodesOfConduct();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<CodeOfConduct> codesOfConduct = response.getBody();
+
+        var codesOfConduct = response.getBody();
         assertThat(codesOfConduct)
                 .isNotEmpty()
                 .hasSize(2);
-        
+
         // Verify structure of codes of conduct
-        CodeOfConduct firstCode = codesOfConduct.getFirst();
+        var firstCode = codesOfConduct.getFirst();
         assertThat(firstCode.getKey()).isEqualTo("django");
         assertThat(firstCode.getName()).isEqualTo("Django");
         assertThat(firstCode.getUrl().toString()).isEqualTo("https://api.github.com/codes_of_conduct/django");
-        
+
         // Check for common codes of conduct
-        List<String> codeKeys = codesOfConduct.stream()
+        var codeKeys = codesOfConduct.stream()
                 .map(CodeOfConduct::getKey)
                 .toList();
-        
+
         // Common codes that GitHub provides (using actual key format)
         assertThat(codeKeys)
                 .contains("django", "contributor_covenant");
@@ -44,15 +43,15 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContributorCovenantCodeOfConduct() {
-        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
-        ResponseEntity<CodeOfConduct> response = api.getConductCode("contributor_covenant");
-        
+        var api = new RestClients(webClient).getCodesOfConductApi();
+        var response = api.getConductCode("contributor_covenant");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(CodeOfConduct.class);
-        
-        CodeOfConduct codeOfConduct = response.getBody();
+
+        var codeOfConduct = response.getBody();
         assertThat(codeOfConduct.getKey()).isEqualTo("contributor_covenant");
         assertThat(codeOfConduct.getName()).contains("Contributor Covenant");
         assertThat(codeOfConduct.getUrl().toString()).isEqualTo("https://api.github.com/codes_of_conduct/contributor_covenant");
@@ -64,15 +63,15 @@ class CodesOfConductApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetCitizenCodeOfConduct() {
-        CodesOfConductApi api = new RestClients(webClient).getCodesOfConductApi();
-        ResponseEntity<CodeOfConduct> response = api.getConductCode("citizen_code_of_conduct");
-        
+        var api = new RestClients(webClient).getCodesOfConductApi();
+        var response = api.getConductCode("citizen_code_of_conduct");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(CodeOfConduct.class);
-        
-        CodeOfConduct codeOfConduct = response.getBody();
+
+        var codeOfConduct = response.getBody();
         assertThat(codeOfConduct.getKey()).isEqualTo("citizen_code_of_conduct");
         assertThat(codeOfConduct.getName()).contains("Citizen Code");
         assertThat(codeOfConduct.getUrl().toString()).isEqualTo("https://api.github.com/codes_of_conduct/citizen_code_of_conduct");

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/EmojisApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/EmojisApiIntegrationTest.java
@@ -2,7 +2,6 @@ package io.github.pulpogato.rest.api;
 
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.util.Map;
 
@@ -12,23 +11,23 @@ class EmojisApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        EmojisApi api = new RestClients(webClient).getEmojisApi();
-        ResponseEntity<Map<String, String>> response = api.get();
-        
+        var api = new RestClients(webClient).getEmojisApi();
+        var response = api.get();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(Map.class);
-        
-        Map<String, String> emojis = response.getBody();
+
+        var emojis = response.getBody();
         assertThat(emojis)
                 .isNotEmpty()
                 .containsKey("+1")
                 .containsKey("100")
                 .containsKey("heart");
-        
+
         // Verify that values are URLs
-        String heartEmojiUrl = emojis.get("heart");
+        var heartEmojiUrl = emojis.get("heart");
         assertThat(heartEmojiUrl)
                 .isNotNull()
                 .startsWith("https://")

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/GitignoreApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/GitignoreApiIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.pulpogato.rest.api;
 import io.github.pulpogato.rest.schemas.GitignoreTemplate;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -13,15 +12,15 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllTemplates() {
-        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
-        ResponseEntity<List<String>> response = api.getAllTemplates();
-        
+        var api = new RestClients(webClient).getGitignoreApi();
+        var response = api.getAllTemplates();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<String> templates = response.getBody();
+
+        var templates = response.getBody();
         assertThat(templates)
                 .isNotEmpty()
                 .contains("Java", "Python", "Node");
@@ -29,15 +28,15 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetJavaTemplate() {
-        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
-        ResponseEntity<GitignoreTemplate> response = api.getTemplate("Java");
-        
+        var api = new RestClients(webClient).getGitignoreApi();
+        var response = api.getTemplate("Java");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(GitignoreTemplate.class);
-        
-        GitignoreTemplate template = response.getBody();
+
+        var template = response.getBody();
         assertThat(template.getName()).isEqualTo("Java");
         assertThat(template.getSource())
                 .isNotNull()
@@ -47,15 +46,15 @@ class GitignoreApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetPythonTemplate() {
-        GitignoreApi api = new RestClients(webClient).getGitignoreApi();
-        ResponseEntity<GitignoreTemplate> response = api.getTemplate("Python");
-        
+        var api = new RestClients(webClient).getGitignoreApi();
+        var response = api.getTemplate("Python");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(GitignoreTemplate.class);
-        
-        GitignoreTemplate template = response.getBody();
+
+        var template = response.getBody();
         assertThat(template.getName()).isEqualTo("Python");
         assertThat(template.getSource())
                 .isNotNull()

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/LicensesApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/LicensesApiIntegrationTest.java
@@ -4,7 +4,6 @@ import io.github.pulpogato.rest.schemas.LicenseSimple;
 import io.github.pulpogato.rest.schemas.License;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -14,29 +13,29 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetAllCommonlyUsed() {
-        LicensesApi api = new RestClients(webClient).getLicensesApi();
-        ResponseEntity<List<LicenseSimple>> response = api.getAllCommonlyUsed(null, null, null);
-        
+        var api = new RestClients(webClient).getLicensesApi();
+        var response = api.getAllCommonlyUsed(null, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<LicenseSimple> licenses = response.getBody();
+
+        var licenses = response.getBody();
         assertThat(licenses)
                 .isNotEmpty()
                 .hasSizeGreaterThan(5);
-        
+
         // Verify common licenses are present
-        List<String> licenseKeys = licenses.stream()
+        var licenseKeys = licenses.stream()
                 .map(LicenseSimple::getKey)
                 .toList();
-        
+
         assertThat(licenseKeys)
                 .contains("mit", "apache-2.0", "gpl-3.0");
-        
+
         // Verify structure of first license
-        LicenseSimple firstLicense = licenses.getFirst();
+        var firstLicense = licenses.getFirst();
         assertThat(firstLicense.getKey()).isEqualTo("agpl-3.0");
         assertThat(firstLicense.getName()).isEqualTo("GNU Affero General Public License v3.0");
         assertThat(firstLicense.getUrl()).isNotNull();
@@ -45,15 +44,15 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetMitLicense() {
-        LicensesApi api = new RestClients(webClient).getLicensesApi();
-        ResponseEntity<License> response = api.get("mit");
-        
+        var api = new RestClients(webClient).getLicensesApi();
+        var response = api.get("mit");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(License.class);
-        
-        License mitLicense = response.getBody();
+
+        var mitLicense = response.getBody();
         assertThat(mitLicense.getKey()).isEqualTo("mit");
         assertThat(mitLicense.getName()).contains("MIT");
         assertThat(mitLicense.getSpdxId()).isEqualTo("MIT");
@@ -73,15 +72,15 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetApacheLicense() {
-        LicensesApi api = new RestClients(webClient).getLicensesApi();
-        ResponseEntity<License> response = api.get("apache-2.0");
-        
+        var api = new RestClients(webClient).getLicensesApi();
+        var response = api.get("apache-2.0");
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(License.class);
-        
-        License apacheLicense = response.getBody();
+
+        var apacheLicense = response.getBody();
         assertThat(apacheLicense.getKey()).isEqualTo("apache-2.0");
         assertThat(apacheLicense.getName()).contains("Apache");
         assertThat(apacheLicense.getSpdxId()).isEqualTo("Apache-2.0");
@@ -92,21 +91,21 @@ class LicensesApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetFeaturedLicenses() {
-        LicensesApi api = new RestClients(webClient).getLicensesApi();
-        ResponseEntity<List<LicenseSimple>> response = api.getAllCommonlyUsed(true, null, null);
-        
+        var api = new RestClients(webClient).getLicensesApi();
+        var response = api.getAllCommonlyUsed(true, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(List.class);
-        
-        List<LicenseSimple> featuredLicenses = response.getBody();
+
+        var featuredLicenses = response.getBody();
         assertThat(featuredLicenses)
                 .isNotEmpty()
                 .hasSize(3); // Featured licenses should be a smaller subset
-        
+
         // Verify the first featured license has specific values
-        LicenseSimple firstFeatured = featuredLicenses.getFirst();
+        var firstFeatured = featuredLicenses.getFirst();
         assertThat(firstFeatured.getKey()).isEqualTo("apache-2.0");
         assertThat(firstFeatured.getName()).isEqualTo("Apache License 2.0");
         assertThat(firstFeatured.getUrl()).isNotNull();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/MetaApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/MetaApiIntegrationTest.java
@@ -4,7 +4,6 @@ import io.github.pulpogato.rest.schemas.ApiOverview;
 import io.github.pulpogato.rest.schemas.Root;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,15 +11,15 @@ class MetaApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testRoot() {
-        MetaApi api = new RestClients(webClient).getMetaApi();
-        ResponseEntity<Root> response = api.root();
-        
+        var api = new RestClients(webClient).getMetaApi();
+        var response = api.root();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(Root.class);
-        
-        Root root = response.getBody();
+
+        var root = response.getBody();
         assertThat(root.getCurrentUserUrl())
                 .isEqualTo("https://api.github.com/user");
         assertThat(root.getEmojisUrl())
@@ -31,15 +30,15 @@ class MetaApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        MetaApi api = new RestClients(webClient).getMetaApi();
-        ResponseEntity<ApiOverview> response = api.get();
-        
+        var api = new RestClients(webClient).getMetaApi();
+        var response = api.get();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(ApiOverview.class);
-        
-        ApiOverview meta = response.getBody();
+
+        var meta = response.getBody();
         assertThat(meta.getVerifiablePasswordAuthentication()).isFalse();
         assertThat(meta.getSshKeyFingerprints()).isNotNull();
         assertThat(meta.getSshKeys()).hasSize(3);

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OrgsApiIntegrationTest extends BaseIntegrationTest {
     @Test
     void testListInstallations() {
-        OrgsApi api = new RestClients(webClient).getOrgsApi();
+        var api = new RestClients(webClient).getOrgsApi();
         var response = api.listAppInstallations("corp", 100L, 1L);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/PullsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/PullsApiIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.github.pulpogato.rest.api;
 
-import io.github.pulpogato.rest.schemas.PullRequestSimple;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,7 @@ class PullsApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetActionsCacheUsage() {
-        PullsApi api = new RestClients(webClient).getPullsApi();
+        var api = new RestClients(webClient).getPullsApi();
         var response = api.list(
                 "example", "cisys-jenkins-bom", PullsApi.ListState.ALL, "johnburns:NEBULA-3674",
             null, null, null, null, null);
@@ -22,11 +21,11 @@ class PullsApiIntegrationTest extends BaseIntegrationTest {
                 .isNotNull()
                 .isInstanceOf(List.class);
 
-        List<PullRequestSimple> pulls = response.getBody();
+        var pulls = response.getBody();
 
         assertThat(pulls).hasSize(1);
 
-        PullRequestSimple pr = pulls.getFirst();
+        var pr = pulls.getFirst();
         assertThat(pr.getNumber()).isEqualTo(170);
     }
 

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/RateLimitApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/RateLimitApiIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.pulpogato.rest.api;
 import io.github.pulpogato.rest.schemas.RateLimitOverview;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,16 +10,16 @@ class RateLimitApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        RateLimitApi api = new RestClients(webClient).getRateLimitApi();
-        ResponseEntity<RateLimitOverview> response = api.get();
-        
+        var api = new RestClients(webClient).getRateLimitApi();
+        var response = api.get();
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(RateLimitOverview.class);
-        
-        RateLimitOverview rateLimitOverview = response.getBody();
-        
+
+        var rateLimitOverview = response.getBody();
+
         // Verify resources structure
         var resources = rateLimitOverview.getResources();
         

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReposApiIntegrationTest extends BaseIntegrationTest {
     @Test
     void testListTags() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.listTags("pulpogato", "pulpogato", 100L, 1L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -37,7 +37,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testListCommits() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.listCommits("pulpogato", "pulpogato",
                 null, null, null, null, null, null, 10L, 1L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
@@ -55,7 +55,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetCommit() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.getCommit("pulpogato", "pulpogato", 1L, 1L, "2667e9ae0adcdbf378fe6273658b57f4e5d24a39");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -66,7 +66,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContentObject() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.getContentObject("pulpogato", "pulpogato", "README.adoc", null);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -84,7 +84,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetContent() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.getContent("pulpogato", "pulpogato", "README.adoc", null);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -102,7 +102,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGet() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.get("pulpogato", "pulpogato");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -115,7 +115,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetBranch() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.getBranch("pulpogato", "pulpogato", "main");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -127,7 +127,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testGetBranchProtection() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.getBranchProtection("pulpogato", "pulpogato", "main");
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -138,7 +138,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrg() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("pulpogato", ReposApi.CreateInOrgRequestBody.builder()
                 .name("create-demo")
                 .description("create demo")
@@ -155,7 +155,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrgWithCustomProperties() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("example", ReposApi.CreateInOrgRequestBody.builder()
                 .name("rsomasunderam-custom-props-demo")
                 .description("create demo")
@@ -215,7 +215,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateRepositoryInOrgWithExtendedCustomProperties() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var response = api.createInOrg("example", ExtendedCreateInOrgRequestBody.builder()
                 .name("rsomasunderam-custom-props-demo")
                 .description("create demo")
@@ -228,8 +228,8 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
                 .isNotNull()
                 .isInstanceOf(FullRepository.class);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        ExtendedFullRepository body = objectMapper.readValue(objectMapper.writeValueAsString(response.getBody()),
+        var objectMapper = new ObjectMapper();
+        var body = objectMapper.readValue(objectMapper.writeValueAsString(response.getBody()),
                 ExtendedFullRepository.class);
 
         assertThat(body.getName()).isEqualTo("rsomasunderam-custom-props-demo");
@@ -240,7 +240,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValues() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
 
         var customPropertyValue = CustomPropertyValue.builder()
                 .propertyName("audit_pci")
@@ -257,7 +257,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesWithMultipleProperties() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
 
         var environmentProperty = CustomPropertyValue.builder()
                 .propertyName("some_string")
@@ -279,7 +279,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesWithArrayValue() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
 
         var tagsProperty = CustomPropertyValue.builder()
                 .propertyName("plural_value")
@@ -296,7 +296,7 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testCreateOrUpdateCustomPropertiesValuesEmptyProperties() {
-        ReposApi api = new RestClients(webClient).getReposApi();
+        var api = new RestClients(webClient).getReposApi();
         var requestBody = ReposApi.CustomPropertiesForReposCreateOrUpdateRepositoryValuesRequestBody.builder()
                 .properties(List.of())
                 .build();

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
@@ -1,11 +1,7 @@
 package io.github.pulpogato.rest.api;
 
-import io.github.pulpogato.rest.schemas.RepoSearchResultItem;
-import io.github.pulpogato.rest.schemas.TopicSearchResultItem;
-import io.github.pulpogato.rest.schemas.UserSearchResultItem;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,21 +9,21 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchRepositories() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Repos200> response = api.repos("pulpogato", null, null, null, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.repos("pulpogato", null, null, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Repos200.class);
-        
-        SearchApi.Repos200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull();
-        
+
         // Should find at least the pulpogato repository itself
         assertThat(searchResult.getItems()).isNotEmpty();
-        RepoSearchResultItem firstRepo = searchResult.getItems().getFirst();
+        var firstRepo = searchResult.getItems().getFirst();
         assertThat(firstRepo.getName()).isNotNull();
         assertThat(firstRepo.getFullName()).isNotNull();
         assertThat(firstRepo.getOwner()).isNotNull();
@@ -36,36 +32,36 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchRepositoriesWithLanguageFilter() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Repos200> response = api.repos("language:java", null, null, 10L, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.repos("language:java", null, null, 10L, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Repos200.class);
-        
-        SearchApi.Repos200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull().isEmpty();
     }
 
     @Test
     void testSearchUsers() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Users200> response = api.users("rahulsom", null, null, null, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.users("rahulsom", null, null, null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Users200.class);
-        
-        SearchApi.Users200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull();
-        
+
         // Should find users with "rahulsom" in name/login
         assertThat(searchResult.getItems()).isNotEmpty();
-        UserSearchResultItem firstUser = searchResult.getItems().getFirst();
+        var firstUser = searchResult.getItems().getFirst();
         assertThat(firstUser.getLogin()).isNotNull();
         assertThat(firstUser.getId()).isNotNull();
         assertThat(firstUser.getType()).isNotNull();
@@ -73,39 +69,39 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchUsersWithLocationFilter() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Users200> response = api.users("location:california", null, null, 5L, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.users("location:california", null, null, 5L, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Users200.class);
-        
-        SearchApi.Users200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull();
-        
+
         // Verify pagination works
         assertThat(searchResult.getItems()).isEmpty();
     }
 
     @Test
     void testSearchTopics() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Topics200> response = api.topics("java", null, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.topics("java", null, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Topics200.class);
-        
-        SearchApi.Topics200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull();
-        
+
         // Should find Java-related topics
         assertThat(searchResult.getItems()).isNotEmpty();
-        TopicSearchResultItem firstTopic = searchResult.getItems().getFirst();
+        var firstTopic = searchResult.getItems().getFirst();
         assertThat(firstTopic.getName()).isNotNull();
         assertThat(firstTopic.getDisplayName()).isNotNull();
         assertThat(firstTopic.getCreatedBy()).isNotNull();
@@ -113,23 +109,23 @@ class SearchApiIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void testSearchTopicsPopular() {
-        SearchApi api = new RestClients(webClient).getSearchApi();
-        ResponseEntity<SearchApi.Topics200> response = api.topics("machine-learning", 10L, null);
-        
+        var api = new RestClients(webClient).getSearchApi();
+        var response = api.topics("machine-learning", 10L, null);
+
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
                 .isNotNull()
                 .isInstanceOf(SearchApi.Topics200.class);
-        
-        SearchApi.Topics200 searchResult = response.getBody();
+
+        var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull();
-        
+
         // Verify topics search returns results
         assertThat(searchResult.getItems()).isNotEmpty();
         assertThat(searchResult.getItems().size()).isEqualTo(10);
-        
-        TopicSearchResultItem firstTopic = searchResult.getItems().getFirst();
+
+        var firstTopic = searchResult.getItems().getFirst();
         assertThat(firstTopic.getName()).isNotNull();
         assertThat(firstTopic.getScore()).isNotNull();
     }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -6,7 +6,6 @@ import io.github.pulpogato.rest.schemas.SimpleUser;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -19,8 +18,8 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetAuthenticatedPublic() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
-        ResponseEntity<UsersApi.GetAuthenticated200> authenticated = api.getAuthenticated();
+        var api = new RestClients(webClient).getUsersApi();
+        var authenticated = api.getAuthenticated();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(authenticated.getBody())
                 .isNotNull()
@@ -35,8 +34,8 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetAuthenticatedPrivate() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
-        ResponseEntity<UsersApi.GetAuthenticated200> authenticated = api.getAuthenticated();
+        var api = new RestClients(webClient).getUsersApi();
+        var authenticated = api.getAuthenticated();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(authenticated.getBody())
                 .isNotNull()
@@ -54,7 +53,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
     @Test
     @Disabled("PATCH is currently broken")
     void testUpdateAuthenticated() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var update = UsersApi.UpdateAuthenticatedRequestBody.builder()
                 .location("San Francisco Bay Area")
                 .build();
@@ -71,7 +70,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListBlockedEmpty() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var blocked = api.listBlockedByAuthenticatedUser(5L, 0L);
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -85,7 +84,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListBlockedValid() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var blocked = api.listBlockedByAuthenticatedUser(5L, 0L);
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -104,7 +103,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testCheckBlocked() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var blocked = api.checkBlocked("some-blocked-user");
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(blocked.getBody())
@@ -113,8 +112,8 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testCheckNotBlocked() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
-        WebClientResponseException exception = catchThrowableOfType(WebClientResponseException.class, () -> api.checkBlocked("gooduser"));
+        var api = new RestClients(webClient).getUsersApi();
+        var exception = catchThrowableOfType(WebClientResponseException.class, () -> api.checkBlocked("gooduser"));
 
         assertThat(exception).isNotNull();
         assertThat(exception.getStatusCode().is4xxClientError()).isTrue();
@@ -123,8 +122,8 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testBlockUserFailed() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
-        WebClientResponseException exception = catchThrowableOfType(WebClientResponseException.class, () -> api.block("some-blocked-user"));
+        var api = new RestClients(webClient).getUsersApi();
+        var exception = catchThrowableOfType(WebClientResponseException.class, () -> api.block("some-blocked-user"));
 
         assertThat(exception).isNotNull();
         assertThat(exception.getStatusCode().is4xxClientError()).isTrue();
@@ -133,7 +132,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testBlockUserSuccess() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var blocked = api.block("gooduser");
 
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
@@ -143,7 +142,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testUnblockUserSuccess() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var blocked = api.block("gooduser");
 
         assertThat(blocked.getStatusCode().is2xxSuccessful()).isTrue();
@@ -153,7 +152,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowers() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var followers = api.listFollowersForAuthenticatedUser( 5L, 0L);
         assertThat(followers.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(followers.getBody())
@@ -172,7 +171,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListGpgKeysForAuthenticatedUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var gpgKeys = api.listGpgKeysForAuthenticatedUser(5L, 0L);
         assertThat(gpgKeys.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(gpgKeys.getBody())
@@ -191,7 +190,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetGpgKeyForAuthenticatedUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var gpgKey = api.getGpgKeyForAuthenticatedUser(175109L);
         assertThat(gpgKey.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(gpgKey.getBody())
@@ -205,7 +204,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListPublicEmailsForAuthenticatedUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var response = api.listPublicEmailsForAuthenticatedUser(5L, 0L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -229,7 +228,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListEmailsForAuthenticatedUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
         var response = api.listEmailsForAuthenticatedUser(5L, 0L);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody())
@@ -260,7 +259,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListSocialAccountsForAuthenticatedUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
         var response = api.listSocialAccountsForAuthenticatedUser(5L, 0L);
 
@@ -279,7 +278,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetById() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
         var response = api.getById(230004L);
 
@@ -307,7 +306,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetByUsername() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
         var response = api.getByUsername("sghill");
 
@@ -335,9 +334,9 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testGetByUsername404() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
-        WebClientResponseException exception = catchThrowableOfType(
+        var exception = catchThrowableOfType(
                 WebClientResponseException.class,
                 () -> api.getByUsername("rahulsom1")
         );
@@ -356,7 +355,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowersForUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
         var response = api.listFollowersForUser("sghill", 5L, 0L);
 
@@ -377,7 +376,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
     @Test
     void testListFollowingForUser() {
-        UsersApi api = new RestClients(webClient).getUsersApi();
+        var api = new RestClients(webClient).getUsersApi();
 
         var response = api.listFollowingForUser("sghill", 5L, 0L);
 


### PR DESCRIPTION
When the type is apparent from the variable name and context, var improves readability.
