### PR TITLE
chore: Remove task dependency

### DIFF
--- a/gradle/pulpogato-rest-codegen/build.gradle.kts
+++ b/gradle/pulpogato-rest-codegen/build.gradle.kts
@@ -72,10 +72,6 @@ pitest {
     excludedTestClasses.set(listOf("io.github.pulpogato.restcodegen.RestCodegenPluginTest"))
 }
 
-tasks.named("pitest") {
-    dependsOn("pluginUnderTestMetadata")
-}
-
 spotless {
     kotlin {
         ktlint()


### PR DESCRIPTION
pitest depended on pluginUnderTestMetadata.
That's not required after https://github.com/szpak/gradle-pitest-plugin/issues/386 was fixed.
