### PR TITLE
chore: Use `@Language("json")` instead of `/* language=json */`

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
@@ -4,6 +4,7 @@ import com.palantir.javapoet.ClassName
 import com.palantir.javapoet.MethodSpec
 import com.palantir.javapoet.TypeName
 import io.github.pulpogato.restcodegen.ext.pascalCase
+import org.intellij.lang.annotations.Language
 import tools.jackson.databind.ObjectMapper
 import java.io.File
 import java.io.FileWriter
@@ -93,7 +94,7 @@ object TestBuilder {
                         .methodBuilder("test${key.pascalCase()}")
                         .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
                         .addAnnotation(Annotations.generated(1, context))
-                        .addStatement($$"$T input = /* language=JSON */ $L", String::class.java, formatted.blockQuote())
+                        .addStatement($$"@$T(\"json\") $T input = $L", Language::class.java, String::class.java, formatted.blockQuote())
                         .addStatement($$"var softly = new $T()", ClassName.get("org.assertj.core.api", "SoftAssertions"))
                         .addStatement(
                             $$"var processed = $T.parseAndCompare(new $T<$T>() {}, input, softly)",

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(libs.bundles.springBoot)
     testRuntimeOnly(libs.groovy)
     testCompileOnly(libs.lombok)
+    testCompileOnly(libs.jetbrainsAnnotations)
     testAnnotationProcessor(libs.lombok)
 }
 


### PR DESCRIPTION
This reduces warnings in generated code.
