### PR TITLE
feat(codegen): use schema title for naming oneOf/anyOf sub-schemas

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -443,6 +443,8 @@ private fun buildFancyObject(
             var newKey = entry.key + index
             if (it.`$ref` != null) {
                 newKey = it.`$ref`.replace("#/components/schemas/", "")
+            } else if (it.title != null) {
+                newKey = it.title
             }
             newKey to it
         }.forEachIndexed { index, (newKey, subSchema) ->


### PR DESCRIPTION
This ensures more semantic names (e.g., 'User' instead of 'RequestedReviewers0') when a direct reference is not available but a title is provided.
