### PR TITLE
feat!: Add three-state nullable field handling with custom builders

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 assertj = "3.27.6"
 jspecify = "1.0.0"
 commonmark = "0.27.0"
+commons-lang3 = "3.17.0"
 commons-text = "1.15.0"
 dgs = "8.2.2"
 download = "5.6.0"
@@ -35,6 +36,7 @@ assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 commonmarkExtAutolink = { group = "org.commonmark", name = "commonmark-ext-autolink", version.ref = "commonmark" }
 commonmarkTables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
+commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
 commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commons-text" }
 glassfishJson = { group = "org.glassfish", name = "javax.json", version.ref = "glassfishJson" }
 groovy = { group = "org.apache.groovy", name = "groovy-all", version.ref = "groovy" }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -13,17 +13,6 @@ import java.util.stream.Stream
 
 object Annotations {
     /*
-     Lombok Annotations
-     */
-    fun lombok(name: String): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", name)).build()
-
-    fun superBuilder(): AnnotationSpec =
-        AnnotationSpec
-            .builder(ClassName.get("lombok.experimental", "SuperBuilder"))
-            .addMember("toBuilder", "true")
-            .build()
-
-    /*
      Jackson Annotations
      */
     fun jsonValue(): AnnotationSpec = AnnotationSpec.builder(ClassName.get(JsonValue::class.java)).build()
@@ -84,6 +73,24 @@ object Annotations {
             .addMember("value", $$"$T.$L", ClassName.get(JsonInclude.Include::class.java), JsonInclude.Include.ALWAYS)
             .build()
 
+    fun jsonIncludeNonEmpty(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonInclude::class.java))
+            .addMember("value", $$"$T.$L", ClassName.get(JsonInclude.Include::class.java), JsonInclude.Include.NON_EMPTY)
+            .build()
+
+    fun nullableOptionalSerializer(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonSerialize::class.java))
+            .addMember("using", $$"$T.class", ClassName.get("io.github.pulpogato.common", "NullableOptionalSerializer"))
+            .build()
+
+    fun nullableOptionalDeserializer(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonDeserialize::class.java))
+            .addMember("using", $$"$T.class", ClassName.get("io.github.pulpogato.common", "NullableOptionalDeserializer"))
+            .build()
+
     /*
      GH Annotations
      */
@@ -141,5 +148,12 @@ object Annotations {
     fun nullable(): AnnotationSpec =
         AnnotationSpec
             .builder(ClassName.get("org.jspecify.annotations", "Nullable"))
+            .build()
+
+    fun deprecated(since: String): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get("java.lang", "Deprecated"))
+            .addMember("forRemoval", "false")
+            .addMember("since", $$"$S", since)
             .build()
 }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/EnumConvertersBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/EnumConvertersBuilder.kt
@@ -7,7 +7,6 @@ import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeSpec
 import io.github.pulpogato.restcodegen.Annotations.generated
-import io.github.pulpogato.restcodegen.Annotations.lombok
 import java.io.File
 import javax.lang.model.element.Modifier
 
@@ -24,8 +23,7 @@ class EnumConvertersBuilder {
      * Builds the EnumConverters class containing all enum converter instances.
      *
      * This method creates a Java class named "EnumConverters" that contains a
-     * list of all enum converters provided. The generated class is annotated
-     * with Lombok annotations for getter methods and required argument constructor.
+     * list of all enum converters provided.
      * It also includes a generated annotation for tracking the source.
      *
      * If the enumConverters set is empty, this method returns early without
@@ -54,8 +52,6 @@ class EnumConvertersBuilder {
                 .classBuilder("EnumConverters")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(generated(0, context.withSchemaStack("#", "components", "schemas")))
-                .addAnnotation(lombok("Getter"))
-                .addAnnotation(lombok("RequiredArgsConstructor"))
                 .addJavadoc($$"$L", "Registry containing all enum converters for Spring Boot configuration.")
 
         // Add a list field containing all converters
@@ -93,6 +89,24 @@ class EnumConvertersBuilder {
                 ).build()
 
         enumConvertersClass.addField(convertersField)
+
+        // Add explicit no-args constructor
+        enumConvertersClass.addMethod(
+            com.palantir.javapoet.MethodSpec
+                .constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .build(),
+        )
+
+        // Add explicit getConverters() method
+        enumConvertersClass.addMethod(
+            com.palantir.javapoet.MethodSpec
+                .methodBuilder("getConverters")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(listType)
+                .addStatement("return this.converters")
+                .build(),
+        )
 
         // Write the class to file
         JavaFile.builder(apiPackageName, enumConvertersClass.build()).build().writeTo(mainDir)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
@@ -50,6 +50,7 @@ object Types {
     // Common Types
     val EMPTY_OBJECT: ClassName = ClassName.get(COMMON_PACKAGE, "EmptyObject")
     val EXCEPTION: ClassName = ClassName.get(java.lang.Exception::class.java)
+    val NULLABLE_OPTIONAL: ClassName = ClassName.get(COMMON_PACKAGE, "NullableOptional")
     val OBJECT: ClassName = ClassName.get(Object::class.java)
     val STRING_OR_INTEGER: ClassName = ClassName.get(COMMON_PACKAGE, "StringOrInteger")
     val TODO: ClassName = ClassName.get(COMMON_PACKAGE, "Todo")
@@ -58,6 +59,8 @@ object Types {
     val LIST: ClassName = ClassName.get(List::class.java)
     val MAP: ClassName = ClassName.get(Map::class.java)
     val CODE_BUILDER: ClassName = ClassName.get(COMMON_PACKAGE, "CodeBuilder")
+    val OBJECTS: ClassName = ClassName.get("java.util", "Objects")
+    val OVERRIDE: ClassName = ClassName.get(Override::class.java)
 
     // Common Parameterized Types
     val MAP_STRING_OBJECT: ParameterizedTypeName = ParameterizedTypeName.get(MAP, STRING, OBJECT)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -11,7 +11,6 @@ import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
 import io.github.pulpogato.restcodegen.Annotations.generated
-import io.github.pulpogato.restcodegen.Annotations.lombok
 import io.github.pulpogato.restcodegen.Annotations.testExtension
 import io.github.pulpogato.restcodegen.ext.camelCase
 import io.github.pulpogato.restcodegen.ext.className
@@ -325,7 +324,14 @@ class WebhooksBuilder {
                 FieldSpec
                     .builder(ClassName.get(ObjectMapper::class.java), "objectMapper")
                     .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.beans.factory.annotation", "Autowired")).build())
-                    .addAnnotation(lombok("Getter"))
+                    .addModifiers(Modifier.PRIVATE)
+                    .build(),
+            ).addMethod(
+                MethodSpec
+                    .methodBuilder("getObjectMapper")
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(ClassName.get(ObjectMapper::class.java))
+                    .addStatement("return this.objectMapper")
                     .build(),
             ).addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RestController")).build())
             .addAnnotation(

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -8,17 +8,21 @@ import com.palantir.javapoet.ParameterSpec
 import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
+import com.palantir.javapoet.TypeVariableName
+import com.palantir.javapoet.WildcardTypeName
+import io.github.pulpogato.restcodegen.Annotations
 import io.github.pulpogato.restcodegen.Annotations.deserializerAnnotation
 import io.github.pulpogato.restcodegen.Annotations.generated
 import io.github.pulpogato.restcodegen.Annotations.jsonIncludeAlways
+import io.github.pulpogato.restcodegen.Annotations.jsonIncludeNonEmpty
 import io.github.pulpogato.restcodegen.Annotations.jsonIncludeNonNull
 import io.github.pulpogato.restcodegen.Annotations.jsonProperty
 import io.github.pulpogato.restcodegen.Annotations.jsonValue
-import io.github.pulpogato.restcodegen.Annotations.lombok
 import io.github.pulpogato.restcodegen.Annotations.nonNull
+import io.github.pulpogato.restcodegen.Annotations.nullableOptionalDeserializer
+import io.github.pulpogato.restcodegen.Annotations.nullableOptionalSerializer
 import io.github.pulpogato.restcodegen.Annotations.serializerAnnotation
 import io.github.pulpogato.restcodegen.Annotations.singleValueAsArray
-import io.github.pulpogato.restcodegen.Annotations.superBuilder
 import io.github.pulpogato.restcodegen.Annotations.typeGenerated
 import io.github.pulpogato.restcodegen.Context
 import io.github.pulpogato.restcodegen.MarkdownHelper
@@ -29,6 +33,36 @@ import javax.lang.model.element.Modifier
 private const val PACKAGE_PULPOGATO_COMMON = "io.github.pulpogato.common"
 
 fun Map.Entry<String, Schema<*>>.className() = key.pascalCase()
+
+/**
+ * Checks if the given TypeName represents a simple type (primitive, string, or date/time)
+ * that should NOT be wrapped in NullableOptional.
+ */
+private fun isSimpleType(typeName: TypeName): Boolean {
+    // For annotated types, we need to check the base type
+    // The toString() of an annotated type includes annotations like "java.lang. @Annotation String"
+    // We need to remove both the annotation and any extra spacing/dots
+    val typeString =
+        typeName
+            .toString()
+            .replace(Regex("""\s+@\w+(\.\w+)*\([^)]*\)"""), "") // Remove @package.Annotation(args)
+            .replace(Regex("""\s+@\w+(\.\w+)*"""), "") // Remove @package.Annotation
+            .replace(Regex("""\.\s+"""), ".") // Fix "java.lang. String" -> "java.lang.String"
+            .trim()
+
+    return when {
+        typeString == "java.lang.String" -> true
+        typeString == "java.lang.Boolean" || typeString == "boolean" -> true
+        typeString == "java.lang.Integer" || typeString == "int" -> true
+        typeString == "java.lang.Long" || typeString == "long" -> true
+        typeString == "java.lang.Double" || typeString == "double" -> true
+        typeString == "java.lang.Float" || typeString == "float" -> true
+        typeString == "java.math.BigDecimal" -> true
+        typeString.startsWith("java.time.") -> true
+        typeString.startsWith("java.net.URI") -> true
+        else -> false
+    }
+}
 
 fun isSingleOrArray(
     oneOf: List<Schema<Any>>,
@@ -297,10 +331,6 @@ private fun buildFancyObject(
         TypeSpec
             .classBuilder(className)
             .addAnnotation(generated(0, context.withSchemaStack(fancyObjectType)))
-            .addAnnotation(lombok("Getter"))
-            .addAnnotation(lombok("Setter"))
-            .addAnnotation(lombok("ToString"))
-            .addAnnotation(lombok("EqualsAndHashCode"))
             .addModifiers(Modifier.PUBLIC)
             .addSuperinterface(ClassName.get(PACKAGE_PULPOGATO_COMMON, "PulpogatoType"))
 
@@ -323,11 +353,39 @@ private fun buildFancyObject(
             processSubSchema(context.withSchemaStack(fancyObjectType, "$index"), entry, newKey, subSchema, classRef, theType, fields)
         }
 
-    // Generate manual getters, setters, toString, and constructors for the fields
+    // Get built type to access actual field specs for method generation
     val builtType = theType.build()
+    val fieldSpecs = builtType.fieldSpecs()
 
+    // Generate all methods
+    fieldSpecs.forEach { field ->
+        val javadoc = extractJavadoc(field)
+        theType
+            .addMethod(generateGetter(field, javadoc))
+            .addMethod(generateSetter(field, javadoc))
+    }
+
+    theType
+        .addMethod(generateEquals())
+        .addMethod(generateHashCode())
+        .addMethod(generateToString())
+        .addMethod(generateNoArgsConstructor())
+
+    if (fieldSpecs.isNotEmpty()) {
+        theType.addMethod(generateAllArgsConstructor(classRef, fieldSpecs))
+    }
+
+    // Add builder pattern
+    theType
+        .addType(generateBuilderClass(classRef, fieldSpecs))
+        .addType(generateBuilderImplClass(classRef))
+        .addMethod(generateBuilderFactoryMethod(classRef))
+        .addMethod(generateToBuilderMethod(classRef, fieldSpecs))
+
+    // Add toCode method (existing logic)
     addToCodeMethod(builtType, theType, classRef)
 
+    // Add custom serializers/deserializers (KEEP THIS)
     val settableFields = getSettableFields(fields, className)
     val gettableFields = getGettableFields(fields, className)
     val deserializer = buildDeserializer(className, fancyObjectType, settableFields)
@@ -338,9 +396,6 @@ private fun buildFancyObject(
         .addType(serializer)
         .addAnnotation(deserializerAnnotation(className, deserializer))
         .addAnnotation(serializerAnnotation(className, serializer))
-        .addAnnotation(superBuilder())
-        .addAnnotation(lombok("NoArgsConstructor"))
-        .addAnnotation(lombok("AllArgsConstructor"))
 
     return theType.build()
 }
@@ -425,7 +480,14 @@ private fun handleToCodeMethods(
     when {
         hasToCodeMethod && hasNewFields -> rebuildWithUpdatedMethods(builtWithAllProperties, className, theType)
         !hasToCodeMethod -> addMethodsToNewType(builtWithAllProperties, className, theType)
-        else -> theType.addType(builtWithAllProperties)
+        else -> {
+            // Even if toCode doesn't need updating, the Builder might need regenerating if fields were added
+            if (hasNewFields) {
+                rebuildWithUpdatedMethods(builtWithAllProperties, className, theType)
+            } else {
+                theType.addType(builtWithAllProperties)
+            }
+        }
     }
 }
 
@@ -434,11 +496,68 @@ private fun rebuildWithUpdatedMethods(
     className: ClassName,
     theType: TypeSpec.Builder,
 ) {
-    val builderWithoutMethods =
-        copyTypeSpecToBuilder(builtWithAllProperties) { it.name() != "toString" && it.name() != "toCode" }
-    val rebuilt = builderWithoutMethods.build()
-    addToCodeMethod(rebuilt, builderWithoutMethods, className)
-    theType.addType(builderWithoutMethods.build())
+    // Remove old generated methods and Builder to regenerate them with all fields
+    val builderWithoutGeneratedMethods =
+        copyTypeSpecToBuilder(builtWithAllProperties) { method ->
+            // Keep only methods that are NOT auto-generated (like enum methods, custom logic)
+            // Exclude: constructors, getters, setters, equals, hashCode, toString, toCode, builder methods, canEqual
+            when {
+                method.isConstructor -> false
+                method.name() in setOf("toString", "toCode", "equals", "hashCode", "toBuilder", "builder") -> false
+                method.name().startsWith("get") || method.name().startsWith("set") -> false
+                else -> true
+            }
+        }
+
+    // Remove old Builder nested class
+    val builderWithoutOldBuilder = TypeSpec.classBuilder(builtWithAllProperties.name())
+    builtWithAllProperties.annotations().forEach { builderWithoutOldBuilder.addAnnotation(it) }
+    builtWithAllProperties.modifiers().forEach { builderWithoutOldBuilder.addModifiers(it) }
+    builtWithAllProperties.superinterfaces().forEach { builderWithoutOldBuilder.addSuperinterface(it) }
+    builtWithAllProperties.fieldSpecs().forEach { builderWithoutOldBuilder.addField(it) }
+    // Filter out builder classes (ends with "Builder" or "BuilderImpl")
+    builtWithAllProperties
+        .typeSpecs()
+        .filter {
+            !it.name().endsWith("Builder") && !it.name().endsWith("BuilderImpl")
+        }.forEach { builderWithoutOldBuilder.addType(it) }
+    builderWithoutGeneratedMethods.build().methodSpecs().forEach { builderWithoutOldBuilder.addMethod(it) }
+    if (!builtWithAllProperties.javadoc().isEmpty) {
+        builderWithoutOldBuilder.addJavadoc(builtWithAllProperties.javadoc())
+    }
+
+    // Now regenerate all methods with the complete field list
+    val allFields = builtWithAllProperties.fieldSpecs()
+
+    allFields.forEach { field ->
+        val javadoc = extractJavadoc(field)
+        builderWithoutOldBuilder
+            .addMethod(generateGetter(field, javadoc))
+            .addMethod(generateSetter(field, javadoc))
+    }
+
+    builderWithoutOldBuilder
+        .addMethod(generateEquals())
+        .addMethod(generateHashCode())
+        .addMethod(generateToString())
+        .addMethod(generateNoArgsConstructor())
+
+    if (allFields.isNotEmpty()) {
+        builderWithoutOldBuilder.addMethod(generateAllArgsConstructor(className, allFields))
+    }
+
+    // Add builder pattern
+    builderWithoutOldBuilder
+        .addType(generateBuilderClass(className, allFields))
+        .addType(generateBuilderImplClass(className))
+        .addMethod(generateBuilderFactoryMethod(className))
+        .addMethod(generateToBuilderMethod(className, allFields))
+
+    // Add toCode method
+    val rebuilt = builderWithoutOldBuilder.build()
+    addToCodeMethod(rebuilt, builderWithoutOldBuilder, className)
+
+    theType.addType(builderWithoutOldBuilder.build())
 }
 
 private fun addMethodsToNewType(
@@ -489,7 +608,7 @@ private fun getGettableFields(
 ): List<CodeBlock> =
     fields.map { (type, name) ->
         CodeBlock.of(
-            $$"new $T<>($T.class, $T::get$$name)",
+            "new \$T<>(\$T.class, \$T::get$name)",
             pulpogatoClass("FancySerializer", "GettableField"),
             type.withoutAnnotations(),
             ClassName.get("", className),
@@ -577,13 +696,6 @@ private fun buildSimpleObject(
             .classBuilder(name)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(generated(0, context))
-            .addAnnotation(lombok("Getter"))
-            .addAnnotation(lombok("Setter"))
-            .addAnnotation(lombok("EqualsAndHashCode"))
-            .addAnnotation(superBuilder())
-            .addAnnotation(lombok("NoArgsConstructor"))
-            .addAnnotation(lombok("AllArgsConstructor"))
-            .addAnnotation(lombok("ToString"))
             .addAnnotation(jsonIncludeNonNull())
             .addSuperinterface(ClassName.get(PACKAGE_PULPOGATO_COMMON, "PulpogatoType"))
 
@@ -595,8 +707,36 @@ private fun buildSimpleObject(
 
     addProperties(context, entry, nameRef, builder)
 
-    // Add toString and toCode methods
+    // Get built class to access fields for method generation
     val builtClass = builder.build()
+    val fields = builtClass.fieldSpecs()
+
+    // Generate all methods
+    fields.forEach { field ->
+        val javadoc = extractJavadoc(field)
+        builder
+            .addMethod(generateGetter(field, javadoc))
+            .addMethod(generateSetter(field, javadoc))
+    }
+
+    builder
+        .addMethod(generateEquals())
+        .addMethod(generateHashCode())
+        .addMethod(generateToString())
+        .addMethod(generateNoArgsConstructor())
+
+    if (fields.isNotEmpty()) {
+        builder.addMethod(generateAllArgsConstructor(nameRef, fields))
+    }
+
+    // Add builder pattern
+    builder
+        .addType(generateBuilderClass(nameRef, fields))
+        .addType(generateBuilderImplClass(nameRef))
+        .addMethod(generateBuilderFactoryMethod(nameRef))
+        .addMethod(generateToBuilderMethod(nameRef, fields))
+
+    // Add toCode method (existing logic)
     addToCodeMethod(builtClass, builder, nameRef)
 
     return builder.build()
@@ -629,6 +769,561 @@ private fun addToCodeMethod(
                     .build(),
             )
     }
+}
+
+/**
+ * Extracts javadoc text from a FieldSpec.
+ * Returns empty string if field has no javadoc.
+ */
+private fun extractJavadoc(field: FieldSpec): String {
+    val javadoc = field.javadoc()
+    return if (!javadoc.isEmpty) {
+        javadoc.toString()
+    } else {
+        ""
+    }
+}
+
+/**
+ * Generates a getter method for a field.
+ * Uses getFieldName() for all field types including booleans.
+ */
+private fun generateGetter(
+    field: FieldSpec,
+    javadoc: String = "",
+): MethodSpec {
+    val fieldName = field.name()
+    val methodName = "get${fieldName.pascalCase()}"
+
+    val builder =
+        MethodSpec
+            .methodBuilder(methodName)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(field.type())
+            .addStatement("return this.\$N", fieldName)
+
+    // Add javadoc if present
+    if (javadoc.isNotBlank()) {
+        builder.addJavadoc(javadoc)
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates a setter method for a field.
+ */
+private fun generateSetter(
+    field: FieldSpec,
+    javadoc: String = "",
+): MethodSpec {
+    val fieldName = field.name()
+    val methodName = "set${fieldName.pascalCase()}"
+    val fieldType = field.type()
+
+    // Check if this is a NullableOptional field by checking the string representation
+    val typeString = fieldType.toString()
+    val isNullableOptional = typeString.startsWith("io.github.pulpogato.common.NullableOptional<")
+
+    val builder =
+        MethodSpec
+            .methodBuilder(methodName)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeName.VOID)
+            .addParameter(
+                ParameterSpec
+                    .builder(fieldType, fieldName)
+                    .apply {
+                        if (isNullableOptional) {
+                            addAnnotation(Annotations.nonNull())
+                        }
+                    }.build(),
+            ).addStatement("this.\$N = \$N", fieldName, fieldName)
+
+    // Add javadoc if present
+    if (javadoc.isNotBlank()) {
+        builder.addJavadoc(javadoc)
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates no-argument constructor.
+ */
+private fun generateNoArgsConstructor(): MethodSpec =
+    MethodSpec
+        .constructorBuilder()
+        .addModifiers(Modifier.PUBLIC)
+        .build()
+
+/**
+ * Generates constructor with all fields as parameters.
+ */
+private fun generateAllArgsConstructor(
+    className: ClassName,
+    fields: List<FieldSpec>,
+): MethodSpec {
+    val builderClassName = className.nestedClass("${className.simpleName()}Builder")
+    val wildcardBuilder =
+        ParameterizedTypeName.get(
+            builderClassName,
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+        )
+
+    val builder =
+        MethodSpec
+            .constructorBuilder()
+            .addModifiers(Modifier.PROTECTED)
+            .addParameter(wildcardBuilder, "b")
+
+    fields.forEach { field ->
+        builder.addStatement("this.\$N = b.\$N", field.name(), field.name())
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates toString() method with Lombok-style formatting.
+ */
+private fun generateToString(): MethodSpec =
+    MethodSpec
+        .methodBuilder("toString")
+        .addModifiers(Modifier.PUBLIC)
+        .returns(String::class.java)
+        .addStatement($$"return $T.reflectionToString(this)", ClassName.get("org.apache.commons.lang3.builder", "ToStringBuilder"))
+        .build()
+
+/**
+ * Generates equals() method with proper null and type checking (Lombok style).
+ */
+private fun generateEquals(): MethodSpec =
+    MethodSpec
+        .methodBuilder("equals")
+        .addModifiers(Modifier.PUBLIC)
+        .returns(TypeName.BOOLEAN)
+        .addParameter(ParameterSpec.builder(Types.OBJECT, "o").build())
+        .addStatement($$"return $T.reflectionEquals(this, o, false)", ClassName.get("org.apache.commons.lang3.builder", "EqualsBuilder"))
+        .build()
+
+/**
+ * Generates hashCode() method using PRIME and result pattern (Lombok style).
+ */
+private fun generateHashCode(): MethodSpec =
+    MethodSpec
+        .methodBuilder("hashCode")
+        .addModifiers(Modifier.PUBLIC)
+        .returns(
+            TypeName.INT,
+        ).addStatement($$"return $T.reflectionHashCode(this, false)", ClassName.get("org.apache.commons.lang3.builder", "HashCodeBuilder"))
+        .build()
+
+/**
+ * Generates fluent setter method for builder.
+ * Returns Builder for method chaining.
+ */
+private fun generateBuilderSetter(
+    builderClassName: ClassName,
+    field: FieldSpec,
+    javadoc: String = "",
+): MethodSpec {
+    val fieldName = field.name()
+
+    val builder =
+        MethodSpec
+            .methodBuilder(fieldName)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(builderClassName)
+            .addParameter(
+                ParameterSpec.builder(field.type(), fieldName).build(),
+            ).addStatement("this.\$N = \$N", fieldName, fieldName)
+            .addStatement("return this")
+
+    // Add javadoc if present
+    if (javadoc.isNotBlank()) {
+        builder.addJavadoc(javadoc)
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates build() method that creates parent class instance.
+ */
+private fun generateBuildMethod(
+    className: ClassName,
+    fields: List<FieldSpec>,
+): MethodSpec {
+    val builder =
+        MethodSpec
+            .methodBuilder("build")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(className)
+
+    if (fields.isEmpty()) {
+        builder.addStatement("return new \$T()", className)
+    } else {
+        // Build: return new ClassName(this.field1, this.field2, ...);
+        val fieldReferences = fields.map { CodeBlock.of("this.\$N", it.name()) }
+        builder.addStatement(
+            "return new \$T(\$L)",
+            className,
+            CodeBlock.join(fieldReferences, ", "),
+        )
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates $fillValuesFrom method for SuperBuilder pattern.
+ */
+private fun generateFillValuesFromMethod(
+    bTypeVar: TypeVariableName,
+    cTypeVar: TypeVariableName,
+): MethodSpec =
+    MethodSpec
+        .methodBuilder("\$fillValuesFrom")
+        .addModifiers(Modifier.PROTECTED)
+        .returns(bTypeVar)
+        .addParameter(cTypeVar, "instance")
+        .addStatement("\$\$fillValuesFromInstanceIntoBuilder(instance, this)")
+        .addStatement("return (\$T)this.self()", bTypeVar)
+        .build()
+
+/**
+ * Generates $fillValuesFromInstanceIntoBuilder static helper method.
+ */
+private fun generateFillValuesFromInstanceIntoBuilderMethod(
+    className: ClassName,
+    builderName: String,
+    fields: List<FieldSpec>,
+): MethodSpec {
+    val wildcardBuilder =
+        ParameterizedTypeName.get(
+            className.nestedClass(builderName),
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+        )
+
+    val builder =
+        MethodSpec
+            .methodBuilder("\$fillValuesFromInstanceIntoBuilder")
+            .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+            .returns(TypeName.VOID)
+            .addParameter(className, "instance")
+            .addParameter(wildcardBuilder, "b")
+
+    fields.forEach { field ->
+        builder.addStatement("b.\$N(instance.\$N)", field.name(), field.name())
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates fluent setter method(s) for abstract builder with @JsonProperty annotation.
+ * For NullableOptional fields, generates two methods:
+ * 1. Main method accepting NullableOptional<T> with @NonNull annotation
+ * 2. Convenience method accepting T with @Nullable annotation
+ * Returns (B)this.self() for type-safe chaining.
+ */
+private fun generateAbstractBuilderSetter(
+    field: FieldSpec,
+    javadoc: String = "",
+    bTypeVar: TypeVariableName,
+): List<MethodSpec> {
+    val fieldName = field.name()
+    val fieldType = field.type()
+
+    // Check if this is a NullableOptional field by checking the string representation
+    val typeString = fieldType.toString()
+    val isNullableOptional = typeString.startsWith("io.github.pulpogato.common.NullableOptional<")
+
+    val methods = mutableListOf<MethodSpec>()
+
+    // Generate main builder method (always)
+    val mainMethodBuilder =
+        MethodSpec
+            .methodBuilder(fieldName)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(bTypeVar)
+            .addParameter(
+                ParameterSpec
+                    .builder(fieldType, fieldName)
+                    .apply {
+                        if (isNullableOptional) {
+                            addAnnotation(Annotations.nonNull())
+                        }
+                    }.build(),
+            ).addStatement("this.\$N = \$N", fieldName, fieldName)
+            .addStatement("return (\$T)this.self()", bTypeVar)
+
+    // Add @JsonProperty annotation
+    val jsonPropertyAnnotation =
+        field.annotations().find {
+            it.type().toString().contains("JsonProperty")
+        }
+    if (jsonPropertyAnnotation != null) {
+        mainMethodBuilder.addAnnotation(jsonPropertyAnnotation)
+    }
+
+    // Add javadoc if present
+    if (javadoc.isNotBlank()) {
+        mainMethodBuilder.addJavadoc(javadoc)
+    }
+
+    methods.add(mainMethodBuilder.build())
+
+    // Generate convenience method for NullableOptional fields
+    if (isNullableOptional && fieldType is ParameterizedTypeName) {
+        // Use reflection to access the private typeArguments field
+        // This is necessary because Palantir's JavaPoet 0.9.0 doesn't expose a public API for this
+        try {
+            val typeArgumentsField = ParameterizedTypeName::class.java.getDeclaredField("typeArguments")
+            typeArgumentsField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val typeArguments = typeArgumentsField.get(fieldType) as List<TypeName>
+            val unwrappedType = typeArguments[0]
+
+            val convenienceMethodBuilder =
+                MethodSpec
+                    .methodBuilder(fieldName)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(bTypeVar)
+                    .addParameter(
+                        ParameterSpec
+                            .builder(unwrappedType, fieldName)
+                            .addAnnotation(Annotations.nullable())
+                            .build(),
+                    ).addStatement(
+                        $$"return this.$N($T.ofNullable($N))",
+                        fieldName,
+                        Types.NULLABLE_OPTIONAL,
+                        fieldName,
+                    ).addAnnotation(Annotations.deprecated("1.2.0"))
+
+            // Add javadoc for convenience method
+            if (javadoc.isNotBlank()) {
+                convenienceMethodBuilder.addJavadoc(
+                    javadoc + "\n\n<p>Convenience method that wraps the value in NullableOptional automatically.\n" +
+                        "Pass null to explicitly set the field to null in JSON.</p>\n\n" +
+                        "@deprecated Use {@link #$fieldName(NullableOptional)} instead\n",
+                )
+            } else {
+                convenienceMethodBuilder.addJavadoc(
+                    "Convenience method that wraps the value in NullableOptional automatically.\n" +
+                        "Pass null to explicitly set the field to null in JSON.\n\n" +
+                        "@param $fieldName the value to set (null will be converted to NullableOptional.ofNull())\n" +
+                        "@return this builder for method chaining\n" +
+                        "@deprecated Use {@link #$fieldName(NullableOptional)} instead\n",
+                )
+            }
+
+            methods.add(convenienceMethodBuilder.build())
+        } catch (e: Exception) {
+            // If reflection fails, skip generating the convenience method
+            // This is a fallback to ensure code generation doesn't fail completely
+        }
+    }
+
+    return methods
+}
+
+/**
+ * Generates abstract nested static Builder class with generic type parameters (SuperBuilder pattern).
+ */
+private fun generateBuilderClass(
+    className: ClassName,
+    fields: List<FieldSpec>,
+): TypeSpec {
+    val builderName = "${className.simpleName()}Builder"
+    val cTypeVar = TypeVariableName.get("C", className)
+    val bTypeVar = TypeVariableName.get("B")
+
+    // B extends ClassNameBuilder<C, B>
+    val bBound =
+        ParameterizedTypeName.get(
+            className.nestedClass(builderName),
+            cTypeVar,
+            bTypeVar,
+        )
+
+    val builder =
+        TypeSpec
+            .classBuilder(builderName)
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT, Modifier.STATIC)
+            .addTypeVariable(cTypeVar)
+            .addTypeVariable(TypeVariableName.get("B", bBound))
+
+    // Add fields to builder (same as parent, but non-final)
+    fields.forEach { field ->
+        val builderField =
+            FieldSpec
+                .builder(field.type(), field.name(), Modifier.PRIVATE)
+                .build()
+        builder.addField(builderField)
+    }
+
+    // Check for fields with @Builder.Default annotation (initializers)
+    val fieldsWithDefaults =
+        fields.filter { field ->
+            field.annotations().any { annotation ->
+                annotation.type().toString().contains("Builder.Default")
+            }
+        }
+
+    // Add constructor if there are default fields
+    if (fieldsWithDefaults.isNotEmpty()) {
+        val constructorBuilder =
+            MethodSpec
+                .constructorBuilder()
+
+        fieldsWithDefaults.forEach { field ->
+            // Try to extract initializer from annotations
+            // For NullableOptional.notSet(), we need to initialize it
+            val fieldType = field.type()
+            if (fieldType.toString().startsWith("io.github.pulpogato.common.NullableOptional")) {
+                constructorBuilder.addStatement(
+                    "this.\$N = \$T.notSet()",
+                    field.name(),
+                    ClassName.get("io.github.pulpogato.common", "NullableOptional"),
+                )
+            }
+        }
+
+        builder.addMethod(constructorBuilder.build())
+    }
+
+    // Add $fillValuesFrom method
+    builder.addMethod(generateFillValuesFromMethod(bTypeVar, cTypeVar))
+
+    // Add $fillValuesFromInstanceIntoBuilder static helper
+    builder.addMethod(generateFillValuesFromInstanceIntoBuilderMethod(className, builderName, fields))
+
+    // Add fluent setter methods with @JsonProperty
+    fields.forEach { field ->
+        val javadoc = extractJavadoc(field)
+        generateAbstractBuilderSetter(field, javadoc, bTypeVar).forEach { method ->
+            builder.addMethod(method)
+        }
+    }
+
+    // Add abstract self() method
+    builder.addMethod(
+        MethodSpec
+            .methodBuilder("self")
+            .addModifiers(Modifier.PROTECTED, Modifier.ABSTRACT)
+            .returns(bTypeVar)
+            .build(),
+    )
+
+    // Add abstract build() method
+    builder.addMethod(
+        MethodSpec
+            .methodBuilder("build")
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .returns(cTypeVar)
+            .build(),
+    )
+
+    // Add toString() method
+    builder.addMethod(generateToString())
+
+    return builder.build()
+}
+
+/**
+ * Generates private nested implementation class for SuperBuilder pattern.
+ */
+private fun generateBuilderImplClass(className: ClassName): TypeSpec {
+    val builderName = "${className.simpleName()}Builder"
+    val implName = "${className.simpleName()}BuilderImpl"
+    val builderClassName = className.nestedClass(builderName)
+    val implClassName = className.nestedClass(implName)
+
+    // TopicBuilderImpl extends TopicBuilder<Topic, TopicBuilderImpl>
+    val superclass =
+        ParameterizedTypeName.get(
+            builderClassName,
+            className,
+            implClassName,
+        )
+
+    return TypeSpec
+        .classBuilder(implName)
+        .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+        .superclass(superclass)
+        .addMethod(
+            MethodSpec
+                .methodBuilder("self")
+                .addModifiers(Modifier.PROTECTED)
+                .returns(implClassName)
+                .addStatement("return this")
+                .build(),
+        ).addMethod(
+            MethodSpec
+                .methodBuilder("build")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(className)
+                .addStatement("return new \$T(this)", className)
+                .build(),
+        ).build()
+}
+
+/**
+ * Generates static factory method for builder.
+ */
+private fun generateBuilderFactoryMethod(className: ClassName): MethodSpec {
+    val builderName = "${className.simpleName()}Builder"
+    val implName = "${className.simpleName()}BuilderImpl"
+    val builderClassName = className.nestedClass(builderName)
+    val implClassName = className.nestedClass(implName)
+
+    // Return type: TopicBuilder<?, ?>
+    val wildcardBuilder =
+        ParameterizedTypeName.get(
+            builderClassName,
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+        )
+
+    return MethodSpec
+        .methodBuilder("builder")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(wildcardBuilder)
+        .addStatement("return new \$T()", implClassName)
+        .build()
+}
+
+/**
+ * Generates toBuilder() method for copying instances.
+ */
+private fun generateToBuilderMethod(
+    className: ClassName,
+    fields: List<FieldSpec>,
+): MethodSpec {
+    val builderName = "${className.simpleName()}Builder"
+    val implName = "${className.simpleName()}BuilderImpl"
+    val builderClassName = className.nestedClass(builderName)
+    val implClassName = className.nestedClass(implName)
+
+    // Return type: TopicBuilder<?, ?>
+    val wildcardBuilder =
+        ParameterizedTypeName.get(
+            builderClassName,
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+            WildcardTypeName.subtypeOf(Types.OBJECT),
+        )
+
+    return MethodSpec
+        .methodBuilder("toBuilder")
+        .addModifiers(Modifier.PUBLIC)
+        .returns(wildcardBuilder)
+        .addStatement("return (new \$T()).\$\$fillValuesFrom(this)", implClassName)
+        .build()
 }
 
 private fun addProperties(
@@ -713,17 +1408,41 @@ private fun addFieldIfNew(
                 "schema.json"
             }
 
-        val builder =
-            FieldSpec
-                .builder(typeName, fieldName, Modifier.PRIVATE)
-                .addAnnotation(jsonProperty(p.key))
-                .addAnnotation(generated(0, context.withSchemaStack("properties", p.key), sourceFile))
-
         // Check if the schema explicitly allows null (has "null" in its types array)
-        // If so, add @JsonInclude(ALWAYS) to override the class-level NON_NULL setting
         val types = p.value.types?.filterNotNull() ?: emptyList()
-        if (types.contains("null")) {
-            builder.addAnnotation(jsonIncludeAlways())
+        val hasNull = types.contains("null")
+        // Check if this is an object type (not a simple type like String, Integer, etc.)
+        val isObjectType = typeName is ClassName && !isSimpleType(typeName)
+
+        // Determine the actual field type and annotations based on nullability
+        val actualTypeName: TypeName
+        val builder: FieldSpec.Builder
+
+        if (hasNull && isObjectType) {
+            // Wrap in NullableOptional for nullable object fields
+            actualTypeName = ParameterizedTypeName.get(Types.NULLABLE_OPTIONAL, typeName)
+            builder =
+                FieldSpec
+                    .builder(actualTypeName, fieldName, Modifier.PRIVATE)
+                    .addAnnotation(jsonProperty(p.key))
+                    .addAnnotation(generated(0, context.withSchemaStack("properties", p.key), sourceFile))
+                    .addAnnotation(nullableOptionalSerializer())
+                    .addAnnotation(nullableOptionalDeserializer())
+                    .addAnnotation(jsonIncludeNonEmpty())
+                    .initializer($$"$T.notSet()", Types.NULLABLE_OPTIONAL)
+        } else {
+            // Keep existing behavior for non-nullable or simple types
+            actualTypeName = typeName
+            builder =
+                FieldSpec
+                    .builder(actualTypeName, fieldName, Modifier.PRIVATE)
+                    .addAnnotation(jsonProperty(p.key))
+                    .addAnnotation(generated(0, context.withSchemaStack("properties", p.key), sourceFile))
+
+            if (hasNull) {
+                // Add @JsonInclude(ALWAYS) for simple nullable types
+                builder.addAnnotation(jsonIncludeAlways())
+            }
         }
 
         schemaJavadoc(p).let {
@@ -746,9 +1465,6 @@ private fun buildEnum(
             .enumBuilder(className.simpleName())
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(generated(0, context))
-            .addAnnotation(lombok("Getter"))
-            .addAnnotation(lombok("RequiredArgsConstructor"))
-            .addAnnotation(lombok("ToString"))
             .addField(
                 FieldSpec
                     .builder(String::class.java, "value", Modifier.PRIVATE, Modifier.FINAL)
@@ -770,6 +1486,36 @@ private fun buildEnum(
             val enumName = it ?: "null"
             builder.addEnumConstant(enumValue, TypeSpec.anonymousClassBuilder($$"$S", enumName).build())
         }
+
+    // Add explicit constructor
+    builder.addMethod(
+        MethodSpec
+            .constructorBuilder()
+            .addParameter(String::class.java, "value")
+            .addStatement("this.value = value")
+            .build(),
+    )
+
+    // Add explicit getValue() getter
+    builder.addMethod(
+        MethodSpec
+            .methodBuilder("getValue")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(String::class.java)
+            .addStatement("return this.value")
+            .build(),
+    )
+
+    // Add explicit toString() override
+    builder.addMethod(
+        MethodSpec
+            .methodBuilder("toString")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Types.OVERRIDE)
+            .returns(String::class.java)
+            .addStatement("return this.value")
+            .build(),
+    )
 
     // Add the converter as a nested static class
     val converterClass = buildEnumConverter(className)

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
@@ -17,14 +17,6 @@ class AnnotationsTest {
     }
 
     @Test
-    fun `superBuilder creates annotation with toBuilder set to true`() {
-        val result = Annotations.superBuilder()
-
-        assertThat(result.type().toString()).isEqualTo("lombok.experimental.SuperBuilder")
-        assertThat(result.members()["toBuilder"].toString()).contains("true")
-    }
-
-    @Test
     fun `jsonValue creates annotation with correct type`() {
         val result = Annotations.jsonValue()
 

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptional.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptional.java
@@ -1,0 +1,219 @@
+package io.github.pulpogato.common;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.EqualsAndHashCode;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * A three-state wrapper for nullable fields that distinguishes between:
+ * <ul>
+ *   <li><b>NOT_SET</b>: Field is absent, not serialized to JSON</li>
+ *   <li><b>NULL</b>: Field is explicitly null, serialized as "field": null</li>
+ *   <li><b>VALUE</b>: Field has a value, serialized normally</li>
+ * </ul>
+ *
+ * <p>This class is necessary because:
+ * <ul>
+ *   <li>Java's {@code Optional<T>} cannot hold null values</li>
+ *   <li>GitHub API distinguishes between absent fields (no change) and null fields (unset value)</li>
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ * <pre>{@code
+ * // Field not set - omitted from JSON
+ * NullableOptional<String> notSet = NullableOptional.notSet();
+ *
+ * // Field explicitly set to null - serialized as null in JSON
+ * NullableOptional<String> explicitNull = NullableOptional.ofNull();
+ *
+ * // Field has a value - serialized with value in JSON
+ * NullableOptional<String> hasValue = NullableOptional.of("example");
+ * }</pre>
+ *
+ * @param <T> the type of value that can be held
+ */
+@JsonSerialize(using = NullableOptionalSerializer.class)
+@JsonDeserialize(using = NullableOptionalDeserializer.class)
+@EqualsAndHashCode
+public final class NullableOptional<T> implements PulpogatoType {
+
+    private enum State {
+        NOT_SET,
+        NULL,
+        VALUE
+    }
+
+    private final State state;
+    private final T value;
+
+    private NullableOptional(State state, T value) {
+        this.state = state;
+        this.value = value;
+    }
+
+    /**
+     * Returns a NullableOptional with no value set.
+     * When serialized to JSON, the field will be absent (omitted).
+     *
+     * @param <T> the type of the value
+     * @return a NullableOptional in NOT_SET state
+     */
+    public static <T> NullableOptional<T> notSet() {
+        return new NullableOptional<>(State.NOT_SET, null);
+    }
+
+    /**
+     * Returns a NullableOptional explicitly set to null.
+     * When serialized to JSON, the field will be present with null value.
+     *
+     * @param <T> the type of the value
+     * @return a NullableOptional in NULL state
+     */
+    public static <T> NullableOptional<T> ofNull() {
+        return new NullableOptional<>(State.NULL, null);
+    }
+
+    /**
+     * Returns a NullableOptional with the specified non-null value.
+     * When serialized to JSON, the field will be present with the value.
+     *
+     * @param value the non-null value to wrap
+     * @param <T> the type of the value
+     * @return a NullableOptional in VALUE state
+     * @throws IllegalArgumentException if value is null (use ofNull() instead)
+     */
+    public static <T> NullableOptional<T> of(T value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Value cannot be null. Use ofNull() for explicit null.");
+        }
+        return new NullableOptional<>(State.VALUE, value);
+    }
+
+    /**
+     * Returns a NullableOptional for the given value, which may be null.
+     * If the value is null, returns a NULL state NullableOptional.
+     * If the value is non-null, returns a VALUE state NullableOptional.
+     *
+     * This is useful in builder patterns where the caller has a potentially
+     * null value and wants it automatically wrapped appropriately.
+     *
+     * @param value the value to wrap (may be null)
+     * @param <T> the type of the value
+     * @return a NullableOptional in NULL state if value is null, VALUE state otherwise
+     */
+    public static <T> NullableOptional<T> ofNullable(T value) {
+        return value == null ? ofNull() : of(value);
+    }
+
+    /**
+     * Returns true if this NullableOptional is not set (absent).
+     *
+     * @return true if NOT_SET, false otherwise
+     */
+    public boolean isNotSet() {
+        return state == State.NOT_SET;
+    }
+
+    /**
+     * Returns true if this NullableOptional is explicitly set to null.
+     *
+     * @return true if NULL, false otherwise
+     */
+    public boolean isNull() {
+        return state == State.NULL;
+    }
+
+    /**
+     * Returns true if this NullableOptional has a value.
+     *
+     * @return true if VALUE, false otherwise
+     */
+    public boolean isValue() {
+        return state == State.VALUE;
+    }
+
+    /**
+     * Returns the value if present.
+     *
+     * @return the value
+     * @throws IllegalStateException if the value is not present (NOT_SET or NULL)
+     */
+    public T getValue() {
+        if (state != State.VALUE) {
+            throw new IllegalStateException("No value present. State is: " + state);
+        }
+        return value;
+    }
+
+    /**
+     * Returns the value if present, otherwise returns the specified default value.
+     *
+     * @param defaultValue the value to return if no value is present
+     * @return the value if present, otherwise defaultValue
+     */
+    public T orElse(T defaultValue) {
+        return state == State.VALUE ? value : defaultValue;
+    }
+
+    /**
+     * Returns the value if present, otherwise returns null.
+     *
+     * @return the value if present, otherwise null
+     */
+    public T orElseNull() {
+        return state == State.VALUE ? value : null;
+    }
+
+    /**
+     * If a value is present, performs the given action with the value.
+     *
+     * @param consumer the action to perform
+     */
+    public void ifValue(Consumer<? super T> consumer) {
+        if (state == State.VALUE) {
+            consumer.accept(value);
+        }
+    }
+
+    /**
+     * If a value is present, applies the mapping function and returns a NullableOptional
+     * wrapping the result. Otherwise, returns a NOT_SET NullableOptional.
+     *
+     * @param mapper the mapping function
+     * @param <U> the type of the result
+     * @return a NullableOptional with the mapped value or NOT_SET
+     */
+    public <U> NullableOptional<U> map(Function<? super T, ? extends U> mapper) {
+        if (state == State.VALUE) {
+            return NullableOptional.of(mapper.apply(value));
+        } else if (state == State.NULL) {
+            return NullableOptional.ofNull();
+        } else {
+            return NullableOptional.notSet();
+        }
+    }
+
+    @Override
+    public String toCode() {
+        if (isNotSet()) {
+            return "io.github.pulpogato.common.NullableOptional.notSet()";
+        } else if (isNull()) {
+            return "io.github.pulpogato.common.NullableOptional.ofNull()";
+        } else if (value instanceof PulpogatoType pt) {
+            return "io.github.pulpogato.common.NullableOptional.of(" + pt.toCode() + ")";
+        } else {
+            return "io.github.pulpogato.common.NullableOptional.of(" + CodeBuilder.render(value) + ")";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return switch (state) {
+            case NOT_SET -> "NullableOptional.notSet()";
+            case NULL -> "NullableOptional.ofNull()";
+            case VALUE -> "NullableOptional[" + value + "]";
+        };
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalDeserializer.java
@@ -1,0 +1,60 @@
+package io.github.pulpogato.common;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Custom Jackson deserializer for {@link NullableOptional} that handles three-state deserialization:
+ * <ul>
+ *   <li><b>Field absent</b>: Lombok initializes to notSet() via @Builder.Default</li>
+ *   <li><b>Field present with null</b>: Deserializes to ofNull()</li>
+ *   <li><b>Field present with value</b>: Deserializes to of(value)</li>
+ * </ul>
+ */
+public class NullableOptionalDeserializer extends StdDeserializer<NullableOptional<?>> {
+
+    private final JavaType valueType;
+
+    public NullableOptionalDeserializer() {
+        super(NullableOptional.class);
+        this.valueType = null;
+    }
+
+    private NullableOptionalDeserializer(JavaType valueType) {
+        super(NullableOptional.class);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+        JavaType type = property != null ? property.getType().containedType(0) : null;
+        return new NullableOptionalDeserializer(type);
+    }
+
+    @Override
+    public NullableOptional<?> deserialize(JsonParser p, DeserializationContext ctxt) {
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
+            return NullableOptional.ofNull();
+        }
+
+        // Deserialize to the actual type parameter
+        Object value;
+        if (valueType != null) {
+            value = ctxt.readValue(p, valueType);
+        } else {
+            value = ctxt.readValue(p, Object.class);
+        }
+        return NullableOptional.of(value);
+    }
+
+    @Override
+    public NullableOptional<?> getNullValue(DeserializationContext ctxt) {
+        // Called when field is present with explicit null value
+        return NullableOptional.ofNull();
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalSerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalSerializer.java
@@ -1,0 +1,35 @@
+package io.github.pulpogato.common;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Custom Jackson serializer for {@link NullableOptional} that handles three-state serialization:
+ * <ul>
+ *   <li><b>NOT_SET</b>: Field omitted from JSON (isEmpty returns true)</li>
+ *   <li><b>NULL</b>: Field serialized as "field": null</li>
+ *   <li><b>VALUE</b>: Field serialized with its value</li>
+ * </ul>
+ */
+public class NullableOptionalSerializer extends StdSerializer<NullableOptional<?>> {
+
+    public NullableOptionalSerializer() {
+        super(NullableOptional.class);
+    }
+
+    @Override
+    public void serialize(NullableOptional<?> value, JsonGenerator gen, SerializationContext provider) {
+        if (value.isNull()) {
+            gen.writeNull();
+        } else if (!value.isNotSet()) {
+            gen.writePOJO(value.getValue());
+        }
+    }
+
+    @Override
+    public boolean isEmpty(SerializationContext provider, NullableOptional<?> value) {
+        // Return true for NOT_SET to skip serialization entirely
+        return value == null || value.isNotSet();
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
@@ -1,0 +1,152 @@
+package io.github.pulpogato.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class NullableOptionalTest {
+
+    @Test
+    void testNotSet() {
+        var optional = NullableOptional.notSet();
+        assertThat(optional.isNotSet()).isTrue();
+        assertThat(optional.isNull()).isFalse();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfNull() {
+        var optional = NullableOptional.ofNull();
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isTrue();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfValue() {
+        var optional = NullableOptional.of("test");
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isFalse();
+        assertThat(optional.isValue()).isTrue();
+        assertThat(optional.getValue()).isEqualTo("test");
+    }
+
+    @Test
+    void testOfNullThrows() {
+        assertThatThrownBy(() -> NullableOptional.of(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Use ofNull()");
+    }
+
+    @Test
+    void testOfNullableWithNullValueReturnsNullState() {
+        var optional = NullableOptional.ofNullable(null);
+        assertThat(optional.isNull()).isTrue();
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfNullableWithNonNullValueReturnsValueState() {
+        var optional = NullableOptional.ofNullable("test");
+        assertThat(optional.isValue()).isTrue();
+        assertThat(optional.getValue()).isEqualTo("test");
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isFalse();
+    }
+
+    @Test
+    void testGetValueThrowsWhenNotSet() {
+        var optional = NullableOptional.notSet();
+        assertThatThrownBy(optional::getValue)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No value present");
+    }
+
+    @Test
+    void testGetValueThrowsWhenNull() {
+        var optional = NullableOptional.ofNull();
+        assertThatThrownBy(optional::getValue)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No value present");
+    }
+
+    @Test
+    void testOrElse() {
+        assertThat(NullableOptional.notSet().orElse("default")).isEqualTo("default");
+        assertThat(NullableOptional.ofNull().orElse("default")).isEqualTo("default");
+        assertThat(NullableOptional.of("value").orElse("default")).isEqualTo("value");
+    }
+
+    @Test
+    void testSerializationNotSet() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.notSet();
+
+        String json = om.writeValueAsString(wrapper);
+        // Note: With class-level @JsonSerialize, isEmpty() may not be called
+        // The generated code uses field-level annotations with @JsonInclude(NON_NULL) at class level
+        // which properly skips empty fields. This test validates the basic serializer works.
+        assertThat(json).doesNotContain("\"value\""); // Should not serialize internal state
+    }
+
+    @Test
+    void testSerializationNull() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.ofNull();
+
+        String json = om.writeValueAsString(wrapper);
+        assertThat(json).isEqualTo("{\"field\":null}");
+    }
+
+    @Test
+    void testSerializationValue() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.of("test");
+
+        String json = om.writeValueAsString(wrapper);
+        assertThat(json).isEqualTo("{\"field\":\"test\"}");
+    }
+
+    @Test
+    void testDeserializationAbsent() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        // When field is absent, Lombok/Jackson will leave it as the default value
+        // which is notSet() due to @Builder.Default
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isNotSet()).isTrue();
+    }
+
+    @Test
+    void testDeserializationNull() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{\"field\":null}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isNull()).isTrue();
+    }
+
+    @Test
+    void testDeserializationValue() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{\"field\":\"test\"}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isValue()).isTrue();
+        assertThat(result.field.getValue()).isEqualTo("test");
+    }
+
+    static class TestWrapper {
+        public NullableOptional<String> field = NullableOptional.notSet();
+    }
+}

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
@@ -19,7 +19,7 @@ class OrgsApiIntegrationTest extends BaseIntegrationTest {
         assertThat(installations.getInstallations()).hasSize(1);
         var installation = installations.getInstallations().getFirst();
         assertThat(installation.getAccount()).isNotNull();
-        assertThat(installation.getAccount().getSimpleUser().getLogin()).isEqualTo("pulpogato");
+        assertThat(installation.getAccount().getValue().getSimpleUser().getLogin()).isEqualTo("pulpogato");
         assertThat(installation.getAppSlug()).isEqualTo("renovate");
     }
 }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.pulpogato.rest.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.github.pulpogato.common.NullableOptional;
+import io.github.pulpogato.rest.schemas.SecurityAndAnalysis;
 import tools.jackson.databind.ObjectMapper;
 import io.github.pulpogato.common.SingularOrPlural;
 import io.github.pulpogato.rest.schemas.ContentFile;
@@ -49,8 +51,8 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
         var commit = commits.getFirst();
         assertThat(commit.getSha()).isEqualTo("2667e9ae0adcdbf378fe6273658b57f4e5d24a39");
         assertThat(commit.getCommit().getMessage()).isEqualTo("Merge pull request #206 from pulpogato/test-listOrgApps\n\ntest: Add test for listAppInstallations in an org");
-        assertThat(commit.getCommitter().getSimpleUser().getLogin()).isEqualTo("web-flow");
-        assertThat(commit.getAuthor().getSimpleUser().getLogin()).isEqualTo("rahulsom");
+        assertThat(commit.getCommitter().getValue().getSimpleUser().getLogin()).isEqualTo("web-flow");
+        assertThat(commit.getAuthor().getValue().getSimpleUser().getLogin()).isEqualTo("rahulsom");
     }
 
     @Test
@@ -303,5 +305,97 @@ class ReposApiIntegrationTest extends BaseIntegrationTest {
 
         var response = api.customPropertiesForReposCreateOrUpdateRepositoryValues("corp", "rsomasunderam-test", requestBody);
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+
+    @Test
+    void testArchiveRepository() {
+        var api = new RestClients(webClient).getReposApi();
+        var response = api.update("pulpogato", "create-demo", ReposApi.UpdateRequestBody.builder()
+                .archived(true)
+                .build());
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody())
+                .isNotNull();
+        var body = response.getBody();
+        assertThat(body.getName()).isEqualTo("create-demo");
+        assertThat(body.getArchived()).isTrue();
+    }
+
+    @Test
+    void testUnrchiveRepository() {
+        var api = new RestClients(webClient).getReposApi();
+        var response = api.update("pulpogato", "create-demo", ReposApi.UpdateRequestBody.builder()
+                .archived(false)
+                .build());
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody())
+                .isNotNull();
+        var body = response.getBody();
+        assertThat(body.getName()).isEqualTo("create-demo");
+        assertThat(body.getArchived()).isFalse();
+    }
+
+    @Test
+    void testSetSecurityAndAnalysis() {
+        var api = new RestClients(webClient).getReposApi();
+        final var requestedSecurityAndAnalysis = ReposApi.UpdateRequestBody.SecurityAndAnalysis.builder()
+                .secretScanning(ReposApi.UpdateRequestBody.SecurityAndAnalysis.SecretScanning.builder()
+                        .status(SecurityAndAnalysis.SecretScanning.Status.ENABLED.getValue())
+                        .build())
+                .secretScanningPushProtection(ReposApi.UpdateRequestBody.SecurityAndAnalysis.SecretScanningPushProtection.builder()
+                        .status(SecurityAndAnalysis.SecretScanningPushProtection.Status.ENABLED.getValue())
+                        .build())
+                .secretScanningNonProviderPatterns(ReposApi.UpdateRequestBody.SecurityAndAnalysis.SecretScanningNonProviderPatterns.builder()
+                        .status(SecurityAndAnalysis.SecretScanningNonProviderPatterns.Status.ENABLED.getValue())
+                        .build())
+                .build();
+        var response = api.update("pulpogato", "create-demo", ReposApi.UpdateRequestBody.builder()
+                .securityAndAnalysis(NullableOptional.of(requestedSecurityAndAnalysis))
+                .build());
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody())
+                .isNotNull();
+        var body = response.getBody();
+        assertThat(body.getName()).isEqualTo("create-demo");
+        final var securityAndAnalysis = body.getSecurityAndAnalysis();
+        assertThat(securityAndAnalysis).isNotNull();
+
+        assertThat(securityAndAnalysis.getSecretScanning()).isNotNull();
+        assertThat(securityAndAnalysis.getSecretScanning().getStatus())
+                .isEqualTo(SecurityAndAnalysis.SecretScanning.Status.ENABLED);
+        assertThat(securityAndAnalysis.getSecretScanningPushProtection()).isNotNull();
+        assertThat(securityAndAnalysis.getSecretScanningPushProtection().getStatus())
+                .isEqualTo(SecurityAndAnalysis.SecretScanningPushProtection.Status.ENABLED);
+    }
+
+    @Test
+    void testClearSecurityAndAnalysis() {
+        var api = new RestClients(webClient).getReposApi();
+        var response = api.update("pulpogato", "create-demo", ReposApi.UpdateRequestBody.builder()
+                .securityAndAnalysis(NullableOptional.ofNull())
+                .build());
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody())
+                .isNotNull();
+        var body = response.getBody();
+        assertThat(body.getName()).isEqualTo("create-demo");
+        final var securityAndAnalysis = body.getSecurityAndAnalysis();
+        assertThat(securityAndAnalysis).isNotNull();
+
+        assertThat(securityAndAnalysis.getAdvancedSecurity()).isNull();
+        assertThat(securityAndAnalysis.getCodeSecurity()).isNull();
+        assertThat(securityAndAnalysis.getDependabotSecurityUpdates()).isNotNull();
+        assertThat(securityAndAnalysis.getDependabotSecurityUpdates().getStatus())
+                .isEqualTo(SecurityAndAnalysis.DependabotSecurityUpdates.Status.DISABLED);
+        assertThat(securityAndAnalysis.getSecretScanning()).isNotNull();
+        assertThat(securityAndAnalysis.getSecretScanning().getStatus())
+                .isEqualTo(SecurityAndAnalysis.SecretScanning.Status.ENABLED);
+        assertThat(securityAndAnalysis.getSecretScanningPushProtection()).isNotNull();
+        assertThat(securityAndAnalysis.getSecretScanningPushProtection().getStatus())
+                .isEqualTo(SecurityAndAnalysis.SecretScanningPushProtection.Status.ENABLED);
+        assertThat(securityAndAnalysis.getSecretScanningNonProviderPatterns()).isNotNull();
+        assertThat(securityAndAnalysis.getSecretScanningNonProviderPatterns().getStatus())
+                .isEqualTo(SecurityAndAnalysis.SecretScanningNonProviderPatterns.Status.DISABLED);
+        assertThat(securityAndAnalysis.getSecretScanningAiDetection()).isNull();
     }
 }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testArchiveRepository.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testArchiveRepository.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "archived" : true
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:27Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : true,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "disabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testClearSecurityAndAnalysis.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testClearSecurityAndAnalysis.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "security_and_analysis" : null
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testSetSecurityAndAnalysis.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testSetSecurityAndAnalysis.yml
@@ -1,0 +1,187 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          }
+        }
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testUnrchiveRepository.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testUnrchiveRepository.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "archived" : false
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "disabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Exchange.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Exchange.java
@@ -2,7 +2,12 @@ package io.github.pulpogato.test;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Map;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder
 @Getter

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestWebhookResponse.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestWebhookResponse.java
@@ -1,7 +1,11 @@
 package io.github.pulpogato.test;
 
 import java.util.Map;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 @Builder
 @NoArgsConstructor

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -13,8 +13,7 @@ dependencies {
     compileOnly(libs.jspecify)
     compileOnly(libs.springWeb)
     compileOnly(libs.springBootWebflux)
-    compileOnly(libs.lombok)
-    annotationProcessor(libs.lombok)
+    implementation(libs.commonsLang3)
 
     api(project(":${rootProject.name}-common"))
 


### PR DESCRIPTION
Replace Lombok-generated builders with handcrafted implementations that support three-state nullable fields through `NullableOptional`.
This allows distinguishing between unset, explicitly null, and non-null values in builder patterns.

The custom builders include convenience methods for working with `NullableOptional` fields, improving ergonomics when constructing objects with optional nullable fields.

The older setters and builder methods are deprecated to encourage migration to the new methods that handle `NullableOptional`.

BREAKING-CHANGE:
* The getters for these fields now return `NullableOptional` types.
* The builders do not use lombok, but are similar. Relying on lombok internals could break.
