### PR TITLE
feat: Add Metrics from Headers from GitHub API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,11 +19,13 @@ jsonApi = "1.1.4"
 junit = "6.0.1"
 junitPlatformLauncher = "6.0.1"
 lombok = "1.18.42"
+micrometer = "1.12.3"
 mockito = "5.21.0"
 palantirJavaFormat = "2.83.0"
 pitest = "1.22.0"
 pitestJunit5Plugin = "1.2.3"
 pitestPlugin = "1.19.0-rc.2"
+reactor = "3.6.0"
 reflections = "0.10.2"
 slf4j = "2.0.17"
 spotless = "8.1.0"
@@ -58,9 +60,12 @@ junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-l
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 mockitoJunitJupiter = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito" }
+micrometerCore = { group = "io.micrometer", name = "micrometer-core", version.ref = "micrometer" }
+micrometerObservation = { group = "io.micrometer", name = "micrometer-observation", version.ref = "micrometer" }
 palantirJavaFormat = { group = "com.palantir.javaformat", name = "palantir-java-format", version.ref = "palantirJavaFormat" }
 pitest = { group = "org.pitest", name = "pitest", version.ref = "pitest" }
 pitestJunit5Plugin = { group = "org.pitest", name = "pitest-junit5-plugin", version.ref = "pitestJunit5Plugin" }
+reactorTest = {group = "io.projectreactor", name = "reactor-test", version.ref = "reactor"}
 reflections = { group = "org.reflections", name = "reflections", version.ref = "reflections" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }

--- a/pulpogato-common/build.gradle.kts
+++ b/pulpogato-common/build.gradle.kts
@@ -8,11 +8,13 @@ plugins {
     alias(libs.plugins.pitest)
 }
 
-val mockitoAgent = configurations.create("mockitoAgent")
+val mockitoAgent by configurations.creating
 
 dependencies {
     compileOnly(libs.jspecify)
     compileOnly(libs.lombok)
+    compileOnly(libs.micrometerCore)
+    compileOnly(libs.micrometerObservation)
     compileOnly(libs.springBootWebflux)
 
     annotationProcessor(libs.lombok)
@@ -29,8 +31,11 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.junit)
+    testImplementation(libs.micrometerCore)
+    testImplementation(libs.micrometerObservation)
     testImplementation(libs.mockito)
     testImplementation(libs.mockitoJunitJupiter)
+    testImplementation(libs.reactorTest)
     testImplementation(libs.springBootWebflux)
 
     testRuntimeOnly(libs.junitPlatformLauncher)

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/client/MetricsExchangeFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/client/MetricsExchangeFunction.java
@@ -1,0 +1,113 @@
+package io.github.pulpogato.common.client;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongConsumer;
+import lombok.Builder;
+import org.jspecify.annotations.NonNull;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+/**
+ * A class that implements the {@link ExchangeFilterFunction} interface to capture
+ * and record rate limit metrics from HTTP responses, typically for GitHub API usage.
+ * Metrics are extracted from specific response headers and reported to a {@link MeterRegistry}.
+ * This is particularly useful for monitoring API rate limits and ensuring that
+ * applications can appropriately handle rate limit constraints.
+ *
+ * <h2>Functionality</h2>
+ * The following HTTP headers are monitored for rate limit metrics:
+ * <ul>
+ *   <li> {@code x-ratelimit-limit}: The maximum number of requests that can be made.
+ *   <li> {@code x-ratelimit-remaining}: The number of requests remaining in the current limit window.
+ *   <li> {@code x-ratelimit-used}: The number of requests already used.
+ *   <li> {@code x-ratelimit-reset}: The timestamp for when the rate limit resets.
+ *   <li> {@code x-ratelimit-resource}: The resource for which the rate limit applies.
+ * </ul>
+ */
+@Builder
+public class MetricsExchangeFunction implements ExchangeFilterFunction {
+
+    private static final String RATE_LIMIT_LIMIT = "x-ratelimit-limit";
+    private static final String RATE_LIMIT_REMAINING = "x-ratelimit-remaining";
+    private static final String RATE_LIMIT_USED = "x-ratelimit-used";
+    private static final String RATE_LIMIT_RESET = "x-ratelimit-reset";
+    private static final String RATE_LIMIT_RESOURCE = "x-ratelimit-resource";
+
+    /**
+     * A registry instance used to record and manage application metrics.
+     * This is used for monitoring and gathering metrics data related to
+     * rate limiting and other quantifiable events during HTTP request processing.
+     */
+    private final MeterRegistry registry;
+    /**
+     * The `clock` variable represents the system's default implementation of a clock,
+     * which is used for retrieving the current date and time.
+     * <p>
+     * By default, it is initialized to the UTC time zone using {@link Clock#systemUTC()}.
+     */
+    @Builder.Default
+    private final Clock clock = Clock.systemUTC();
+    /**
+     * The base prefix used for naming metrics related to GitHub API rate limits.
+     */
+    @Builder.Default
+    private final String prefix = "github.api.rateLimit";
+    /**
+     * A list of default tags applied to all metrics recorded by the {@code MetricsExchangeFunction}.
+     */
+    @Builder.Default
+    private final List<Tag> defaultTags = List.of();
+
+    @Override
+    @NonNull
+    public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        return next.exchange(request).doOnNext(this::recordRateLimitMetrics);
+    }
+
+    private void withNumericHeader(ClientResponse response, String headerName, LongConsumer consumer) {
+        var value = getFirstHeader(response, headerName);
+        if (value != null) {
+            try {
+                var numericValue = Long.parseLong(value);
+                consumer.accept(numericValue);
+            } catch (NumberFormatException ignore) {
+                // ignore this
+            }
+        }
+    }
+
+    private void recordRateLimitMetrics(ClientResponse response) {
+        // Extract rate limit headers
+        String resource = getFirstHeader(response, RATE_LIMIT_RESOURCE);
+
+        // Create tags for the metrics
+        List<Tag> tags = new ArrayList<>(defaultTags);
+        tags.add(Tag.of("resource", resource != null ? resource : "unknown"));
+
+        withNumericHeader(response, RATE_LIMIT_LIMIT, v -> registry.gauge(prefix + ".limit", tags, v));
+        withNumericHeader(response, RATE_LIMIT_REMAINING, v -> registry.gauge(prefix + ".remaining", tags, v));
+        withNumericHeader(response, RATE_LIMIT_USED, v -> registry.gauge(prefix + ".used", tags, v));
+        withNumericHeader(
+                response,
+                RATE_LIMIT_RESET,
+                resetValue -> registry.gauge(
+                        prefix + ".secondsToReset",
+                        tags,
+                        resetValue - clock.instant().getEpochSecond()));
+    }
+
+    private String getFirstHeader(ClientResponse response, String headerName) {
+        List<String> headerValues = response.headers().header(headerName);
+        if (headerValues != null && !headerValues.isEmpty()) {
+            return headerValues.getFirst();
+        }
+        return null;
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/client/MetricsExchangeFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/client/MetricsExchangeFunctionTest.java
@@ -1,0 +1,141 @@
+package io.github.pulpogato.common.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.internal.DefaultGauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsExchangeFunctionTest {
+
+    private final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+    private MeterRegistry meterRegistry;
+
+    @Mock
+    private ExchangeFunction exchangeFunction;
+
+    @Mock
+    private ClientResponse response;
+
+    @Mock
+    private ClientResponse.Headers headers;
+
+    private MetricsExchangeFunction metricsExchangeFunction;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        metricsExchangeFunction = MetricsExchangeFunction.builder()
+                .registry(meterRegistry)
+                .clock(clock)
+                .build();
+    }
+
+    @Test
+    void testRateLimitMetricsAreRecorded() {
+        // GIVEN
+        Instant now = clock.instant();
+        Instant hourLater = now.plus(1, ChronoUnit.HOURS);
+
+        given(headers.header("x-ratelimit-limit")).willReturn(List.of("5000"));
+        given(headers.header("x-ratelimit-remaining")).willReturn(List.of("4999"));
+        given(headers.header("x-ratelimit-used")).willReturn(List.of("1"));
+        given(headers.header("x-ratelimit-reset")).willReturn(List.of(String.valueOf(hourLater.getEpochSecond())));
+        given(headers.header("x-ratelimit-resource")).willReturn(List.of("core"));
+        given(response.headers()).willReturn(headers);
+
+        given(exchangeFunction.exchange(any(ClientRequest.class))).willReturn(Mono.just(response));
+
+        // WHEN
+        ClientRequest clientRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.github.com/test"))
+                .build();
+
+        StepVerifier.create(metricsExchangeFunction.filter(clientRequest, exchangeFunction))
+                .expectNext(response)
+                .verifyComplete();
+
+        // THEN
+        var meters = meterRegistry.getMeters();
+        assertThat(meters)
+                .isNotEmpty()
+                .hasSize(4)
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.limit");
+                    assertThat(meter.getId().getTag("resource")).isEqualTo("core");
+                    assertThat(meter).isInstanceOf(DefaultGauge.class);
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(5000);
+                })
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.remaining");
+                    assertThat(meter.getId().getTag("resource")).isEqualTo("core");
+                    assertThat(meter).isInstanceOf(DefaultGauge.class);
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(4999);
+                })
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.used");
+                    assertThat(meter.getId().getTag("resource")).isEqualTo("core");
+                    assertThat(meter).isInstanceOf(DefaultGauge.class);
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(1);
+                })
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.secondsToReset");
+                    assertThat(meter.getId().getTag("resource")).isEqualTo("core");
+                    assertThat(meter).isInstanceOf(DefaultGauge.class);
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(3600);
+                });
+    }
+
+    @Test
+    void testRateLimitMetricsWithMissingHeaders() {
+        // GIVEN
+        given(headers.header("x-ratelimit-limit")).willReturn(List.of("5000"));
+        given(headers.header("x-ratelimit-remaining")).willReturn(null);
+        given(headers.header("x-ratelimit-used")).willReturn(null);
+        given(headers.header("x-ratelimit-reset")).willReturn(null);
+        given(headers.header("x-ratelimit-resource")).willReturn(null);
+        given(response.headers()).willReturn(headers);
+
+        given(exchangeFunction.exchange(any(ClientRequest.class))).willReturn(Mono.just(response));
+
+        // WHEN
+        ClientRequest clientRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.github.com/test"))
+                .build();
+
+        StepVerifier.create(metricsExchangeFunction.filter(clientRequest, exchangeFunction))
+                .expectNext(response)
+                .verifyComplete();
+
+        // THEN
+        var meters = meterRegistry.getMeters();
+        assertThat(meters).isNotEmpty().hasSize(1);
+        var theMeter = meters.getFirst();
+        assertThat(theMeter).isInstanceOf(DefaultGauge.class);
+        assertThat(theMeter.getId().getName()).isEqualTo("github.api.rateLimit.limit");
+        var gauge = (DefaultGauge) theMeter;
+        assertThat(gauge.value()).isEqualTo(5000);
+    }
+}


### PR DESCRIPTION
This should help monitoring systems understand rate limits.

It needs to be configured with a valid Metrics Registry.
