### PR TITLE
fix(ci): mint app token right before PR creation in unignore workflow

### DIFF
--- a/.github/workflows/unignore.yml
+++ b/.github/workflows/unignore.yml
@@ -17,12 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          client-id: 1784694
-          private-key: ${{ secrets.PRIVATE_KEY }}
-
       - name: Configure Git User
         run: |
           git config user.name "GitHub Actions Bot"
@@ -62,6 +56,15 @@ jobs:
             git diff
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+
+      # Mint the app token here, not at job start: installation tokens expire
+      # 1 hour after creation, and the gradle check above can run longer than that.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        if: steps.check.outputs.changed == 'true'
+        with:
+          client-id: 1784694
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Create Pull Request
         env:


### PR DESCRIPTION
## Problem

The **Unignore Tests** workflow fails at the *Create Pull Request* step with:

```
HTTP 401: Bad credentials (https://api.github.com/graphql)
```

(e.g. [run 27171331008](https://github.com/pulpogato/pulpogato/actions/runs/27171331008/job/80210812852)).

## Root cause

`actions/create-github-app-token` mints an installation token with a hard **1-hour TTL**. The workflow minted it as the second step, but `scripts/unignore.py` runs `./gradlew check` (the full build + test suite), which can take over an hour — that run took **1h8m**. By the time `gh pr create` ran (68 minutes after the token was minted), the token had expired.

The `git push` in the same step succeeded because `actions/checkout` was given no `token:` input and so persisted the default `github.token` (valid for the whole job) for git operations. Only `gh pr create`, which reads `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}`, hit the expired app token.

Other workflows (`update-schema-version.yml`, `check-issues-statuses.yml`) are unaffected: they either reach their token-using step within the 1-hour window or use `github.token` directly.

## Fix

Move the `create-github-app-token` step to immediately before the *Create Pull Request* step (gated on the same `changed == 'true'` condition) so the token is fresh when `gh pr create` uses it. The token is referenced only in that step, so the move is safe.

Downstream CI is preserved: `build.yml` triggers on `pull_request`, and the PR is still opened with the app token (now fresh), so opening it still triggers the build.