### PR TITLE
fix: Add Converter from StringOrInteger to String

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/StringOrInteger.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/StringOrInteger.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.core.convert.converter.Converter;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
@@ -120,6 +121,19 @@ public class StringOrInteger implements PulpogatoType {
                     List.of(
                             new GettableField<>(Long.class, StringOrInteger::getIntegerValue),
                             new GettableField<>(String.class, StringOrInteger::getStringValue)));
+        }
+    }
+
+    public static class StringConverter implements Converter<StringOrInteger, String> {
+        @Override
+        public String convert(StringOrInteger source) {
+            if (source.getStringValue() != null) {
+                return source.getStringValue();
+            }
+            if (source.getIntegerValue() != null) {
+                return source.getIntegerValue().toString();
+            }
+            return null;
         }
     }
 }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
@@ -1,9 +1,11 @@
 package io.github.pulpogato.rest.api;
 
+import io.github.pulpogato.common.StringOrInteger;
 import io.github.pulpogato.rest.schemas.ActionsCacheUsageByRepository;
 import io.github.pulpogato.rest.schemas.ActionsCacheList;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,6 +58,23 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
 
         // Verify pagination works
         assertThat(cacheList.getActionsCaches()).hasSize(10);
+    }
+
+    @Test
+    void testCreateWorkflowDispatch() {
+        RestClients restClients = new RestClients(webClient);
+        // Next statement was for testing if converters can be added in user-land.
+        // restClients.getConversionService().addConverter(new StringOrInteger.StringConverter());
+        var api = restClients.getActionsApi();
+
+        var response = api.createWorkflowDispatch(
+                "pulpogato",
+                "pulpogato",
+                StringOrInteger.builder().stringValue("check-issues-statuses.yml").build(),
+                ActionsApi.CreateWorkflowDispatchRequestBody.builder().ref("main").build()
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
 }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ActionsApiIntegrationTest/testCreateWorkflowDispatch.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ActionsApiIntegrationTest/testCreateWorkflowDispatch.yml
@@ -1,0 +1,21 @@
+- request:
+    method: POST
+    uri: /repos/pulpogato/pulpogato/actions/workflows/check-issues-statuses.yml/dispatches
+    protocol: HTTP/1.1
+    headers:
+      Content-Type: application/json
+    body: |-
+      {
+        "ref" : "main"
+      }
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    body: |-
+      {
+        "workflow_run_id" : 20355835086,
+        "run_url" : "https://api.github.com/repos/pulpogato/pulpogato/actions/runs/20355835086",
+        "html_url" : "https://github.com/pulpogato/pulpogato/actions/runs/20355835086"
+      }


### PR DESCRIPTION
That type is used as a `@PathVariable` in a few places and needs conversion to String so it can fit in the URL.

Also, the `FormattingConversionService` used to accomplish all conversions is now exposed in `RestClients`. This can allow users to extend it.
