### PR TITLE
fix(scripts): fix final check crashing on already-deleted files

### DIFF
--- a/scripts/delete-customizations.py
+++ b/scripts/delete-customizations.py
@@ -121,10 +121,11 @@ def process_schema_group(label, files, gradle_tasks):
 
     if len(removable) > 1:
         start_group(f"Final check: removing {len(removable)} candidate(s) together")
-        if not try_without(removable, gradle_tasks):
+        # Files are already deleted from the per-unit tests above; just re-run the check.
+        if not gradle_check(gradle_tasks):
             end_group()
             print("ERROR: Individual removals passed but combined removal failed.")
-            print("Restoring all files. Manual investigation required.")
+            print("Manual investigation required.")
             sys.exit(2)
         end_group()
 


### PR DESCRIPTION
## Summary

- `delete-customizations.py` was crashing with `FileNotFoundError` in the "Final check" phase
- When testing units individually, `try_without` intentionally leaves files deleted on success
- The "Final check" then called `try_without` again on those same files, which tried to `read_text()` them — crash
- Fix: use `gradle_check` directly in the Final check since the files are already deleted