### PR TITLE
chore: Suppress warnings from kotlin

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Types.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 object Types {
     const val COMMON_PACKAGE = "io.github.pulpogato.common"
 


### PR DESCRIPTION
The generated code is in Java and needs Java types. The IDE assumes kotlin types can be used in the generator.
