### PR TITLE
feat(github-files): add GitHub Actions typing schema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,16 @@ tasks.register<UpdateRepositoryBranchPropertyTask>("updateSchemastoreVersion") {
     gitHubToken.set(providers.environmentVariable("GITHUB_TOKEN").orElse(""))
 }
 
+tasks.register<UpdateRepositoryBranchPropertyTask>("updateGithubActionsTypingSchemaVersion") {
+    description = "Update GitHub Actions typing schema version from typesafegithub/github-actions-typing"
+    group = "maintenance"
+    repository.set(project.ext["gh.actions.typing.repo"].toString())
+    branch.set("schema-latest")
+    propertyName.set("gh.actions.typing.commit")
+    propertiesFile.set(layout.projectDirectory.file("gradle.properties"))
+    gitHubToken.set(providers.environmentVariable("GITHUB_TOKEN").orElse(""))
+}
+
 val checkPlugin =
     tasks.register("checkPlugin", Exec::class) {
         description = "Run check on plugin code"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ gh.api.version=2022-11-28
 # Schemastore
 schemastore.repo=schemastore/schemastore
 schemastore.commit=4a030d4
+
+# GitHub Actions typing schema
+gh.actions.typing.repo=typesafegithub/github-actions-typing
+gh.actions.typing.commit=f9d0e25

--- a/pulpogato-github-files/build.gradle.kts
+++ b/pulpogato-github-files/build.gradle.kts
@@ -14,24 +14,94 @@ plugins {
 
 val schemastoreRepo = project.ext["schemastore.repo"].toString()
 val schemastoreCommit = project.ext["schemastore.commit"].toString()
+val githubActionsTypingRepo = project.ext["gh.actions.typing.repo"].toString()
+val githubActionsTypingCommit = project.ext["gh.actions.typing.commit"].toString()
 
 description = "Java types for GitHub file configuration schemas"
 
 data class SchemaSpec(
     val filename: String,
     val subpackage: String,
+    val sourceName: String,
+    val sourceDescription: String,
+    val sourceCommit: String,
+    val sourceUrl: String,
 )
 
 val schemas =
     listOf(
-        SchemaSpec("github-action.json", "actions"),
-        SchemaSpec("github-discussion.json", "discussion"),
-        SchemaSpec("github-funding.json", "funding"),
-        SchemaSpec("github-issue-config.json", "issueconfig"),
-        SchemaSpec("github-issue-forms.json", "issueforms"),
-        SchemaSpec("github-release-config.json", "releases"),
-        SchemaSpec("github-workflow.json", "workflows"),
-        SchemaSpec("github-workflow-template-properties.json", "workflowtemplates"),
+        SchemaSpec(
+            "github-action.json",
+            "actions",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-action.json",
+        ),
+        SchemaSpec(
+            "github-actions-typing.schema.json",
+            "actionstyping",
+            "Github-Actions-Typing",
+            "typesafegithub/github-actions-typing",
+            githubActionsTypingCommit,
+            "https://raw.githubusercontent.com/$githubActionsTypingRepo/$githubActionsTypingCommit/github-actions-typing.schema.json",
+        ),
+        SchemaSpec(
+            "github-discussion.json",
+            "discussion",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-discussion.json",
+        ),
+        SchemaSpec(
+            "github-funding.json",
+            "funding",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-funding.json",
+        ),
+        SchemaSpec(
+            "github-issue-config.json",
+            "issueconfig",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-issue-config.json",
+        ),
+        SchemaSpec(
+            "github-issue-forms.json",
+            "issueforms",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-issue-forms.json",
+        ),
+        SchemaSpec(
+            "github-release-config.json",
+            "releases",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-release-config.json",
+        ),
+        SchemaSpec(
+            "github-workflow.json",
+            "workflows",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-workflow.json",
+        ),
+        SchemaSpec(
+            "github-workflow-template-properties.json",
+            "workflowtemplates",
+            "Schemastore",
+            "schemastore",
+            schemastoreCommit,
+            "https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/github-workflow-template-properties.json",
+        ),
     )
 
 val downloadAllSchemas =
@@ -46,8 +116,8 @@ schemas.forEach { spec ->
     val downloadTask =
         tasks.register<Download>("downloadSchema$taskSuffix") {
             group = "code generation"
-            description = "Download ${spec.filename} from schemastore"
-            src("https://raw.githubusercontent.com/$schemastoreRepo/$schemastoreCommit/src/schemas/json/${spec.filename}")
+            description = "Download ${spec.filename} from ${spec.sourceDescription}"
+            src(spec.sourceUrl)
             dest(project.layout.buildDirectory.file("generated-src/main/resources/${spec.filename}"))
             overwrite(false)
         }
@@ -57,26 +127,38 @@ schemas.forEach { spec ->
 
 val addSchemaInfoToBroker =
     tasks.register<WriteInfoPropertiesTask>("addSchemaInfoToBroker") {
-        description = "Writes schema metadata (checksum, schemastore commit) to info.properties for the info broker plugin"
+        description = "Writes schema metadata (checksums, source commits) to info.properties for the info broker plugin"
         group = "build setup"
         dependsOn(downloadAllSchemas)
-        staticEntries.put("Schemastore-Commit", schemastoreCommit)
+        schemas
+            .associate { it.sourceName to it.sourceCommit }
+            .forEach { (sourceName, sourceCommit) ->
+                staticEntries.put("$sourceName-Commit", sourceCommit)
+            }
         schemas.forEach { spec ->
             checksumFiles.from(project.layout.buildDirectory.file("generated-src/main/resources/${spec.filename}"))
             val label = spec.subpackage.replaceFirstChar { it.uppercase() }
-            checksumEntriesByFilename.put(spec.filename, "Schemastore-$label-SHA256")
+            checksumEntriesByFilename.put(spec.filename, "${spec.sourceName}-$label-SHA256")
         }
         outputFile.set(layout.buildDirectory.file("reports/schema-info.properties"))
     }
 
 val infoPropertiesFile = addSchemaInfoToBroker.flatMap { it.outputFile }
 val infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin::class.java)
-infoBrokerPlugin.add("Schemastore-Commit", PropertiesFileValueClosure(infoPropertiesFile.get().asFile, "Schemastore-Commit"))
+schemas
+    .map { it.sourceName }
+    .distinct()
+    .forEach { sourceName ->
+        infoBrokerPlugin.add(
+            "$sourceName-Commit",
+            PropertiesFileValueClosure(infoPropertiesFile.get().asFile, "$sourceName-Commit"),
+        )
+    }
 schemas.forEach { spec ->
     val label = spec.subpackage.replaceFirstChar { it.uppercase() }
     infoBrokerPlugin.add(
-        "Schemastore-$label-SHA256",
-        PropertiesFileValueClosure(infoPropertiesFile.get().asFile, "Schemastore-$label-SHA256"),
+        "${spec.sourceName}-$label-SHA256",
+        PropertiesFileValueClosure(infoPropertiesFile.get().asFile, "${spec.sourceName}-$label-SHA256"),
     )
 }
 

--- a/pulpogato-github-files/src/test/java/io/github/pulpogato/githubfiles/GithubActionsTypingDeserializationTest.java
+++ b/pulpogato-github-files/src/test/java/io/github/pulpogato/githubfiles/GithubActionsTypingDeserializationTest.java
@@ -1,0 +1,73 @@
+package io.github.pulpogato.githubfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.pulpogato.githubfiles.actionstyping.TopLevelOrNull;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GithubActionsTypingDeserializationTest {
+
+    static Stream<Mappers.MapperPair> mappers() {
+        return Mappers.mappers();
+    }
+
+    @Language("yaml")
+    private static final String YAML = """
+            inputs:
+              log-level:
+                type: enum
+                allowed-values:
+                  - debug
+                  - info
+              retries:
+                type: integer
+                named-values:
+                  default: 3
+              paths:
+                type: list
+                separator: ","
+                list-item:
+                  type: string
+            outputs:
+              artifact-id:
+                type: string
+            """;
+
+    @ParameterizedTest
+    @MethodSource("mappers")
+    void deserializesInputsAndOutputs(Mappers.MapperPair mp) throws Exception {
+        var typing = mp.yamlMapper().readValue(YAML, TopLevelOrNull.class);
+
+        assertThat(typing.getInputs()).containsKeys("log-level", "retries", "paths");
+        assertThat(typing.getOutputs()).containsKey("artifact-id");
+
+        var logLevel = typing.getInputs().get("log-level");
+        assertThat(logLevel)
+                .containsEntry("type", "enum")
+                .containsEntry("allowed-values", java.util.List.of("debug", "info"));
+
+        var retries = typing.getInputs().get("retries");
+        assertThat(retries).containsEntry("type", "integer").containsEntry("named-values", Map.of("default", 3));
+
+        var paths = typing.getInputs().get("paths");
+        assertThat(paths)
+                .containsEntry("type", "list")
+                .containsEntry("separator", ",")
+                .containsEntry("list-item", Map.of("type", "string"));
+
+        assertThat(typing.getOutputs().get("artifact-id")).containsEntry("type", "string");
+    }
+
+    @ParameterizedTest
+    @MethodSource("mappers")
+    void roundTripsViaJson(Mappers.MapperPair mp) throws Exception {
+        var typing = mp.yamlMapper().readValue(YAML, TopLevelOrNull.class);
+        var json = mp.jsonMapper().writeValueAsString(typing);
+        var roundTripped = mp.jsonMapper().readValue(json, TopLevelOrNull.class);
+        assertThat(roundTripped).isEqualTo(typing);
+    }
+}

--- a/scripts/update-schema-version.sh
+++ b/scripts/update-schema-version.sh
@@ -86,3 +86,10 @@ update_and_pr \
     "schemastore.commit" \
     "update-schemastore-version" \
     "${SCHEMASTORE_REPO}"
+
+GH_ACTIONS_TYPING_REPO=$(grep "gh.actions.typing.repo=" gradle.properties | cut -d'=' -f2)
+update_and_pr \
+    "updateGithubActionsTypingSchemaVersion" \
+    "gh.actions.typing.commit" \
+    "update-github-actions-typing-schema-version" \
+    "${GH_ACTIONS_TYPING_REPO}"


### PR DESCRIPTION
## Summary
- add the GitHub Actions typing schema to 
- pin that schema to a tracked upstream commit in 
- include the schema in the update workflow and add a deserialization regression test

## Verification
- ./gradlew :pulpogato-github-files:test
- ./gradlew check --max-workers=3