### PR TITLE
fix(metrics): Address warnings from Metrics

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/client/MetricsExchangeFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/client/MetricsExchangeFunction.java
@@ -5,6 +5,8 @@ import io.micrometer.core.instrument.Tag;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 import lombok.Builder;
 import org.jspecify.annotations.NonNull;
@@ -65,6 +67,8 @@ public class MetricsExchangeFunction implements ExchangeFilterFunction {
     @Builder.Default
     private final List<Tag> defaultTags = List.of();
 
+    private final ConcurrentHashMap<String, AtomicLong> gauges = new ConcurrentHashMap<>();
+
     @Override
     @NonNull
     public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
@@ -84,23 +88,31 @@ public class MetricsExchangeFunction implements ExchangeFilterFunction {
     }
 
     private void recordRateLimitMetrics(ClientResponse response) {
-        // Extract rate limit headers
         String resource = getFirstHeader(response, RATE_LIMIT_RESOURCE);
 
-        // Create tags for the metrics
         List<Tag> tags = new ArrayList<>(defaultTags);
         tags.add(Tag.of("resource", resource != null ? resource : "unknown"));
 
-        withNumericHeader(response, RATE_LIMIT_LIMIT, v -> registry.gauge(prefix + ".limit", tags, v));
-        withNumericHeader(response, RATE_LIMIT_REMAINING, v -> registry.gauge(prefix + ".remaining", tags, v));
-        withNumericHeader(response, RATE_LIMIT_USED, v -> registry.gauge(prefix + ".used", tags, v));
+        withNumericHeader(response, RATE_LIMIT_LIMIT, v -> setGauge(prefix + ".limit", tags, v));
+        withNumericHeader(response, RATE_LIMIT_REMAINING, v -> setGauge(prefix + ".remaining", tags, v));
+        withNumericHeader(response, RATE_LIMIT_USED, v -> setGauge(prefix + ".used", tags, v));
         withNumericHeader(
                 response,
                 RATE_LIMIT_RESET,
-                resetValue -> registry.gauge(
+                resetValue -> setGauge(
                         prefix + ".secondsToReset",
                         tags,
                         resetValue - clock.instant().getEpochSecond()));
+    }
+
+    private void setGauge(String name, List<Tag> tags, long value) {
+        var key = name + "/" + tags;
+        var ref = gauges.computeIfAbsent(key, k -> {
+            var atomicLong = new AtomicLong(value);
+            registry.gauge(name, tags, atomicLong, AtomicLong::get);
+            return atomicLong;
+        });
+        ref.set(value);
     }
 
     private String getFirstHeader(ClientResponse response, String headerName) {

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/client/MetricsExchangeFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/client/MetricsExchangeFunctionTest.java
@@ -110,6 +110,60 @@ class MetricsExchangeFunctionTest {
     }
 
     @Test
+    void testGaugeValuesUpdateOnSubsequentResponses() {
+        // GIVEN - first response
+        Instant now = clock.instant();
+        Instant hourLater = now.plus(1, ChronoUnit.HOURS);
+
+        given(headers.header("x-ratelimit-limit")).willReturn(List.of("5000"));
+        given(headers.header("x-ratelimit-remaining")).willReturn(List.of("4999"));
+        given(headers.header("x-ratelimit-used")).willReturn(List.of("1"));
+        given(headers.header("x-ratelimit-reset")).willReturn(List.of(String.valueOf(hourLater.getEpochSecond())));
+        given(headers.header("x-ratelimit-resource")).willReturn(List.of("core"));
+        given(response.headers()).willReturn(headers);
+        given(exchangeFunction.exchange(any(ClientRequest.class))).willReturn(Mono.just(response));
+
+        var clientRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.github.com/test"))
+                .build();
+
+        StepVerifier.create(metricsExchangeFunction.filter(clientRequest, exchangeFunction))
+                .expectNext(response)
+                .verifyComplete();
+
+        // GIVEN - second response with different values
+        ClientResponse response2 = org.mockito.Mockito.mock(ClientResponse.class);
+        ClientResponse.Headers headers2 = org.mockito.Mockito.mock(ClientResponse.Headers.class);
+        given(headers2.header("x-ratelimit-limit")).willReturn(List.of("5000"));
+        given(headers2.header("x-ratelimit-remaining")).willReturn(List.of("4990"));
+        given(headers2.header("x-ratelimit-used")).willReturn(List.of("10"));
+        given(headers2.header("x-ratelimit-reset")).willReturn(List.of(String.valueOf(hourLater.getEpochSecond())));
+        given(headers2.header("x-ratelimit-resource")).willReturn(List.of("core"));
+        given(response2.headers()).willReturn(headers2);
+        given(exchangeFunction.exchange(any(ClientRequest.class))).willReturn(Mono.just(response2));
+
+        // WHEN - second call
+        StepVerifier.create(metricsExchangeFunction.filter(clientRequest, exchangeFunction))
+                .expectNext(response2)
+                .verifyComplete();
+
+        // THEN - still only 4 meters, values reflect the second response
+        var meters = meterRegistry.getMeters();
+        assertThat(meters).hasSize(4);
+
+        assertThat(meters)
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.remaining");
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(4990);
+                })
+                .anySatisfy(meter -> {
+                    assertThat(meter.getId().getName()).isEqualTo("github.api.rateLimit.used");
+                    var gauge = (DefaultGauge) meter;
+                    assertThat(gauge.value()).isEqualTo(10);
+                });
+    }
+
+    @Test
     void testRateLimitMetricsWithMissingHeaders() {
         // GIVEN
         given(headers.header("x-ratelimit-limit")).willReturn(List.of("5000"));


### PR DESCRIPTION
We're seeing warnings like

```
This Gauge has been already registered (MeterId{name='github.api.rateLimit.limit', tags=[tag(clientType=rest),...,tag(resource=core)]}), the registration will be ignored. Note that subsequent logs will be logged at debug level.
```
