### PR TITLE
feat: add GHES 3.21 support and retire GHES 3.16 (EOL)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,10 @@ dependencies {
 |{central-prefix}pulpogato-graphql-ghec{central-middle}pulpogato-graphql-ghec{central-suffix} {snapshot-prefix}pulpogato-graphql-ghec{snapshot-middle}pulpogato-graphql-ghec{snapshot-suffix}
 |{central-prefix}pulpogato-rest-ghec{central-middle}pulpogato-rest-ghec{central-suffix} {snapshot-prefix}pulpogato-rest-ghec{snapshot-middle}pulpogato-rest-ghec{snapshot-suffix}
 
+|https://docs.github.com/en/enterprise-server@3.21[GHES-3.21]
+|{central-prefix}pulpogato-graphql-ghes-3.21{central-middle}pulpogato-graphql-ghes-3.21{central-suffix} {snapshot-prefix}pulpogato-graphql-ghes-3.21{snapshot-middle}pulpogato-graphql-ghes-3.21{snapshot-suffix}
+|{central-prefix}pulpogato-rest-ghes-3.21{central-middle}pulpogato-rest-ghes-3.21{central-suffix} {snapshot-prefix}pulpogato-rest-ghes-3.21{snapshot-middle}pulpogato-rest-ghes-3.21{snapshot-suffix}
+
 |https://docs.github.com/en/enterprise-server@3.20[GHES-3.20]
 |{central-prefix}pulpogato-graphql-ghes-3.20{central-middle}pulpogato-graphql-ghes-3.20{central-suffix} {snapshot-prefix}pulpogato-graphql-ghes-3.20{snapshot-middle}pulpogato-graphql-ghes-3.20{snapshot-suffix}
 |{central-prefix}pulpogato-rest-ghes-3.20{central-middle}pulpogato-rest-ghes-3.20{central-suffix} {snapshot-prefix}pulpogato-rest-ghes-3.20{snapshot-middle}pulpogato-rest-ghes-3.20{snapshot-suffix}
@@ -109,10 +113,6 @@ dependencies {
 |{central-prefix}pulpogato-graphql-ghes-3.17{central-middle}pulpogato-graphql-ghes-3.17{central-suffix} {snapshot-prefix}pulpogato-graphql-ghes-3.17{snapshot-middle}pulpogato-graphql-ghes-3.17{snapshot-suffix}
 |{central-prefix}pulpogato-rest-ghes-3.17{central-middle}pulpogato-rest-ghes-3.17{central-suffix} {snapshot-prefix}pulpogato-rest-ghes-3.17{snapshot-middle}pulpogato-rest-ghes-3.17{snapshot-suffix}
 
-|https://docs.github.com/en/enterprise-server@3.16[GHES-3.16]
-|{central-prefix}pulpogato-graphql-ghes-3.16{central-middle}pulpogato-graphql-ghes-3.16{central-suffix} {snapshot-prefix}pulpogato-graphql-ghes-3.16{snapshot-middle}pulpogato-graphql-ghes-3.16{snapshot-suffix}
-|{central-prefix}pulpogato-rest-ghes-3.16{central-middle}pulpogato-rest-ghes-3.16{central-suffix} {snapshot-prefix}pulpogato-rest-ghes-3.16{snapshot-middle}pulpogato-rest-ghes-3.16{snapshot-suffix}
-
 |===
 
 .EOL Versions
@@ -122,6 +122,10 @@ dependencies {
 [cols="1,1,1"]
 |===
 |GitHub Version |GraphQL |REST
+
+|https://docs.github.com/en/enterprise-server@3.16[GHES-3.16]
+|{central-prefix}pulpogato-graphql-ghes-3.16{deprecated-middle}pulpogato-graphql-ghes-3.16{central-suffix}
+|{central-prefix}pulpogato-rest-ghes-3.16{deprecated-middle}pulpogato-rest-ghes-3.16{central-suffix}
 
 |https://docs.github.com/en/enterprise-server@3.15[GHES-3.15]
 |{central-prefix}pulpogato-graphql-ghes-3.15{deprecated-middle}pulpogato-graphql-ghes-3.15{central-suffix}

--- a/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
+++ b/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
@@ -3,21 +3,21 @@
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/protected-branch-pull-request-review/value"
   reason: "TODO: GitHub example has org data where schema expects SimpleUser/Enterprise"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/paths/~1scim~1v2~1organizations~1{org}~1Users~1{scim_user_id}/patch/requestBody/content/application~1json/examples/default/value"
   reason: "https://github.com/github/rest-api-description/issues/5874"
   versions:
@@ -25,11 +25,11 @@
 - example: "#/paths/~1repos~1{owner}~1{repo}~1replicas~1caches/get/responses/200/content/application~1json/examples/default/value"
   reason: "https://github.com/github/rest-api-description/issues/4590"
   versions:
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/paths/~1repos~1{owner}~1{repo}~1security-advisories~1{ghsa_id}/patch/requestBody/content/application~1json/examples/update_vvrs/value"
   reason: "https://github.com/github/rest-api-description/issues/5056"
   versions:
@@ -39,11 +39,11 @@
   reason: "https://github.com/github/rest-api-description/issues/4470"
   versions:
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/paths/~1versions/get/responses/200/content/application~1json/examples/default/value"
   reason: "The API returns a List of LocalDate that cannot be serialized and compared."
   versions:
@@ -54,11 +54,11 @@
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/classroom-assignment/value"
   reason: "https://github.com/github/rest-api-description/issues/5480"
   versions:
@@ -93,41 +93,42 @@
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/ghes-license-info/value"
   reason: "https://github.com/github/rest-api-description/issues/5516"
   versions:
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/organization-simple/value"
   reason: "https://github.com/github/rest-api-description/issues/5542"
   versions:
     - fpt
     - ghec
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/ghes-license-check/value"
   reason: "https://github.com/github/rest-api-description/issues/5546"
   versions:
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/ghes-get-maintenance/value"
   reason: "https://github.com/github/rest-api-description/issues/5547"
   versions:
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/list-attestations-bulk/value"
   reason: "https://github.com/github/rest-api-description/issues/5861"
   versions:
@@ -139,77 +140,79 @@
     - fpt
     - ghec
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/projects-v2-item-with-content/value"
   reason: "https://github.com/github/rest-api-description/issues/5601"
   versions:
     - fpt
     - ghec
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/org-ruleset-items/value"
   reason: "https://github.com/github/rest-api-description/issues/5602"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/dependabot-alerts-for-repository/value"
   reason: "https://github.com/github/rest-api-description/issues/5628"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/dependabot-alert-open/value"
   reason: "https://github.com/github/rest-api-description/issues/5628"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/environments/value"
   reason: "https://github.com/github/rest-api-description/issues/5629"
   versions:
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/custom-deployment-protection-rule-apps/value"
   reason: "https://github.com/github/rest-api-description/issues/5630"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/repository-ruleset-items/value"
   reason: "https://github.com/github/rest-api-description/issues/5641"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21
 - example: "#/components/examples/issue-search-result-item-paginated-lexical-fallback/value"
   reason: "https://github.com/github/rest-api-description/issues/6233"
   versions:
     - fpt
     - ghec
-    - ghes-3.16
     - ghes-3.17
     - ghes-3.18
     - ghes-3.19
     - ghes-3.20
+    - ghes-3.21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,11 +40,11 @@ val allVersions =
     listOf(
         "fpt",
         "ghec",
-        "ghes-3.16",
         "ghes-3.17",
         "ghes-3.18",
         "ghes-3.19",
         "ghes-3.20",
+        "ghes-3.21",
     )
 
 allVersions.forEach { ghVersion ->


### PR DESCRIPTION
## Summary

- Add GHES 3.21 as a supported version (new REST and GraphQL modules)
- Remove GHES 3.16 from active builds (EOL)
- Move GHES 3.16 to the EOL section in README
- Update `IgnoredTests.yml` to add `ghes-3.21` to all known upstream spec issues, and drop the now-dead `ghes-3.16` entries