### PR TITLE
feat: Add API version support and default headers for GitHub API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ gh.api.repo=github/rest-api-description
 
 # GitHub REST API Description SHA
 gh.api.commit=76df6d2
+
+gh.api.version=2022-11-28

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -223,13 +223,17 @@ class PathsBuilder {
                     ClassName.get("io.github.pulpogato.common", "StringOrInteger", "StringConverter"),
                 ).addStatement(
                     $$"""
-                    this.factory = $T.builderFor(
-                            $T.create(restClient))
+                    this.factory = $T.builderFor($T.create(
+                            restClient.mutate()
+                                    .filter(new $T())
+                                    .build()
+                            ))
                             .conversionService(this.conversionService)
                             .build()
                     """.trimIndent(),
                     ClassName.get("org.springframework.web.service.invoker", "HttpServiceProxyFactory"),
                     ClassName.get("org.springframework.web.reactive.function.client.support", "WebClientAdapter"),
+                    ClassName.get("io.github.pulpogato.common", "DefaultHeadersExchangeFunction"),
                 )
 
         // Initialize all API fields in the constructor

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenExtension.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenExtension.kt
@@ -49,10 +49,15 @@ open class RestCodegenExtension(
     var testDir: RegularFileProperty = project.objects.fileProperty()
 
     /**
-     * The version of the API being generated.
+     * The commit hash from which the API is being generated.
      *
      * This property is used for version tracking and may be used in generated code
      * for documentation or version-specific configurations.
+     */
+    var apiCommit: Property<String> = project.objects.property(String::class.java)
+
+    /**
+     * The API Version from GitHub.
      */
     var apiVersion: Property<String> = project.objects.property(String::class.java)
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
@@ -11,10 +11,11 @@ class RestCodegenPlugin : Plugin<Project> {
 
         val downloadSchema = target.tasks.register("downloadSchema", DownloadSchemaTask::class.java)
         downloadSchema.configure {
+            apiCommit.set(extension.apiCommit)
             apiVersion.set(extension.apiVersion)
             projectVariant.set(extension.projectVariant)
             apiRepository.set(extension.apiRepository)
-            schemaFile.set(target.layout.buildDirectory.file("generated-src/main/resources/schema.json"))
+            schemaFile.set(target.layout.buildDirectory.file("generated-src/main/resources/github.schema.json"))
         }
 
         val generateJava = target.tasks.register("generateJava", GenerateJavaTask::class.java)

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/DefaultHeadersExchangeFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/DefaultHeadersExchangeFunction.java
@@ -1,0 +1,66 @@
+package io.github.pulpogato.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+/**
+ * <p>
+ * An implementation of the {@link ExchangeFilterFunction} interface that adds default headers
+ * to every outgoing HTTP request, specifically for use with GitHub APIs or similar integrations.
+ * This class ensures consistency in client requests by setting predefined headers.
+ * </p>
+ * <p>
+ * The following headers are added to each request:
+ * </p>
+ * <ul>
+ *   <li> "X-GitHub-Api-Version": specifies the version of the GitHub API being targeted.
+ *   <li> "X-Pulpogato-Version": indicates the version of the Pulpogato client.
+ * </ul>
+ * <p>
+ * This functionality is particularly useful when interacting with APIs that require consistent
+ * versioning or client information in the request headers.
+ * </p>
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DefaultHeadersExchangeFunction implements ExchangeFilterFunction {
+
+    private final String pulpogatoVersion;
+    private final String githubApiVersion;
+
+    public DefaultHeadersExchangeFunction() {
+        this(loadProperty("pulpogato.version"), loadProperty("github.api.version"));
+    }
+
+    private static String loadProperty(String key) {
+        try (InputStream input = new ClassPathResource("pulpogato-headers.properties").getInputStream()) {
+            Properties properties = new Properties();
+            properties.load(input);
+            return properties.getProperty(key, null);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    @NonNull
+    public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        ClientRequest.Builder builder = ClientRequest.from(request);
+        if (githubApiVersion != null) {
+            builder.header("X-GitHub-Api-Version", githubApiVersion);
+        }
+        if (pulpogatoVersion != null) {
+            builder.header("X-Pulpogato-Version", pulpogatoVersion);
+        }
+        return next.exchange(builder.build());
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/DefaultHeadersExchangeFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/DefaultHeadersExchangeFunctionTest.java
@@ -1,0 +1,87 @@
+package io.github.pulpogato.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+class DefaultHeadersExchangeFunctionTest {
+
+    private ExchangeFunction exchangeFunction;
+    private ClientResponse mockResponse;
+
+    @BeforeEach
+    void setUp() {
+        exchangeFunction = mock(ExchangeFunction.class);
+        mockResponse = mock(ClientResponse.class);
+    }
+
+    @Test
+    void addsHeadersFromPropertiesFile() {
+        // Test the default constructor behavior with test properties file
+        var filter = new DefaultHeadersExchangeFunction();
+
+        var originalRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.github.com"))
+                .build();
+
+        when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(mockResponse));
+
+        var result = filter.filter(originalRequest, exchangeFunction).block();
+
+        // Verify that the exchange function was called (meaning the filter worked)
+        var captor = org.mockito.ArgumentCaptor.forClass(ClientRequest.class);
+        verify(exchangeFunction).exchange(captor.capture());
+
+        var capturedRequest = captor.getValue();
+
+        // With our test properties file, both headers should be present
+        assertThat(capturedRequest.headers().get("X-GitHub-Api-Version")).containsExactly("2022-11-28-test");
+        assertThat(capturedRequest.headers().get("X-Pulpogato-Version")).containsExactly("1.0.0-test");
+
+        assertThat(result).isEqualTo(mockResponse);
+    }
+
+    @Test
+    void preservesOriginalRequestHeadersAndMethod() {
+        var filter = new DefaultHeadersExchangeFunction();
+        var originalRequest = ClientRequest.create(HttpMethod.POST, URI.create("https://api.github.com"))
+                .header("Existing-Header", "existing-value")
+                .build();
+
+        when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(mockResponse));
+
+        filter.filter(originalRequest, exchangeFunction).block();
+
+        var captor = org.mockito.ArgumentCaptor.forClass(ClientRequest.class);
+        verify(exchangeFunction).exchange(captor.capture());
+
+        var capturedRequest = captor.getValue();
+        // Verify that original headers are preserved
+        assertThat(capturedRequest.headers().get("Existing-Header")).containsExactly("existing-value");
+        assertThat(capturedRequest.method()).isEqualTo(HttpMethod.POST);
+    }
+
+    @Test
+    void returnsCorrectResponseFromExchangeFunction() {
+        var expectedResponse = mock(ClientResponse.class);
+        var filter = new DefaultHeadersExchangeFunction();
+        var originalRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.github.com"))
+                .build();
+
+        when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(expectedResponse));
+
+        var actualResponse = filter.filter(originalRequest, exchangeFunction).block();
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+}

--- a/pulpogato-common/src/test/resources/pulpogato-headers.properties
+++ b/pulpogato-common/src/test/resources/pulpogato-headers.properties
@@ -1,0 +1,2 @@
+pulpogato.version=1.0.0-test
+github.api.version=2022-11-28-test

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
@@ -34,7 +34,7 @@ public class ProxyController {
     private final RestTemplate restTemplate;
 
     public ProxyController() {
-        // Configure RestTemplate with Apache HttpClient to support PATCH method
+        // Configure RestTemplate with Apache HttpClient to support the PATCH method
         var httpClient = HttpClients.createDefault();
         var requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
         this.restTemplate = new RestTemplate(requestFactory);
@@ -140,8 +140,9 @@ public class ProxyController {
         var requestHeadersMap = new HashMap<String, String>();
 
         request.getHeaderNames().asIterator().forEachRemaining(headerName -> {
-            if (Set.of("user-agent", "host", "TapeName", "Content-Length").stream()
-                    .noneMatch(it -> it.equalsIgnoreCase(headerName))) {
+            Set<String> excludedHeaders = Set.of(
+                    "user-agent", "host", "TapeName", "Content-Length", "X-GitHub-Api-Version", "X-Pulpogato-Version");
+            if (excludedHeaders.stream().noneMatch(it -> it.equalsIgnoreCase(headerName))) {
                 requestHeadersMap.put(headerName, request.getHeader(headerName));
             }
         });

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -36,7 +36,8 @@ codegen {
     packageName.set("io.github.pulpogato")
     mainDir.set(file("${project.layout.buildDirectory.get()}/generated-src/main/java"))
     testDir.set(file("${project.layout.buildDirectory.get()}/generated-src/test/java"))
-    apiVersion.set(project.ext.get("gh.api.commit").toString())
+    apiCommit.set(project.ext.get("gh.api.commit").toString())
+    apiVersion.set(project.ext.get("gh.api.version").toString())
     apiRepository.set(project.ext.get("gh.api.repo").toString())
     projectVariant.set(variant)
 }
@@ -145,6 +146,7 @@ val addSchemaInfoToBroker = tasks.register("addSchemaInfoToBroker") {
         val infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin::class.java)
         infoBrokerPlugin.add("GitHub-API-Repo", project.ext.get("gh.api.repo").toString())
         infoBrokerPlugin.add("GitHub-API-Commit", project.ext.get("gh.api.commit").toString())
+        infoBrokerPlugin.add("GitHub-API-Version", project.ext.get("gh.api.version").toString())
         infoBrokerPlugin.add("GitHub-API-SHA256", sha256)
     }
 }


### PR DESCRIPTION
- Introduce DefaultHeadersExchangeFunction to add `X-GitHub-Api-Version` and `X-Pulpogato-Version` headers to all requests
- Modify build process to include API version in generated artifacts
