### PR TITLE
chore: Update schema version to `3237c14`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.parallel=true
 gh.api.repo=github/rest-api-description
 
 # GitHub REST API Description SHA
-gh.api.commit=04fd6c5
+gh.api.commit=3237c14
 
 gh.api.version=2022-11-28

--- a/pulpogato-common/src/main/resources/issueComment.pin.schema.json
+++ b/pulpogato-common/src/main/resources/issueComment.pin.schema.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Additions Schema",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "pinned-issue-comment": {
+        "title": "Pinned Issue Comment",
+        "description": "Metadata about a pinned issue comment. This schema is missing from the upstream OpenAPI spec. See: https://github.com/github/rest-api-description/issues/5938",
+        "type": "object",
+        "properties": {
+          "pinned_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time the comment was pinned"
+          },
+          "pinned_by": {
+            "anyOf": [ {
+              "type": "null"
+            }, {
+              "$ref": "#/components/schemas/simple-user"
+            } ],
+            "description": "The user who pinned the comment"
+          }
+        }
+      }
+    }
+  },
+  "paths": { }
+}


### PR DESCRIPTION
This requires introducing a new schema for `pinned-issue-comment` which is referenced in `issue-comment.pin` but not defined.

This is related to https://github.com/github/rest-api-description/issues/5938
