### PR TITLE
chore: Run `check-issues-statuses` on push to main

### DIFF
--- a/.github/workflows/check-issues-statuses.yml
+++ b/.github/workflows/check-issues-statuses.yml
@@ -1,6 +1,8 @@
 name: Check Issue Statuses
 
 on:
+  push:
+    branches: ['main']
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:


### PR DESCRIPTION
This reduces time taken to detect transitions.
