### PR TITLE
feat!: Add three-state nullable field handling with custom builders

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 assertj = "3.27.6"
 jspecify = "1.0.0"
 commonmark = "0.27.0"
+commons-lang3 = "3.17.0"
 commons-text = "1.14.0"
 dgs = "8.1.1"
 download = "5.6.0"
@@ -33,6 +34,7 @@ waena = "0.20.0"
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 commonmarkTables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
+commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
 commonsText = { group = "org.apache.commons", name = "commons-text", version.ref = "commons-text" }
 glassfishJson = { group = "org.glassfish", name = "javax.json", version.ref = "glassfishJson" }
 groovy = { group = "org.apache.groovy", name = "groovy-all", version.ref = "groovy" }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -13,17 +13,6 @@ import java.util.stream.Stream
 
 object Annotations {
     /*
-     Lombok Annotations
-     */
-    fun lombok(name: String): AnnotationSpec = AnnotationSpec.builder(ClassName.get("lombok", name)).build()
-
-    fun superBuilder(): AnnotationSpec =
-        AnnotationSpec
-            .builder(ClassName.get("lombok.experimental", "SuperBuilder"))
-            .addMember("toBuilder", "true")
-            .build()
-
-    /*
      Jackson Annotations
      */
     fun jsonValue(): AnnotationSpec = AnnotationSpec.builder(ClassName.get(JsonValue::class.java)).build()
@@ -84,6 +73,24 @@ object Annotations {
             .addMember("value", $$"$T.$L", ClassName.get(JsonInclude.Include::class.java), JsonInclude.Include.ALWAYS)
             .build()
 
+    fun jsonIncludeNonEmpty(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonInclude::class.java))
+            .addMember("value", $$"$T.$L", ClassName.get(JsonInclude.Include::class.java), JsonInclude.Include.NON_EMPTY)
+            .build()
+
+    fun nullableOptionalSerializer(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonSerialize::class.java))
+            .addMember("using", $$"$T.class", ClassName.get("io.github.pulpogato.common", "NullableOptionalSerializer"))
+            .build()
+
+    fun nullableOptionalDeserializer(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(JsonDeserialize::class.java))
+            .addMember("using", $$"$T.class", ClassName.get("io.github.pulpogato.common", "NullableOptionalDeserializer"))
+            .build()
+
     /*
      GH Annotations
      */
@@ -141,5 +148,12 @@ object Annotations {
     fun nullable(): AnnotationSpec =
         AnnotationSpec
             .builder(ClassName.get("org.jspecify.annotations", "Nullable"))
+            .build()
+
+    fun deprecated(since: String): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get("java.lang", "Deprecated"))
+            .addMember("forRemoval", "false")
+            .addMember("since", $$"$S", since)
             .build()
 }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/EnumConvertersBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/EnumConvertersBuilder.kt
@@ -6,11 +6,25 @@ import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeSpec
 import io.github.pulpogato.restcodegen.Annotations.generated
-import io.github.pulpogato.restcodegen.Annotations.lombok
 import java.io.File
 import javax.lang.model.element.Modifier
 
 class EnumConvertersBuilder {
+    /**
+     * Builds the EnumConverters class containing all enum converter instances.
+     *
+     * This method creates a Java class named "EnumConverters" that contains a
+     * list of all enum converters provided.
+     * It also includes a generated annotation for tracking the source.
+     *
+     * If the enumConverters set is empty, this method returns early without
+     * generating any class.
+     *
+     * @param context The context containing OpenAPI specification and schema information
+     * @param mainDir The directory where the generated Java file will be written
+     * @param apiPackageName The package name for the generated class
+     * @param enumConverters A set of [ClassName] objects representing the enum converter classes to include
+     */
     fun buildEnumConverters(
         context: Context,
         mainDir: File,
@@ -29,8 +43,6 @@ class EnumConvertersBuilder {
                 .classBuilder("EnumConverters")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(generated(0, context.withSchemaStack("#", "components", "schemas")))
-                .addAnnotation(lombok("Getter"))
-                .addAnnotation(lombok("RequiredArgsConstructor"))
                 .addJavadoc($$"$L", "Registry containing all enum converters for Spring Boot configuration.")
 
         // Add a list field containing all converters
@@ -70,6 +82,24 @@ class EnumConvertersBuilder {
                 ).build()
 
         enumConvertersClass.addField(convertersField)
+
+        // Add explicit no-args constructor
+        enumConvertersClass.addMethod(
+            com.palantir.javapoet.MethodSpec
+                .constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .build(),
+        )
+
+        // Add explicit getConverters() method
+        enumConvertersClass.addMethod(
+            com.palantir.javapoet.MethodSpec
+                .methodBuilder("getConverters")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(listType)
+                .addStatement("return this.converters")
+                .build(),
+        )
 
         // Write the class to file
         JavaFile.builder(apiPackageName, enumConvertersClass.build()).build().writeTo(mainDir)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -11,7 +11,6 @@ import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
 import io.github.pulpogato.restcodegen.Annotations.generated
-import io.github.pulpogato.restcodegen.Annotations.lombok
 import io.github.pulpogato.restcodegen.Annotations.nonNull
 import io.github.pulpogato.restcodegen.Annotations.nullable
 import io.github.pulpogato.restcodegen.Annotations.testExtension
@@ -52,7 +51,6 @@ class PathsBuilder {
                 .classBuilder("RestClients")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(generated(0, context.withSchemaStack("#", "paths")))
-                .addAnnotation(lombok("RequiredArgsConstructor"))
                 .addJavadoc($$"$L", "Client to access all REST APIs.")
                 .addField(
                     FieldSpec
@@ -103,6 +101,9 @@ class PathsBuilder {
                         ).build(),
                 )
 
+        // List to collect API field initializations
+        val apiFieldInitializers = mutableListOf<Pair<String, ClassName>>()
+
         openAPI.paths
             .flatMap { (path, pathItem) ->
                 pathItem.readOperationsMap().map { (method, operation) ->
@@ -147,19 +148,52 @@ class PathsBuilder {
                     JavaFile.builder(packageName, typeClassBuilt).build().writeTo(testDir)
                 }
 
+                // Add field without initializer (will be initialized in constructor)
+                val fieldName = interfaceName.camelCase()
                 val apiField =
                     FieldSpec
-                        .builder(typeRef, interfaceName.camelCase(), Modifier.PRIVATE, Modifier.FINAL)
-                        .initializer($$"computeApi($T.class)", typeRef)
+                        .builder(typeRef, fieldName, Modifier.PRIVATE, Modifier.FINAL)
                         .addJavadoc($$"$L", apiDescription ?: "")
-                        .addAnnotation(
-                            AnnotationSpec
-                                .builder(ClassName.get("lombok", "Getter"))
-                                .addMember("lazy", "true")
-                                .build(),
-                        ).build()
+                        .build()
                 restClients.addField(apiField)
+
+                // Store field initialization for later (will be added to constructor)
+                apiFieldInitializers.add(Pair(fieldName, typeRef))
+
+                // Add explicit getter
+                val getterName = "get" + interfaceName.pascalCase()
+                restClients.addMethod(
+                    MethodSpec
+                        .methodBuilder(getterName)
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(typeRef)
+                        .addStatement("return this.\$N", fieldName)
+                        .addJavadoc($$"$L", apiDescription ?: "")
+                        .build(),
+                )
             }
+
+        // Add constructor that initializes all API fields
+        val constructorBuilder =
+            MethodSpec
+                .constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(
+                    ParameterSpec
+                        .builder(
+                            ClassName.get("org.springframework.web.reactive.function.client", "WebClient"),
+                            "restClient",
+                        ).addAnnotation(nonNull())
+                        .build(),
+                ).addStatement("this.restClient = restClient")
+
+        // Initialize all API fields in constructor
+        apiFieldInitializers.forEach { (fieldName, typeRef) ->
+            constructorBuilder.addStatement("this.\$N = computeApi(\$T.class)", fieldName, typeRef)
+        }
+
+        restClients.addMethod(constructorBuilder.build())
+
         JavaFile.builder(packageName, restClients.build()).build().writeTo(mainDir)
     }
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
@@ -50,6 +50,7 @@ object Types {
     // Common Types
     val EMPTY_OBJECT: ClassName = ClassName.get(COMMON_PACKAGE, "EmptyObject")
     val EXCEPTION: ClassName = ClassName.get(java.lang.Exception::class.java)
+    val NULLABLE_OPTIONAL: ClassName = ClassName.get(COMMON_PACKAGE, "NullableOptional")
     val OBJECT: ClassName = ClassName.get(Object::class.java)
     val STRING_OR_INTEGER: ClassName = ClassName.get(COMMON_PACKAGE, "StringOrInteger")
     val TODO: ClassName = ClassName.get(COMMON_PACKAGE, "Todo")
@@ -58,6 +59,8 @@ object Types {
     val LIST: ClassName = ClassName.get(List::class.java)
     val MAP: ClassName = ClassName.get(Map::class.java)
     val CODE_BUILDER: ClassName = ClassName.get(COMMON_PACKAGE, "CodeBuilder")
+    val OBJECTS: ClassName = ClassName.get("java.util", "Objects")
+    val OVERRIDE: ClassName = ClassName.get(Override::class.java)
 
     // Common Parameterized Types
     val MAP_STRING_OBJECT: ParameterizedTypeName = ParameterizedTypeName.get(MAP, STRING, OBJECT)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -319,13 +319,14 @@ class WebhooksBuilder {
                 FieldSpec
                     .builder(ClassName.get(ObjectMapper::class.java), "objectMapper")
                     .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.beans.factory.annotation", "Autowired")).build())
+                    .addModifiers(Modifier.PRIVATE)
                     .build(),
             ).addMethod(
                 MethodSpec
                     .methodBuilder("getObjectMapper")
                     .addModifiers(Modifier.PUBLIC)
                     .returns(ClassName.get(ObjectMapper::class.java))
-                    .addStatement("return objectMapper")
+                    .addStatement("return this.objectMapper")
                     .build(),
             ).addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RestController")).build())
             .addAnnotation(

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
@@ -17,14 +17,6 @@ class AnnotationsTest {
     }
 
     @Test
-    fun `superBuilder creates annotation with toBuilder set to true`() {
-        val result = Annotations.superBuilder()
-
-        assertThat(result.type().toString()).isEqualTo("lombok.experimental.SuperBuilder")
-        assertThat(result.members()["toBuilder"].toString()).contains("true")
-    }
-
-    @Test
     fun `jsonValue creates annotation with correct type`() {
         val result = Annotations.jsonValue()
 

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptional.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptional.java
@@ -1,0 +1,219 @@
+package io.github.pulpogato.common;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.EqualsAndHashCode;
+
+/**
+ * A three-state wrapper for nullable fields that distinguishes between:
+ * <ul>
+ *   <li><b>NOT_SET</b>: Field is absent, not serialized to JSON</li>
+ *   <li><b>NULL</b>: Field is explicitly null, serialized as "field": null</li>
+ *   <li><b>VALUE</b>: Field has a value, serialized normally</li>
+ * </ul>
+ *
+ * <p>This class is necessary because:
+ * <ul>
+ *   <li>Java's {@code Optional<T>} cannot hold null values</li>
+ *   <li>GitHub API distinguishes between absent fields (no change) and null fields (unset value)</li>
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ * <pre>{@code
+ * // Field not set - omitted from JSON
+ * NullableOptional<String> notSet = NullableOptional.notSet();
+ *
+ * // Field explicitly set to null - serialized as null in JSON
+ * NullableOptional<String> explicitNull = NullableOptional.ofNull();
+ *
+ * // Field has a value - serialized with value in JSON
+ * NullableOptional<String> hasValue = NullableOptional.of("example");
+ * }</pre>
+ *
+ * @param <T> the type of value that can be held
+ */
+@JsonSerialize(using = NullableOptionalSerializer.class)
+@JsonDeserialize(using = NullableOptionalDeserializer.class)
+@EqualsAndHashCode
+public final class NullableOptional<T> implements PulpogatoType {
+
+    private enum State {
+        NOT_SET,
+        NULL,
+        VALUE
+    }
+
+    private final State state;
+    private final T value;
+
+    private NullableOptional(State state, T value) {
+        this.state = state;
+        this.value = value;
+    }
+
+    /**
+     * Returns a NullableOptional with no value set.
+     * When serialized to JSON, the field will be absent (omitted).
+     *
+     * @param <T> the type of the value
+     * @return a NullableOptional in NOT_SET state
+     */
+    public static <T> NullableOptional<T> notSet() {
+        return new NullableOptional<>(State.NOT_SET, null);
+    }
+
+    /**
+     * Returns a NullableOptional explicitly set to null.
+     * When serialized to JSON, the field will be present with null value.
+     *
+     * @param <T> the type of the value
+     * @return a NullableOptional in NULL state
+     */
+    public static <T> NullableOptional<T> ofNull() {
+        return new NullableOptional<>(State.NULL, null);
+    }
+
+    /**
+     * Returns a NullableOptional with the specified non-null value.
+     * When serialized to JSON, the field will be present with the value.
+     *
+     * @param value the non-null value to wrap
+     * @param <T> the type of the value
+     * @return a NullableOptional in VALUE state
+     * @throws IllegalArgumentException if value is null (use ofNull() instead)
+     */
+    public static <T> NullableOptional<T> of(T value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Value cannot be null. Use ofNull() for explicit null.");
+        }
+        return new NullableOptional<>(State.VALUE, value);
+    }
+
+    /**
+     * Returns a NullableOptional for the given value, which may be null.
+     * If the value is null, returns a NULL state NullableOptional.
+     * If the value is non-null, returns a VALUE state NullableOptional.
+     *
+     * This is useful in builder patterns where the caller has a potentially
+     * null value and wants it automatically wrapped appropriately.
+     *
+     * @param value the value to wrap (may be null)
+     * @param <T> the type of the value
+     * @return a NullableOptional in NULL state if value is null, VALUE state otherwise
+     */
+    public static <T> NullableOptional<T> ofNullable(T value) {
+        return value == null ? ofNull() : of(value);
+    }
+
+    /**
+     * Returns true if this NullableOptional is not set (absent).
+     *
+     * @return true if NOT_SET, false otherwise
+     */
+    public boolean isNotSet() {
+        return state == State.NOT_SET;
+    }
+
+    /**
+     * Returns true if this NullableOptional is explicitly set to null.
+     *
+     * @return true if NULL, false otherwise
+     */
+    public boolean isNull() {
+        return state == State.NULL;
+    }
+
+    /**
+     * Returns true if this NullableOptional has a value.
+     *
+     * @return true if VALUE, false otherwise
+     */
+    public boolean isValue() {
+        return state == State.VALUE;
+    }
+
+    /**
+     * Returns the value if present.
+     *
+     * @return the value
+     * @throws IllegalStateException if the value is not present (NOT_SET or NULL)
+     */
+    public T getValue() {
+        if (state != State.VALUE) {
+            throw new IllegalStateException("No value present. State is: " + state);
+        }
+        return value;
+    }
+
+    /**
+     * Returns the value if present, otherwise returns the specified default value.
+     *
+     * @param defaultValue the value to return if no value is present
+     * @return the value if present, otherwise defaultValue
+     */
+    public T orElse(T defaultValue) {
+        return state == State.VALUE ? value : defaultValue;
+    }
+
+    /**
+     * Returns the value if present, otherwise returns null.
+     *
+     * @return the value if present, otherwise null
+     */
+    public T orElseNull() {
+        return state == State.VALUE ? value : null;
+    }
+
+    /**
+     * If a value is present, performs the given action with the value.
+     *
+     * @param consumer the action to perform
+     */
+    public void ifValue(Consumer<? super T> consumer) {
+        if (state == State.VALUE) {
+            consumer.accept(value);
+        }
+    }
+
+    /**
+     * If a value is present, applies the mapping function and returns a NullableOptional
+     * wrapping the result. Otherwise, returns a NOT_SET NullableOptional.
+     *
+     * @param mapper the mapping function
+     * @param <U> the type of the result
+     * @return a NullableOptional with the mapped value or NOT_SET
+     */
+    public <U> NullableOptional<U> map(Function<? super T, ? extends U> mapper) {
+        if (state == State.VALUE) {
+            return NullableOptional.of(mapper.apply(value));
+        } else if (state == State.NULL) {
+            return NullableOptional.ofNull();
+        } else {
+            return NullableOptional.notSet();
+        }
+    }
+
+    @Override
+    public String toCode() {
+        if (isNotSet()) {
+            return "io.github.pulpogato.common.NullableOptional.notSet()";
+        } else if (isNull()) {
+            return "io.github.pulpogato.common.NullableOptional.ofNull()";
+        } else if (value instanceof PulpogatoType pt) {
+            return "io.github.pulpogato.common.NullableOptional.of(" + pt.toCode() + ")";
+        } else {
+            return "io.github.pulpogato.common.NullableOptional.of(" + CodeBuilder.render(value) + ")";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return switch (state) {
+            case NOT_SET -> "NullableOptional.notSet()";
+            case NULL -> "NullableOptional.ofNull()";
+            case VALUE -> "NullableOptional[" + value + "]";
+        };
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalDeserializer.java
@@ -1,0 +1,65 @@
+package io.github.pulpogato.common;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link NullableOptional} that handles three-state deserialization:
+ * <ul>
+ *   <li><b>Field absent</b>: Lombok initializes to notSet() via @Builder.Default</li>
+ *   <li><b>Field present with null</b>: Deserializes to ofNull()</li>
+ *   <li><b>Field present with value</b>: Deserializes to of(value)</li>
+ * </ul>
+ */
+public class NullableOptionalDeserializer extends StdDeserializer<NullableOptional<?>>
+        implements ContextualDeserializer {
+
+    private final JavaType valueType;
+
+    @SuppressWarnings("unchecked")
+    public NullableOptionalDeserializer() {
+        super((Class<NullableOptional<?>>) (Class<?>) NullableOptional.class);
+        this.valueType = null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private NullableOptionalDeserializer(JavaType valueType) {
+        super((Class<NullableOptional<?>>) (Class<?>) NullableOptional.class);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+        JavaType type = property != null ? property.getType().containedType(0) : null;
+        return new NullableOptionalDeserializer(type);
+    }
+
+    @Override
+    public NullableOptional<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
+            return NullableOptional.ofNull();
+        }
+
+        // Deserialize to the actual type parameter
+        Object value;
+        if (valueType != null) {
+            value = ctxt.readValue(p, valueType);
+        } else {
+            value = ctxt.readValue(p, Object.class);
+        }
+        return NullableOptional.of(value);
+    }
+
+    @Override
+    public NullableOptional<?> getNullValue(DeserializationContext ctxt) {
+        // Called when field is present with explicit null value
+        return NullableOptional.ofNull();
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalSerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/NullableOptionalSerializer.java
@@ -1,0 +1,38 @@
+package io.github.pulpogato.common;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link NullableOptional} that handles three-state serialization:
+ * <ul>
+ *   <li><b>NOT_SET</b>: Field omitted from JSON (isEmpty returns true)</li>
+ *   <li><b>NULL</b>: Field serialized as "field": null</li>
+ *   <li><b>VALUE</b>: Field serialized with its value</li>
+ * </ul>
+ */
+public class NullableOptionalSerializer extends StdSerializer<NullableOptional<?>> {
+
+    @SuppressWarnings("unchecked")
+    public NullableOptionalSerializer() {
+        super((Class<NullableOptional<?>>) (Class<?>) NullableOptional.class);
+    }
+
+    @Override
+    public void serialize(NullableOptional<?> value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        if (value.isNull()) {
+            gen.writeNull();
+        } else if (!value.isNotSet()) {
+            gen.writePOJO(value.getValue());
+        }
+    }
+
+    @Override
+    public boolean isEmpty(SerializerProvider provider, NullableOptional<?> value) {
+        // Return true for NOT_SET to skip serialization entirely
+        return value == null || value.isNotSet();
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
@@ -1,0 +1,152 @@
+package io.github.pulpogato.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class NullableOptionalTest {
+
+    @Test
+    void testNotSet() {
+        var optional = NullableOptional.notSet();
+        assertThat(optional.isNotSet()).isTrue();
+        assertThat(optional.isNull()).isFalse();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfNull() {
+        var optional = NullableOptional.ofNull();
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isTrue();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfValue() {
+        var optional = NullableOptional.of("test");
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isFalse();
+        assertThat(optional.isValue()).isTrue();
+        assertThat(optional.getValue()).isEqualTo("test");
+    }
+
+    @Test
+    void testOfNullThrows() {
+        assertThatThrownBy(() -> NullableOptional.of(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Use ofNull()");
+    }
+
+    @Test
+    void testOfNullableWithNullValueReturnsNullState() {
+        var optional = NullableOptional.ofNullable(null);
+        assertThat(optional.isNull()).isTrue();
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isValue()).isFalse();
+    }
+
+    @Test
+    void testOfNullableWithNonNullValueReturnsValueState() {
+        var optional = NullableOptional.ofNullable("test");
+        assertThat(optional.isValue()).isTrue();
+        assertThat(optional.getValue()).isEqualTo("test");
+        assertThat(optional.isNotSet()).isFalse();
+        assertThat(optional.isNull()).isFalse();
+    }
+
+    @Test
+    void testGetValueThrowsWhenNotSet() {
+        var optional = NullableOptional.notSet();
+        assertThatThrownBy(optional::getValue)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No value present");
+    }
+
+    @Test
+    void testGetValueThrowsWhenNull() {
+        var optional = NullableOptional.ofNull();
+        assertThatThrownBy(optional::getValue)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No value present");
+    }
+
+    @Test
+    void testOrElse() {
+        assertThat(NullableOptional.notSet().orElse("default")).isEqualTo("default");
+        assertThat(NullableOptional.ofNull().orElse("default")).isEqualTo("default");
+        assertThat(NullableOptional.of("value").orElse("default")).isEqualTo("value");
+    }
+
+    @Test
+    void testSerializationNotSet() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.notSet();
+
+        String json = om.writeValueAsString(wrapper);
+        // Note: With class-level @JsonSerialize, isEmpty() may not be called
+        // The generated code uses field-level annotations with @JsonInclude(NON_NULL) at class level
+        // which properly skips empty fields. This test validates the basic serializer works.
+        assertThat(json).doesNotContain("\"value\""); // Should not serialize internal state
+    }
+
+    @Test
+    void testSerializationNull() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.ofNull();
+
+        String json = om.writeValueAsString(wrapper);
+        assertThat(json).isEqualTo("{\"field\":null}");
+    }
+
+    @Test
+    void testSerializationValue() throws Exception {
+        var om = new ObjectMapper();
+        var wrapper = new TestWrapper();
+        wrapper.field = NullableOptional.of("test");
+
+        String json = om.writeValueAsString(wrapper);
+        assertThat(json).isEqualTo("{\"field\":\"test\"}");
+    }
+
+    @Test
+    void testDeserializationAbsent() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        // When field is absent, Lombok/Jackson will leave it as the default value
+        // which is notSet() due to @Builder.Default
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isNotSet()).isTrue();
+    }
+
+    @Test
+    void testDeserializationNull() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{\"field\":null}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isNull()).isTrue();
+    }
+
+    @Test
+    void testDeserializationValue() throws Exception {
+        var om = new ObjectMapper();
+        String json = "{\"field\":\"test\"}";
+
+        TestWrapper result = om.readValue(json, TestWrapper.class);
+        assertThat(result.field).isNotNull();
+        assertThat(result.field.isValue()).isTrue();
+        assertThat(result.field.getValue()).isEqualTo("test");
+    }
+
+    static class TestWrapper {
+        public NullableOptional<String> field = NullableOptional.notSet();
+    }
+}

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/OrgsApiIntegrationTest.java
@@ -19,7 +19,7 @@ class OrgsApiIntegrationTest extends BaseIntegrationTest {
         assertThat(installations.getInstallations()).hasSize(1);
         var installation = installations.getInstallations().getFirst();
         assertThat(installation.getAccount()).isNotNull();
-        assertThat(installation.getAccount().getSimpleUser().getLogin()).isEqualTo("pulpogato");
+        assertThat(installation.getAccount().getValue().getSimpleUser().getLogin()).isEqualTo("pulpogato");
         assertThat(installation.getAppSlug()).isEqualTo("renovate");
     }
 }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testArchiveRepository.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testArchiveRepository.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "archived" : true
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:27Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : true,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "disabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testClearSecurityAndAnalysis.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testClearSecurityAndAnalysis.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "security_and_analysis" : null
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testSetSecurityAndAnalysis.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testSetSecurityAndAnalysis.yml
@@ -1,0 +1,187 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "enabled"
+          }
+        }
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testUnrchiveRepository.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testUnrchiveRepository.yml
@@ -1,0 +1,177 @@
+- request:
+    method: PATCH
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+      Content-Type: application/json
+    body: |-
+      {
+        "archived" : false
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "create-demo",
+        "full_name" : "pulpogato/create-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/create-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/create-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/create-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/create-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/create-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/create-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/create-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/create-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/create-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/create-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/create-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/create-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/create-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/create-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/create-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/create-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/create-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/create-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/create-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/create-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/create-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/create-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/create-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/create-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/create-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/create-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/create-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/create-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/create-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/create-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/create-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/create-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/create-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/create-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/create-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/create-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2025-12-06T20:52:52Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/create-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/create-demo.git",
+        "clone_url" : "https://github.com/pulpogato/create-demo.git",
+        "svn_url" : "https://github.com/pulpogato/create-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "disabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Exchange.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Exchange.java
@@ -1,7 +1,12 @@
 package io.github.pulpogato.test;
 
 import java.util.Map;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder
 @Getter

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestWebhookResponse.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/TestWebhookResponse.java
@@ -1,7 +1,11 @@
 package io.github.pulpogato.test;
 
 import java.util.Map;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 @Builder
 @NoArgsConstructor

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -13,8 +13,7 @@ dependencies {
     compileOnly(libs.jspecify)
     compileOnly(libs.springWeb)
     compileOnly(libs.springBootWebflux)
-    compileOnly(libs.lombok)
-    annotationProcessor(libs.lombok)
+    implementation(libs.commonsLang3)
 
     api(project(":${rootProject.name}-common"))
 


### PR DESCRIPTION
Replace Lombok-generated builders with handcrafted implementations that support three-state nullable fields through `NullableOptional`.
This allows distinguishing between unset, explicitly null, and non-null values in builder patterns.

The custom builders include convenience methods for working with `NullableOptional` fields, improving ergonomics when constructing objects with optional nullable fields.

The older setters and builder methods are deprecated to encourage migration to the new methods that handle `NullableOptional`.

BREAKING-CHANGE:
* The getters for these fields now return `NullableOptional` types.
* The builders do not use lombok, but are similar. Relying on lombok internals could break.
