### PR TITLE
feat: Support isOneOfOnlyForValidation

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -84,12 +84,22 @@ fun typesAre(
 fun isAnyOfOnlyForValidation(
     anyOf: List<Schema<Any>>,
     parentSchema: Schema<*>,
+): Boolean = isOnlyForValidation(anyOf, parentSchema)
+
+fun isOneOfOnlyForValidation(
+    oneOf: List<Schema<Any>>,
+    parentSchema: Schema<*>,
+): Boolean = isOnlyForValidation(oneOf, parentSchema)
+
+private fun isOnlyForValidation(
+    subSchemas: List<Schema<Any>>,
+    parentSchema: Schema<*>,
 ): Boolean {
     if (parentSchema.properties == null || parentSchema.properties.isEmpty()) {
         return false
     }
 
-    return anyOf.all { subSchema ->
+    return subSchemas.all { subSchema ->
         (subSchema.properties == null || subSchema.properties.isEmpty()) &&
             subSchema.`$ref` == null &&
             (subSchema.types == null || subSchema.types.isEmpty()) &&
@@ -161,6 +171,10 @@ fun referenceAndDefinition(
             buildType("${prefix}${entry.className()}", parentClass) {
                 buildFancyObject(context, entry, anyOf, "anyOf", it)
             }
+        }
+
+        oneOf != null && isOneOfOnlyForValidation(oneOf, entry.value) -> {
+            buildType("${prefix}${entry.className()}", parentClass) { buildSimpleObject(context, entry, it) }
         }
 
         oneOf != null -> {

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensionsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensionsTest.kt
@@ -101,4 +101,65 @@ class SchemaExtensionsTest {
 
         assertThat(typesAre(oneOf, "string", "boolean")).isFalse()
     }
+
+    @Test
+    fun `isOneOfOnlyForValidation returns true for oneOf with only required constraints`() {
+        val oneOfSchema1 =
+            Schema<Any>().apply {
+                required = listOf("code_scanning_alerts")
+            }
+        val oneOfSchema2 =
+            Schema<Any>().apply {
+                required = listOf("secret_scanning_alerts")
+            }
+
+        val parentSchema =
+            Schema<Any>().apply {
+                type = "object"
+                properties =
+                    mapOf(
+                        "name" to Schema<Any>().apply { type = "string" },
+                        "code_scanning_alerts" to Schema<Any>().apply { type = "array" },
+                        "secret_scanning_alerts" to Schema<Any>().apply { type = "array" },
+                    )
+            }
+
+        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isTrue()
+    }
+
+    @Test
+    fun `isOneOfOnlyForValidation returns false for oneOf with type definitions`() {
+        val oneOfSchema1 =
+            Schema<Any>().apply {
+                type = "object"
+                types = setOf("object")
+                properties = mapOf("field1" to Schema<Any>().apply { type = "string" })
+            }
+        val oneOfSchema2 =
+            Schema<Any>().apply {
+                type = "object"
+                types = setOf("object")
+                properties = mapOf("field2" to Schema<Any>().apply { type = "integer" })
+            }
+
+        val parentSchema =
+            Schema<Any>().apply {
+                type = "object"
+                properties = mapOf("name" to Schema<Any>().apply { type = "string" })
+            }
+
+        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isFalse()
+    }
+
+    @Test
+    fun `isOneOfOnlyForValidation returns false when parent has no properties`() {
+        val oneOfSchema =
+            Schema<Any>().apply {
+                required = listOf("code_scanning_alerts")
+            }
+
+        val parentSchema = Schema<Any>()
+
+        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema), parentSchema)).isFalse()
+    }
 }


### PR DESCRIPTION
This fixes the generated types for `io.github.pulpogato.rest.api.CampaignsApi.CreateCampaignRequestBody`
