### PR TITLE
fix(deps): upgrade graphql-dgs-client to v12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ commonmark = "0.28.0"
 commons-lang3 = "3.20.0"
 commons-text = "1.15.0"
 dgs = "8.5.0"
-dgsClient = "11.1.0"
+dgsClient = "12.0.0"
 download = "5.7.0"
 groovy = "5.0.5"
 jackson2 = "2.21.3"
@@ -51,10 +51,14 @@ glassfishJson = { group = "org.glassfish", name = "javax.json", version.ref = "g
 groovy = { group = "org.apache.groovy", name = "groovy-all", version.ref = "groovy" }
 httpclient5 = { group = "org.apache.httpcomponents.client5", name = "httpclient5", version.ref = "httpclient5" }
 jackson2Core = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson2" }
+jackson2Jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version.ref = "jackson2" }
 jackson2Time = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson2" }
 jackson2Yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson2" }
 jackson3Core = { group = "tools.jackson.core", name = "jackson-databind", version.ref = "jackson3" }
+jackson3ModuleKotlin = { group = "tools.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson3" }
 jackson3Yaml = { group = "tools.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson3" }
+jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson2" }
+jacksonModuleParameterNames = { group = "com.fasterxml.jackson.module", name = "jackson-module-parameter-names", version.ref = "jackson2" }
 jakartaAnnotations = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakarta" }
 javapoet = { group = "com.palantir.javapoet", name = "javapoet", version.ref = "javapoet" }
 jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }

--- a/graphql.gradle.kts
+++ b/graphql.gradle.kts
@@ -15,7 +15,6 @@ plugins {
 }
 
 dependencies {
-    api(libs.jackson3Core)
     api(project(":pulpogato-common"))
 
     compileOnly(libs.jakartaAnnotations)
@@ -23,6 +22,10 @@ dependencies {
     testImplementation(libs.bundles.springBoot)
     testImplementation(libs.dgsClient)
     testImplementation(project(":${rootProject.name}-rest-tests"))
+    testRuntimeOnly(libs.jackson2Jdk8)
+    testRuntimeOnly(libs.jackson3ModuleKotlin)
+    testRuntimeOnly(libs.jacksonModuleKotlin)
+    testRuntimeOnly(libs.jacksonModuleParameterNames)
 }
 
 fun getUrl(projectVariant: String): String {

--- a/pulpogato-graphql-fpt/src/test/java/io/github/pulpogato/graphql/FindOpenPullRequestsTest.java
+++ b/pulpogato-graphql-fpt/src/test/java/io/github/pulpogato/graphql/FindOpenPullRequestsTest.java
@@ -2,9 +2,13 @@ package io.github.pulpogato.graphql;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import com.netflix.graphql.dgs.client.WebClientGraphQLClient;
+import com.netflix.graphql.dgs.client.DgsWebClientGraphQLClient;
+import com.netflix.graphql.dgs.client.Jackson2DgsJsonMapperAdapter;
+import com.netflix.graphql.dgs.client.Jackson3DgsJsonMapperAdapter;
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
+import com.netflix.graphql.dgs.json.DgsJsonMapper;
 import io.github.pulpogato.common.util.LinkedHashMapBuilder;
 import io.github.pulpogato.graphql.client.RepositoryGraphQLQuery;
 import io.github.pulpogato.graphql.client.RepositoryProjectionRoot;
@@ -20,8 +24,11 @@ import io.github.pulpogato.graphql.types.User;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Stream;
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class FindOpenPullRequestsTest extends BaseIntegrationTest {
     // tag::query[]
@@ -60,11 +67,18 @@ class FindOpenPullRequestsTest extends BaseIntegrationTest {
         """;
     // end::query[]
 
-    @Test
-    void testFindOpenPullRequestsQuery() {
+    static Stream<Arguments> mappers() {
+        return Stream.of(
+                arguments("jackson2", Jackson2DgsJsonMapperAdapter.fromOptions()),
+                arguments("jackson3", Jackson3DgsJsonMapperAdapter.fromOptions()));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("mappers")
+    void testFindOpenPullRequestsQuery(String mapperName, DgsJsonMapper mapper) {
         var graphqlWebClient = webClient.mutate().baseUrl("/graphql").build();
         // tag::execute[]
-        WebClientGraphQLClient graphQLClient = new WebClientGraphQLClient(graphqlWebClient);
+        var graphQLClient = new DgsWebClientGraphQLClient(graphqlWebClient, h -> {}, mapper);
 
         var variables = LinkedHashMapBuilder.of(
                 entry("owner", "pulpogato"), // <1>
@@ -191,11 +205,12 @@ class FindOpenPullRequestsTest extends BaseIntegrationTest {
                         .build());
     }
 
-    @Test
-    void testFindOpenPullRequestsTypedQuery() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("mappers")
+    void testFindOpenPullRequestsTypedQuery(String mapperName, DgsJsonMapper mapper) {
         var graphqlWebClient = webClient.mutate().baseUrl("/graphql").build();
         // tag::execute-typed-query[]
-        WebClientGraphQLClient graphQLClient = new WebClientGraphQLClient(graphqlWebClient);
+        var graphQLClient = new DgsWebClientGraphQLClient(graphqlWebClient, h -> {}, mapper);
 
         var query = RepositoryGraphQLQuery.newRequest()
                 .followRenames(false)


### PR DESCRIPTION
Migrate from deprecated WebClientGraphQLClient to DgsWebClientGraphQLClient,
which requires an explicit DgsJsonMapper. Parameterize the GraphQL integration
tests to run against both Jackson2 and Jackson3 mappers, and add the required
Jackson runtime dependencies.
