### PR TITLE
refactor: Exclude byte[] from CachedResponse equals and hashCode

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachedResponse.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachedResponse.java
@@ -2,6 +2,10 @@ package io.github.pulpogato.common.cache;
 
 import java.util.List;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -12,20 +16,36 @@ import org.jspecify.annotations.Nullable;
  * the response was cached. This information is used to determine cache
  * freshness and to send conditional requests (If-None-Match, If-Modified-Since).
  *
- * @param body The cached response body as bytes
- * @param headers All response headers to preserve (Content-Type, etc.)
- * @param etag The ETag header value from the response, if present
- * @param lastModified The Last-Modified header value from the response, if present
- * @param maxAgeSeconds The max-age value from Cache-Control header in seconds, or -1 if not present
- * @param cachedAtMillis The system time in milliseconds when this response was cached
  */
-public record CachedResponse(
-        byte[] body,
-        Map<String, List<String>> headers,
-        @Nullable String etag,
-        @Nullable String lastModified,
-        long maxAgeSeconds,
-        long cachedAtMillis) {
+@EqualsAndHashCode(of = {"body", "headers", "etag", "lastModified", "maxAgeSeconds", "cachedAtMillis"})
+@ToString(of = {"headers", "etag", "lastModified", "maxAgeSeconds", "cachedAtMillis"})
+@RequiredArgsConstructor
+@Getter
+public final class CachedResponse {
+    /**
+     * The cached response body as bytes.
+     */
+    private final byte[] body;
+    /**
+     * All response headers to preserve ({@code Content-Type}, etc.).
+     */
+    private final Map<String, List<String>> headers;
+    /**
+     * The {@code ETag} header value from the response, if present.
+     */
+    private final @Nullable String etag;
+    /**
+     * The {@code Last-Modified} header value from the response, if present.
+     */
+    private final @Nullable String lastModified;
+    /**
+     * The max-age value from the {@code Cache-Control} header in seconds, or {@code -1} if not present.
+     */
+    private final long maxAgeSeconds;
+    /**
+     * The system time in milliseconds when this response was cached.
+     */
+    private final long cachedAtMillis;
 
     /**
      * Checks if this cached response has expired based on the max-age directive.

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -134,7 +134,7 @@ class CachingExchangeFilterFunctionTest {
 
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().etag()).isEqualTo("\"abc123\"");
+            assertThat(captor.getValue().getEtag()).isEqualTo("\"abc123\"");
         }
 
         @Test
@@ -152,7 +152,7 @@ class CachingExchangeFilterFunctionTest {
             assertThat(result).isNotNull();
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().lastModified()).isEqualTo("Wed, 21 Oct 2015 07:28:00 GMT");
+            assertThat(captor.getValue().getLastModified()).isEqualTo("Wed, 21 Oct 2015 07:28:00 GMT");
         }
 
         @Test
@@ -170,7 +170,7 @@ class CachingExchangeFilterFunctionTest {
             assertThat(result).isNotNull();
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().maxAgeSeconds()).isEqualTo(60);
+            assertThat(captor.getValue().getMaxAgeSeconds()).isEqualTo(60);
         }
 
         @Test
@@ -188,8 +188,8 @@ class CachingExchangeFilterFunctionTest {
             assertThat(result).isNotNull();
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().headers()).containsKey("Content-Type");
-            assertThat(captor.getValue().headers().get("Content-Type")).contains("application/json");
+            assertThat(captor.getValue().getHeaders()).containsKey("Content-Type");
+            assertThat(captor.getValue().getHeaders().get("Content-Type")).contains("application/json");
         }
     }
 
@@ -331,7 +331,7 @@ class CachingExchangeFilterFunctionTest {
 
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().etag()).isEqualTo("\"new\"");
+            assertThat(captor.getValue().getEtag()).isEqualTo("\"new\"");
         }
     }
 
@@ -429,8 +429,8 @@ class CachingExchangeFilterFunctionTest {
 
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
-            assertThat(captor.getValue().body()).hasSize(300_000);
-            assertThat(captor.getValue().etag()).isEqualTo("\"large-body\"");
+            assertThat(captor.getValue().getBody()).hasSize(300_000);
+            assertThat(captor.getValue().getEtag()).isEqualTo("\"large-body\"");
         }
 
         @Test


### PR DESCRIPTION
The prior implementation was not checking for equivalence.
