### PR TITLE
feat: Add caching support

### DIFF
--- a/pulpogato-common/build.gradle.kts
+++ b/pulpogato-common/build.gradle.kts
@@ -13,6 +13,7 @@ val mockitoAgent = configurations.create("mockitoAgent")
 dependencies {
     compileOnly(libs.jspecify)
     compileOnly(libs.lombok)
+    compileOnly(libs.springBootWebflux)
     annotationProcessor(libs.lombok)
     implementation(libs.slf4j)
 
@@ -27,6 +28,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockito)
     testImplementation(libs.mockitoJunitJupiter)
+    testImplementation(libs.springBootWebflux)
     testRuntimeOnly(libs.junitPlatformLauncher)
 
     mockitoAgent(libs.mockito) { isTransitive = false }

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CacheKeyMapper.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CacheKeyMapper.java
@@ -1,0 +1,9 @@
+package io.github.pulpogato.common.cache;
+
+import java.util.function.Function;
+import org.springframework.web.reactive.function.client.ClientRequest;
+
+/**
+ * Functional interface for mapping a ClientRequest to a cache key string.
+ */
+public interface CacheKeyMapper extends Function<ClientRequest, String> {}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachedResponse.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachedResponse.java
@@ -1,0 +1,52 @@
+package io.github.pulpogato.common.cache;
+
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a cached HTTP response with its caching metadata.
+ *
+ * <p>This record stores the response body along with HTTP headers and caching metadata
+ * (ETag, Last-Modified, Cache-Control max-age) and the timestamp when
+ * the response was cached. This information is used to determine cache
+ * freshness and to send conditional requests (If-None-Match, If-Modified-Since).
+ *
+ * @param body The cached response body as bytes
+ * @param headers All response headers to preserve (Content-Type, etc.)
+ * @param etag The ETag header value from the response, if present
+ * @param lastModified The Last-Modified header value from the response, if present
+ * @param maxAgeSeconds The max-age value from Cache-Control header in seconds, or -1 if not present
+ * @param cachedAtMillis The system time in milliseconds when this response was cached
+ */
+public record CachedResponse(
+        byte[] body,
+        Map<String, List<String>> headers,
+        @Nullable String etag,
+        @Nullable String lastModified,
+        long maxAgeSeconds,
+        long cachedAtMillis) {
+
+    /**
+     * Checks if this cached response has expired based on the max-age directive.
+     *
+     * @param currentTimeMillis the current time in milliseconds to compare against
+     * @return true if the cached response has exceeded its max-age, false if still fresh or no max-age was specified
+     */
+    public boolean isExpired(long currentTimeMillis) {
+        if (maxAgeSeconds < 0) {
+            return false;
+        }
+        var ageMillis = currentTimeMillis - cachedAtMillis;
+        return ageMillis > (maxAgeSeconds * 1000);
+    }
+
+    /**
+     * Checks if this cached response can be validated with conditional headers.
+     *
+     * @return true if either ETag or Last-Modified is present
+     */
+    public boolean canRevalidate() {
+        return etag != null || lastModified != null;
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
@@ -1,0 +1,159 @@
+package io.github.pulpogato.common.cache;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.cache.Cache;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * HTTP caching filter that implements conditional request handling.
+ *
+ * <p>This filter intercepts requests and responses to provide HTTP caching based on:
+ *
+ * <ul>
+ *   <li>ETag / If-None-Match
+ *   <li>Last-Modified / If-Modified-Since
+ *   <li>Cache-Control max-age
+ * </ul>
+ *
+ * <p>When a cached response exists and is still fresh (within max-age), it is returned directly.
+ * When expired, conditional headers are added and on 304 Not Modified the cached response body
+ * is returned.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * HttpCache cache = new InMemoryHttpCache();
+ * WebClient client = WebClient.builder()
+ *     .filter(new CachingExchangeFilterFunction(cache))
+ *     .build();
+ * }</pre>
+ */
+@RequiredArgsConstructor
+public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
+
+    /**
+     * Name of the custom header indicating cache status.
+     */
+    public static final String CACHE_HEADER_NAME = "X-Pulpogato-Cache";
+
+    private static final Pattern MAX_AGE_PATTERN = Pattern.compile("max-age=(\\d+)");
+
+    private final DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+
+    /**
+     * The cache instance to store and retrieve cached responses.
+     */
+    private final Cache cache;
+
+    /**
+     * Function to map ClientRequest to cache key strings.
+     */
+    private final CacheKeyMapper cacheKeyMapper;
+
+    /**
+     * Clock instance for time-based operations.
+     */
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        // Only cache GET requests
+        if (!request.method().name().equals("GET")) {
+            return next.exchange(request);
+        }
+
+        var cacheKey = cacheKeyMapper.apply(request);
+        var cached = cache.get(cacheKey, CachedResponse.class);
+
+        // If we have a fresh cached response, return it
+        if (cached != null && !cached.isExpired(clock.millis())) {
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                    .headers(h -> h.putAll(cached.headers()))
+                    .header(CACHE_HEADER_NAME, "HIT")
+                    .body(Flux.just(bufferFactory.wrap(cached.body())))
+                    .build());
+        }
+
+        // Build request with conditional headers if we have a stale cache entry
+        var requestBuilder = ClientRequest.from(request);
+        if (cached != null && cached.canRevalidate()) {
+            if (cached.etag() != null) {
+                requestBuilder.header("If-None-Match", cached.etag());
+            }
+            if (cached.lastModified() != null) {
+                requestBuilder.header("If-Modified-Since", cached.lastModified());
+            }
+        }
+
+        var conditionalRequest = requestBuilder.build();
+
+        return next.exchange(conditionalRequest).flatMap(response -> {
+            // On 304, return cached body
+            if (response.statusCode().value() == 304 && cached != null) {
+                return response.releaseBody()
+                        .then(Mono.just(ClientResponse.create(HttpStatus.OK)
+                                .headers(h -> h.putAll(cached.headers()))
+                                .header(CACHE_HEADER_NAME, "REVALIDATED")
+                                .body(Flux.just(bufferFactory.wrap(cached.body())))
+                                .build()));
+            }
+
+            // Cache the response if it has caching headers
+            if (response.statusCode().is2xxSuccessful()) {
+                return cacheResponse(cacheKey, response);
+            }
+
+            return Mono.just(response);
+        });
+    }
+
+    private Mono<ClientResponse> cacheResponse(String cacheKey, ClientResponse response) {
+        var headers = response.headers().asHttpHeaders();
+        var etag = headers.getETag();
+        var lastModified = headers.getFirst("Last-Modified");
+        var cacheControl = headers.getFirst("Cache-Control");
+
+        var maxAge = parseMaxAge(cacheControl);
+
+        // Only cache if there are caching headers
+        if (etag == null && lastModified == null && maxAge < 0) {
+            return Mono.just(response);
+        }
+        // Copy headers to a plain Map for serialization
+        var headerMap = new HashMap<String, List<String>>();
+        headers.forEach((key, values) -> headerMap.put(key, new ArrayList<>(values)));
+        return response.bodyToMono(byte[].class).defaultIfEmpty(new byte[0]).map(body -> {
+            var cachedResponse = new CachedResponse(body, headerMap, etag, lastModified, maxAge, clock.millis());
+            cache.put(cacheKey, cachedResponse);
+
+            return ClientResponse.create(response.statusCode())
+                    .headers(h -> headers.forEach(h::put))
+                    .header(CACHE_HEADER_NAME, "MISS")
+                    .body(Flux.just(bufferFactory.wrap(body)))
+                    .build();
+        });
+    }
+
+    private static long parseMaxAge(String cacheControl) {
+        if (cacheControl != null) {
+            var matcher = MAX_AGE_PATTERN.matcher(cacheControl);
+            if (matcher.find()) {
+                return Long.parseLong(matcher.group(1));
+            }
+        }
+        return -1;
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapper.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapper.java
@@ -1,0 +1,22 @@
+package io.github.pulpogato.common.cache;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+import org.springframework.web.reactive.function.client.ClientRequest;
+
+/**
+ * Default implementation of CacheKeyMapper that generates a cache key
+ * based on the HTTP method, host, path, and query parameters of the request.
+ */
+public class DefaultCacheKeyMapper implements CacheKeyMapper {
+    @Override
+    public String apply(ClientRequest request) {
+        final var url = request.url();
+        final var host = Optional.ofNullable(request.headers().getFirst("Host"))
+                .orElse(url.getHost() + (url.getPort() != -1 ? ":" + url.getPort() : ""));
+        final var pathAndQuery = MessageFormat.format(
+                "{0}{1}",
+                url.getRawPath(), url.getRawQuery() != null ? MessageFormat.format("?{0}", url.getRawQuery()) : "");
+        return MessageFormat.format("{0} {1} {2}", request.method().name(), host, pathAndQuery);
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachedResponseTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachedResponseTest.java
@@ -1,0 +1,112 @@
+package io.github.pulpogato.common.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CachedResponseTest {
+
+    private static final byte[] BODY = "test".getBytes();
+    private static final Map<String, java.util.List<String>> HEADERS = Map.of();
+
+    @Nested
+    @DisplayName("isExpired")
+    class IsExpired {
+
+        @Test
+        @DisplayName("returns false when maxAgeSeconds is negative")
+        void returnsFalseWhenMaxAgeIsNegative() {
+            var response = new CachedResponse(BODY, HEADERS, null, null, -1, 0);
+
+            assertThat(response.isExpired(1_000_000)).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns false when within max-age window")
+        void returnsFalseWhenWithinMaxAge() {
+            var cachedAt = 1000L;
+            var maxAge = 60L;
+            var response = new CachedResponse(BODY, HEADERS, null, null, maxAge, cachedAt);
+
+            assertThat(response.isExpired(cachedAt + 30_000)).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns false when exactly at max-age boundary")
+        void returnsFalseWhenAtExactBoundary() {
+            var cachedAt = 1000L;
+            var maxAge = 60L;
+            var response = new CachedResponse(BODY, HEADERS, null, null, maxAge, cachedAt);
+
+            assertThat(response.isExpired(cachedAt + 60_000)).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns true when past max-age")
+        void returnsTrueWhenPastMaxAge() {
+            var cachedAt = 1000L;
+            var maxAge = 60L;
+            var response = new CachedResponse(BODY, HEADERS, null, null, maxAge, cachedAt);
+
+            assertThat(response.isExpired(cachedAt + 60_001)).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns false when maxAgeSeconds is zero and time has not passed")
+        void returnsFalseWhenMaxAgeZeroAndNoTimePassed() {
+            var cachedAt = 1000L;
+            var response = new CachedResponse(BODY, HEADERS, null, null, 0, cachedAt);
+
+            assertThat(response.isExpired(cachedAt)).isFalse();
+        }
+
+        @Test
+        @DisplayName("returns true when maxAgeSeconds is zero and any time has passed")
+        void returnsTrueWhenMaxAgeZeroAndTimePassed() {
+            var cachedAt = 1000L;
+            var response = new CachedResponse(BODY, HEADERS, null, null, 0, cachedAt);
+
+            assertThat(response.isExpired(cachedAt + 1)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("canRevalidate")
+    class CanRevalidate {
+
+        @Test
+        @DisplayName("returns true when etag is present")
+        void returnsTrueWhenEtagPresent() {
+            var response = new CachedResponse(BODY, HEADERS, "\"abc123\"", null, -1, 0);
+
+            assertThat(response.canRevalidate()).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns true when lastModified is present")
+        void returnsTrueWhenLastModifiedPresent() {
+            var response = new CachedResponse(BODY, HEADERS, null, "Wed, 21 Oct 2015 07:28:00 GMT", -1, 0);
+
+            assertThat(response.canRevalidate()).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns true when both etag and lastModified are present")
+        void returnsTrueWhenBothPresent() {
+            var response = new CachedResponse(BODY, HEADERS, "\"abc123\"", "Wed, 21 Oct 2015 07:28:00 GMT", -1, 0);
+
+            assertThat(response.canRevalidate()).isTrue();
+        }
+
+        @Test
+        @DisplayName("returns false when neither etag nor lastModified is present")
+        void returnsFalseWhenNeitherPresent() {
+            var response = new CachedResponse(BODY, HEADERS, null, null, -1, 0);
+
+            assertThat(response.canRevalidate()).isFalse();
+        }
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -1,0 +1,394 @@
+package io.github.pulpogato.common.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class CachingExchangeFilterFunctionTest {
+
+    private static final String TEST_URL = "https://api.example.com/data";
+    private static final String CACHE_KEY = "GET api.example.com /data";
+    private static final long CURRENT_TIME = 1_000_000L;
+    private static final byte[] RESPONSE_BODY = "test response".getBytes(StandardCharsets.UTF_8);
+    private static final Map<String, List<String>> DEFAULT_HEADERS =
+            Map.of("Content-Type", List.of("application/json"));
+
+    @Mock
+    private Cache cache;
+
+    @Mock
+    private CacheKeyMapper cacheKeyMapper;
+
+    @Mock
+    private Clock clock;
+
+    @Mock
+    private ExchangeFunction exchangeFunction;
+
+    private CachingExchangeFilterFunction filter;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        filter = new CachingExchangeFilterFunction(cache, cacheKeyMapper, clock);
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    private ClientRequest createGetRequest() {
+        return ClientRequest.create(HttpMethod.GET, URI.create(TEST_URL)).build();
+    }
+
+    private ClientRequest createPostRequest() {
+        return ClientRequest.create(HttpMethod.POST, URI.create(TEST_URL)).build();
+    }
+
+    private ClientResponse createResponse(HttpStatus status, String etag, String lastModified, String cacheControl) {
+        var builder = ClientResponse.create(status).header("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+        if (etag != null) {
+            builder.header("ETag", etag);
+        }
+        if (lastModified != null) {
+            builder.header("Last-Modified", lastModified);
+        }
+        if (cacheControl != null) {
+            builder.header("Cache-Control", cacheControl);
+        }
+        builder.body(Flux.just(bufferFactory.wrap(RESPONSE_BODY)));
+        return builder.build();
+    }
+
+    private ClientResponse create304Response() {
+        return ClientResponse.create(HttpStatus.NOT_MODIFIED).build();
+    }
+
+    @Nested
+    @DisplayName("Non-GET requests")
+    class NonGetRequests {
+
+        @Test
+        @DisplayName("POST requests bypass cache")
+        void postRequestsBypassCache() {
+            var request = createPostRequest();
+            var response = createResponse(HttpStatus.OK, null, null, null);
+            when(exchangeFunction.exchange(request)).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isEqualTo(response);
+            verify(cache, never()).get(any(), eq(CachedResponse.class));
+            verify(cache, never()).put(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cache miss")
+    class CacheMiss {
+
+        @Test
+        @DisplayName("First request with ETag gets cached and returns MISS header")
+        void firstRequestWithEtagGetsCached() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = createResponse(HttpStatus.OK, "\"abc123\"", null, null);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().header(CachingExchangeFilterFunction.CACHE_HEADER_NAME))
+                    .containsExactly("MISS");
+
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().etag()).isEqualTo("\"abc123\"");
+        }
+
+        @Test
+        @DisplayName("First request with Last-Modified gets cached")
+        void firstRequestWithLastModifiedGetsCached() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = createResponse(HttpStatus.OK, null, "Wed, 21 Oct 2015 07:28:00 GMT", null);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().lastModified()).isEqualTo("Wed, 21 Oct 2015 07:28:00 GMT");
+        }
+
+        @Test
+        @DisplayName("First request with Cache-Control max-age gets cached")
+        void firstRequestWithMaxAgeGetsCached() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = createResponse(HttpStatus.OK, null, null, "private, max-age=60");
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().maxAgeSeconds()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("Cached response preserves Content-Type header")
+        void cachedResponsePreservesContentType() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = createResponse(HttpStatus.OK, "\"abc123\"", null, null);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().headers()).containsKey("Content-Type");
+            assertThat(captor.getValue().headers().get("Content-Type")).contains("application/json");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cache hit")
+    class CacheHit {
+
+        @Test
+        @DisplayName("Fresh cached response returns HIT without server request")
+        void freshCachedResponseReturnsHit() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var cachedResponse =
+                    new CachedResponse(RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(cachedResponse);
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().header(CachingExchangeFilterFunction.CACHE_HEADER_NAME))
+                    .containsExactly("HIT");
+            assertThat(result.statusCode()).isEqualTo(HttpStatus.OK);
+            verify(exchangeFunction, never()).exchange(any());
+        }
+
+        @Test
+        @DisplayName("Fresh cached response preserves Content-Type header")
+        void freshCachedResponsePreservesContentType() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var headers = Map.of("Content-Type", List.of("application/json"), "X-Custom", List.of("value"));
+            var cachedResponse = new CachedResponse(RESPONSE_BODY, headers, "\"abc123\"", null, 60, CURRENT_TIME);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(cachedResponse);
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().contentType()).hasValue(MediaType.APPLICATION_JSON);
+            assertThat(result.headers().header("X-Custom")).containsExactly("value");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cache revalidation")
+    class CacheRevalidation {
+
+        @Test
+        @DisplayName("Stale entry with ETag sends If-None-Match header")
+        void staleEntryWithEtagSendsIfNoneMatch() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var staleCache =
+                    new CachedResponse(RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 1, CURRENT_TIME - 10000);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            filter.filter(request, exchangeFunction).block();
+
+            var captor = ArgumentCaptor.forClass(ClientRequest.class);
+            verify(exchangeFunction).exchange(captor.capture());
+            assertThat(captor.getValue().headers().getFirst("If-None-Match")).isEqualTo("\"abc123\"");
+        }
+
+        @Test
+        @DisplayName("Stale entry with Last-Modified sends If-Modified-Since header")
+        void staleEntryWithLastModifiedSendsIfModifiedSince() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var staleCache = new CachedResponse(
+                    RESPONSE_BODY, DEFAULT_HEADERS, null, "Wed, 21 Oct 2015 07:28:00 GMT", 1, CURRENT_TIME - 10000);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            filter.filter(request, exchangeFunction).block();
+
+            var captor = ArgumentCaptor.forClass(ClientRequest.class);
+            verify(exchangeFunction).exchange(captor.capture());
+            assertThat(captor.getValue().headers().getFirst("If-Modified-Since"))
+                    .isEqualTo("Wed, 21 Oct 2015 07:28:00 GMT");
+        }
+
+        @Test
+        @DisplayName("304 response returns cached body with REVALIDATED header")
+        void notModifiedReturnsCachedBodyWithRevalidatedHeader() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var staleCache =
+                    new CachedResponse(RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 1, CURRENT_TIME - 10000);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().header(CachingExchangeFilterFunction.CACHE_HEADER_NAME))
+                    .containsExactly("REVALIDATED");
+            assertThat(result.statusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("304 response preserves Content-Type from cached entry")
+        void notModifiedPreservesContentType() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var headers = Map.of("Content-Type", List.of("application/json"));
+            var staleCache = new CachedResponse(RESPONSE_BODY, headers, "\"abc123\"", null, 1, CURRENT_TIME - 10000);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().contentType()).hasValue(MediaType.APPLICATION_JSON);
+        }
+
+        @Test
+        @DisplayName("200 response after revalidation updates cache")
+        void okResponseAfterRevalidationUpdatesCache() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var staleCache = new CachedResponse(
+                    "old data".getBytes(), DEFAULT_HEADERS, "\"old\"", null, 1, CURRENT_TIME - 10000);
+            var newResponse = createResponse(HttpStatus.OK, "\"new\"", null, null);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(newResponse));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.headers().header(CachingExchangeFilterFunction.CACHE_HEADER_NAME))
+                    .containsExactly("MISS");
+
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().etag()).isEqualTo("\"new\"");
+        }
+    }
+
+    @Nested
+    @DisplayName("Responses not cached")
+    class ResponsesNotCached {
+
+        @Test
+        @DisplayName("Response without caching headers is not cached")
+        void responseWithoutCachingHeadersNotCached() {
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = ClientResponse.create(HttpStatus.OK)
+                    .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .body(Flux.just(bufferFactory.wrap(RESPONSE_BODY)))
+                    .build();
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            verify(cache, never()).put(any(), any());
+        }
+
+        @Test
+        @DisplayName("4xx response is not cached")
+        void clientErrorNotCached() {
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = ClientResponse.create(HttpStatus.NOT_FOUND)
+                    .header("ETag", "\"abc\"")
+                    .body(Flux.just(bufferFactory.wrap("not found".getBytes())))
+                    .build();
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.statusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            verify(cache, never()).put(any(), any());
+        }
+
+        @Test
+        @DisplayName("5xx response is not cached")
+        void serverErrorNotCached() {
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var response = ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .header("ETag", "\"abc\"")
+                    .body(Flux.just(bufferFactory.wrap("error".getBytes())))
+                    .build();
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            assertThat(result).isNotNull();
+            assertThat(result.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            verify(cache, never()).put(any(), any());
+        }
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapperTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapperTest.java
@@ -1,0 +1,177 @@
+package io.github.pulpogato.common.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.ClientRequest;
+
+class DefaultCacheKeyMapperTest {
+
+    private final DefaultCacheKeyMapper mapper = new DefaultCacheKeyMapper();
+
+    @Nested
+    @DisplayName("HTTP method")
+    class HttpMethodTests {
+
+        @Test
+        @DisplayName("includes GET method in cache key")
+        void includesGetMethod() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).startsWith("GET ");
+        }
+
+        @Test
+        @DisplayName("includes POST method in cache key")
+        void includesPostMethod() {
+            var request = ClientRequest.create(HttpMethod.POST, URI.create("https://api.example.com/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).startsWith("POST ");
+        }
+
+        @Test
+        @DisplayName("includes PUT method in cache key")
+        void includesPutMethod() {
+            var request = ClientRequest.create(HttpMethod.PUT, URI.create("https://api.example.com/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).startsWith("PUT ");
+        }
+    }
+
+    @Nested
+    @DisplayName("Host resolution")
+    class HostResolutionTests {
+
+        @Test
+        @DisplayName("uses Host header when present")
+        void usesHostHeader() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header("Host", "custom-host.example.com")
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET custom-host.example.com /data");
+        }
+
+        @Test
+        @DisplayName("derives host from URL when Host header is absent")
+        void derivesHostFromUrl() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /data");
+        }
+
+        @Test
+        @DisplayName("includes port in host when non-standard port is used")
+        void includesPortWhenNonStandard() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com:8443/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com:8443 /data");
+        }
+
+        @Test
+        @DisplayName("omits port when using default HTTPS port")
+        void omitsDefaultHttpsPort() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com:443/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com:443 /data");
+        }
+    }
+
+    @Nested
+    @DisplayName("Path and query")
+    class PathAndQueryTests {
+
+        @Test
+        @DisplayName("includes path in cache key")
+        void includesPath() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/users/123"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /users/123");
+        }
+
+        @Test
+        @DisplayName("includes query parameters in cache key")
+        void includesQueryParameters() {
+            var request = ClientRequest.create(
+                            HttpMethod.GET, URI.create("https://api.example.com/search?q=test&page=1"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /search?q=test&page=1");
+        }
+
+        @Test
+        @DisplayName("handles empty query string")
+        void handlesEmptyQuery() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).doesNotContain("?");
+        }
+
+        @Test
+        @DisplayName("handles root path")
+        void handlesRootPath() {
+            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /");
+        }
+
+        @Test
+        @DisplayName("preserves URL-encoded characters in path")
+        void preservesEncodedPath() {
+            var request = ClientRequest.create(
+                            HttpMethod.GET, URI.create("https://api.example.com/path%20with%20spaces"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /path%20with%20spaces");
+        }
+
+        @Test
+        @DisplayName("preserves URL-encoded characters in query")
+        void preservesEncodedQuery() {
+            var request = ClientRequest.create(
+                            HttpMethod.GET, URI.create("https://api.example.com/search?q=hello%20world"))
+                    .build();
+
+            var key = mapper.apply(request);
+
+            assertThat(key).isEqualTo("GET api.example.com /search?q=hello%20world");
+        }
+    }
+}


### PR DESCRIPTION
The webclient can be modified to support caching.

```
webClient.mutate()
     .filter(new CachingExchangeFilterFunction(cache))
     .build()
```

That will allow caching based on `Cache-Control` to cache for `max-age`.

Once a cache expires, it will revalidate.
When using `ETag` to provide GitHub with a `If-None-Match` or using `Last-Modified` to provide a `If-Modified-Since`, GitHub can revalidate your cache.
These revalidations do not count against your API limit.

While you can use a `ConcurrentMapCache` from Spring, that is highly discouraged. That is going to grow without bounds.
