### PR TITLE
refactor: Add LinkedHashMapBuilder

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/LinkedHashMapBuilder.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/LinkedHashMapBuilder.java
@@ -1,0 +1,19 @@
+package io.github.pulpogato.common;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LinkedHashMapBuilder {
+    private LinkedHashMapBuilder() {
+        // Empty Default Private Constructor. This should not be instantiated.
+    }
+
+    @SafeVarargs
+    public static <K, V> LinkedHashMap<K, V> of(Map.Entry<K, V>... entries) {
+        var map = new LinkedHashMap<K, V>();
+        for (var entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+}

--- a/pulpogato-graphql-fpt/src/test/java/io/github/pulpogato/graphql/FindOpenPullRequestsTest.java
+++ b/pulpogato-graphql-fpt/src/test/java/io/github/pulpogato/graphql/FindOpenPullRequestsTest.java
@@ -1,6 +1,7 @@
 package io.github.pulpogato.graphql;
 
 import com.netflix.graphql.dgs.client.WebClientGraphQLClient;
+import io.github.pulpogato.common.LinkedHashMapBuilder;
 import io.github.pulpogato.graphql.types.MergeableState;
 import io.github.pulpogato.graphql.types.PullRequestMergeMethod;
 import io.github.pulpogato.graphql.types.Repository;
@@ -8,7 +9,6 @@ import io.github.pulpogato.test.BaseIntegrationTest;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,10 +49,12 @@ class FindOpenPullRequestsTest extends BaseIntegrationTest {
     void testFindOpenPullRequestsQuery() {
         var graphqlWebClient = webClient.mutate().baseUrl("/graphql").build();
         WebClientGraphQLClient graphQLClient = new WebClientGraphQLClient(graphqlWebClient);
-        var variables = new LinkedHashMap<String, String>();
-        variables.put("owner", "pulpogato");
-        variables.put("repo", "pulpogato");
-        variables.put("branch", "main");
+
+        var variables = LinkedHashMapBuilder.of(
+                Map.entry("owner", "pulpogato"),
+                Map.entry("repo", "pulpogato"),
+                Map.entry("branch", "main")
+        );
         var response = graphQLClient.reactiveExecuteQuery(OPEN_PRS, variables).block();
 
         assertThat(response).isNotNull();


### PR DESCRIPTION
`Map.ofEntries` does not guarantee consistent order.
This preserves similar code but with guaranteed order.
