### PR TITLE
fix(build): Use correct dependency type

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -94,14 +95,16 @@ open class GenerateJavaTask : DefaultTask() {
     /**
      * The common resources directory for schema additions.
      */
-    @Input
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     val commonResourcesDir: Property<File> = project.objects.property(File::class.java)
 
     /**
      * The module resources directory for schema additions.
      */
-    @Input
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     val moduleResourcesDir: Property<File> = project.objects.property(File::class.java)
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
@@ -42,8 +42,18 @@ class RestCodegenPlugin : Plugin<Project> {
                 }
             rootProjectDir.set(target.rootProject.projectDir)
             projectDir.set(target.projectDir)
-            commonResourcesDir.set(target.rootProject.projectDir.resolve("pulpogato-common/src/main/resources"))
-            moduleResourcesDir.set(target.projectDir.resolve("src/main/resources"))
+            commonResourcesDir.set(
+                target.provider {
+                    val dir = target.rootProject.projectDir.resolve("pulpogato-common/src/main/resources")
+                    if (dir.exists()) dir else null
+                },
+            )
+            moduleResourcesDir.set(
+                target.provider {
+                    val dir = target.projectDir.resolve("src/main/resources")
+                    if (dir.exists()) dir else null
+                },
+            )
         }
     }
 }


### PR DESCRIPTION
We used to annotate `commonResourcesDir` and `moduleResourcesDir` as `@Input` - so when files there changed, it would not rerun the task.

Now it's `@InputDirectory` - so it should work.
