### PR TITLE
chore: Infer content type correctly

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -719,14 +719,12 @@ class PathsBuilder {
                 .mapNotNull { (k, v) ->
                     atomicMethod.operation.requestBody.content
                         .filterKeys { contentType -> contentType.lowercase().contains("json") }
-                        .map { (_, _) ->
+                        .map { (contentType, _) ->
                             TestBuilder.buildTest(
                                 context.withSchemaStack(
                                     "requestBody",
                                     "content",
-                                    atomicMethod.operation.requestBody.content
-                                        .firstEntry()
-                                        .key,
+                                    contentType,
                                     "examples",
                                     k,
                                     "value",


### PR DESCRIPTION
Prior to this change, we were making two calls to requestBody.content
