### PR TITLE
refactor: Refer to GitHub API commit as `gh.api.commit`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Extract GitHub API Version
       id: api-version
-      run: echo "version=$(grep 'gh.api.version' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+      run: echo "version=$(grep 'gh.api.commit' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
 
     - name: Cache Downloaded Schemas
       id: schema-cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Code generation is core to the project:
 - Parallel builds enabled (`org.gradle.parallel=true`)
 - Custom JVM args for compilation with module exports
 - Memory allocated: 4GB (`-Xmx4g`)
-- GitHub API version tracked in `gradle.properties` as `gh.api.version`
+- GitHub API version tracked in `gradle.properties` as `gh.api.commit`
 
 ## Testing Approach
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,12 +64,12 @@ tasks.register("updateRestSchemaVersion") {
         val json = ObjectMapper().readTree(branches)
         val sha = json.get("commit").get("sha").asText().take(7)
         val oldProps = project.file("gradle.properties").readText()
-        val newProps = oldProps.replace(Regex("gh.api.version=.*"), "gh.api.version=$sha")
+        val newProps = oldProps.replace(Regex("gh.api.commit=.*"), "gh.api.commit=$sha")
         project.file("gradle.properties").writeText(newProps)
-        if (project.ext.get("gh.api.version") != sha) {
-            println("Updated gh.api.version from ${project.ext.get("gh.api.version")} to $sha")
+        if (project.ext.get("gh.api.commit") != sha) {
+            println("Updated gh.api.commit from ${project.ext.get("gh.api.commit")} to $sha")
         } else {
-            println("gh.api.version is already up to date")
+            println("gh.api.commit is already up to date")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.parallel=true
 gh.api.repo=github/rest-api-description
 
 # GitHub REST API Description SHA
-gh.api.version=76df6d2
+gh.api.commit=76df6d2

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -36,7 +36,7 @@ codegen {
     packageName.set("io.github.pulpogato")
     mainDir.set(file("${project.layout.buildDirectory.get()}/generated-src/main/java"))
     testDir.set(file("${project.layout.buildDirectory.get()}/generated-src/test/java"))
-    apiVersion.set(project.ext.get("gh.api.version").toString())
+    apiVersion.set(project.ext.get("gh.api.commit").toString())
     apiRepository.set(project.ext.get("gh.api.repo").toString())
     projectVariant.set(variant)
 }
@@ -144,7 +144,7 @@ val addSchemaInfoToBroker = tasks.register("addSchemaInfoToBroker") {
 
         val infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin::class.java)
         infoBrokerPlugin.add("GitHub-API-Repo", project.ext.get("gh.api.repo").toString())
-        infoBrokerPlugin.add("GitHub-API-Version", project.ext.get("gh.api.version").toString())
+        infoBrokerPlugin.add("GitHub-API-Commit", project.ext.get("gh.api.commit").toString())
         infoBrokerPlugin.add("GitHub-API-SHA256", sha256)
     }
 }

--- a/update-schema-version.sh
+++ b/update-schema-version.sh
@@ -16,11 +16,11 @@ else
     git checkout main
 fi
 
-OLD_SHA=$(grep gh.api.version gradle.properties | cut -d'=' -f2)
+OLD_SHA=$(grep gh.api.commit gradle.properties | cut -d'=' -f2)
 export OLD_SHA
 
 ./gradlew updateRestSchemaVersion
-NEW_SHA=$(grep gh.api.version gradle.properties | cut -d'=' -f2)
+NEW_SHA=$(grep gh.api.commit gradle.properties | cut -d'=' -f2)
 export NEW_SHA
 
 BRANCH_NAME=update-schema-version


### PR DESCRIPTION
GitHub has an internal concept of an API Version that's set at `2022-11-28`.

This reduces the confusion.
