### PR TITLE
feat: Add builder support to `CachingExchangeFilterFunction`

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
+import lombok.Builder;
 import org.jspecify.annotations.NonNull;
 import org.springframework.cache.Cache;
+import org.springframework.cache.support.NoOpCache;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpStatus;
@@ -46,6 +48,7 @@ import reactor.core.publisher.Mono;
  *     .build();
  * }</pre>
  */
+@Builder
 public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
 
     /**
@@ -70,23 +73,27 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
     /**
      * The cache instance to store and retrieve cached responses.
      */
-    private final Cache cache;
+    @Builder.Default
+    private final Cache cache = new NoOpCache("no-op-cache");
 
     /**
      * Function to map ClientRequest to cache key strings.
      */
-    private final CacheKeyMapper cacheKeyMapper;
+    @Builder.Default
+    private final CacheKeyMapper cacheKeyMapper = new DefaultCacheKeyMapper();
 
     /**
      * Clock instance for time-based operations.
      */
-    private final Clock clock;
+    @Builder.Default
+    private final Clock clock = Clock.systemUTC();
 
     /**
      * Maximum size in bytes for responses to be cached.
      * Responses larger than this will be returned but not cached.
      */
-    private final int maxCacheableSize;
+    @Builder.Default
+    private final int maxCacheableSize = DEFAULT_MAX_CACHEABLE_SIZE;
 
     /**
      * Creates a new CachingExchangeFilterFunction with the default max cacheable size (2MB).
@@ -94,9 +101,14 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
      * @param cache          The cache instance to store responses
      * @param cacheKeyMapper Function to generate cache keys from requests
      * @param clock          Clock for time-based operations
+     * @deprecated Use the builder() method instead
      */
+    @Deprecated
     public CachingExchangeFilterFunction(Cache cache, CacheKeyMapper cacheKeyMapper, Clock clock) {
-        this(cache, cacheKeyMapper, clock, DEFAULT_MAX_CACHEABLE_SIZE);
+        this.cache = cache;
+        this.cacheKeyMapper = cacheKeyMapper;
+        this.clock = clock;
+        this.maxCacheableSize = DEFAULT_MAX_CACHEABLE_SIZE;
     }
 
     /**
@@ -107,7 +119,9 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
      * @param clock            Clock for time-based operations
      * @param maxCacheableSize Maximum response size in bytes to cache (responses larger than this
      *                         will be returned but not cached)
+     * @deprecated Use the builder() method instead
      */
+    @Deprecated
     public CachingExchangeFilterFunction(
             Cache cache, CacheKeyMapper cacheKeyMapper, Clock clock, int maxCacheableSize) {
         this.cache = cache;

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -58,7 +58,11 @@ class CachingExchangeFilterFunctionTest {
 
     @BeforeEach
     void setUp() {
-        filter = new CachingExchangeFilterFunction(cache, cacheKeyMapper, clock);
+        filter = CachingExchangeFilterFunction.builder()
+                .cache(cache)
+                .cacheKeyMapper(cacheKeyMapper)
+                .clock(clock)
+                .build();
         bufferFactory = new DefaultDataBufferFactory();
     }
 
@@ -433,7 +437,11 @@ class CachingExchangeFilterFunctionTest {
         @DisplayName("Response body exceeding max cacheable size returns SKIP and is not cached")
         void bodyExceedingLimitReturnsSkip() {
             // Use a small limit for testing
-            var smallLimitFilter = new CachingExchangeFilterFunction(cache, cacheKeyMapper, clock, 1000);
+            var smallLimitFilter = CachingExchangeFilterFunction.builder()
+                    .cache(cache)
+                    .cacheKeyMapper(cacheKeyMapper)
+                    .maxCacheableSize(1000)
+                    .build();
             var largeBody = new byte[2000];
             for (int i = 0; i < largeBody.length; i++) {
                 largeBody[i] = (byte) (i % 256);
@@ -467,7 +475,12 @@ class CachingExchangeFilterFunctionTest {
         @Test
         @DisplayName("Response with Content-Length exceeding limit skips caching immediately")
         void contentLengthExceedingLimitSkipsEarly() {
-            var smallLimitFilter = new CachingExchangeFilterFunction(cache, cacheKeyMapper, clock, 1000);
+            var smallLimitFilter = CachingExchangeFilterFunction.builder()
+                    .cache(cache)
+                    .cacheKeyMapper(cacheKeyMapper)
+                    .clock(clock)
+                    .maxCacheableSize(1000)
+                    .build();
             var largeBody = new byte[2000];
 
             when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
@@ -492,7 +505,12 @@ class CachingExchangeFilterFunctionTest {
         @Test
         @DisplayName("Custom max cacheable size is respected")
         void customMaxCacheableSizeIsRespected() {
-            var customFilter = new CachingExchangeFilterFunction(cache, cacheKeyMapper, clock, 500);
+            var customFilter = CachingExchangeFilterFunction.builder()
+                    .cache(cache)
+                    .cacheKeyMapper(cacheKeyMapper)
+                    .clock(clock)
+                    .maxCacheableSize(500)
+                    .build();
             var smallBody = new byte[400]; // Under limit
             var largeBody = new byte[600]; // Over limit
 

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ActionsApiIntegrationTest.java
@@ -2,15 +2,12 @@ package io.github.pulpogato.rest.api;
 
 import io.github.pulpogato.common.StringOrInteger;
 import io.github.pulpogato.common.cache.CachingExchangeFilterFunction;
-import io.github.pulpogato.common.cache.DefaultCacheKeyMapper;
-import io.github.pulpogato.rest.schemas.ActionsCacheUsageByRepository;
 import io.github.pulpogato.rest.schemas.ActionsCacheList;
+import io.github.pulpogato.rest.schemas.ActionsCacheUsageByRepository;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.http.HttpStatus;
-
-import java.time.Clock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -99,7 +96,7 @@ class ActionsApiIntegrationTest extends BaseIntegrationTest {
     @Test
     void testListWorkflowRunsWithCache() {
         var cachingClient = webClient.mutate()
-                .filter(new CachingExchangeFilterFunction(new ConcurrentMapCache("test-cache"), new DefaultCacheKeyMapper(), Clock.systemUTC()))
+                .filter(CachingExchangeFilterFunction.builder().cache(new ConcurrentMapCache("test-cache")).build())
                 .build();
         var api = new RestClients(cachingClient).getActionsApi();
         var response = api.listWorkflowRuns(


### PR DESCRIPTION
This allows defaulting values.
The older constructors are still available, but deprecated.
