### PR TITLE
refactor(common): modernize CodeBuilder

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/util/CodeBuilder.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/util/CodeBuilder.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -19,6 +20,11 @@ public class CodeBuilder {
 
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+    private static final int INDENT_SIZE = 2;
+
+    private static String indentOnly(String input) {
+        return input.indent(INDENT_SIZE).replaceAll("\n$", "");
+    }
 
     /**
      * The type of the object being built.
@@ -58,12 +64,13 @@ public class CodeBuilder {
     public String build() {
         StringBuilder sb = new StringBuilder();
         sb.append(type).append(".builder()");
-        properties.forEach((key, value) -> sb.append("\n    .")
+        properties.forEach((key, value) -> sb.append("\n")
+                .append(indentOnly("."))
                 .append(key)
                 .append("(")
                 .append(render(value))
                 .append(")"));
-        sb.append("\n    .build()");
+        sb.append("\n").append(indentOnly(".build()"));
         return sb.toString();
     }
 
@@ -85,30 +92,28 @@ public class CodeBuilder {
             case Double n -> n + "D";
             case Float n -> n + "F";
             case BigDecimal bd -> "new java.math.BigDecimal(\"" + bd + "\")";
-            case PulpogatoType pt -> pt.toCode().indent(2).trim();
+            case PulpogatoType pt -> pt.toCode().indent(INDENT_SIZE).trim();
             case Enum<?> e -> e.getClass().getName() + "." + e.name();
             case URI u -> "URI.create(\"" + u + "\")";
             case UUID uuid -> "UUID.fromString(\"" + uuid + "\")";
             case OffsetDateTime odt -> formatDateTime(odt);
             case LocalDate ld -> "LocalDate.parse(\"" + ld + "\")";
-            case Map<?, ?> map -> formatMap(map);
-            case List<?> list -> formatList(list);
-            default -> "/* [TODO: CodeBuilder.render]" + value + " */ " + null;
+            case Map<?, ?> map -> formatMap(map).indent(INDENT_SIZE).trim();
+            case List<?> list -> formatList(list).indent(INDENT_SIZE).trim();
+            default -> throw new UnsupportedOperationException(getMessage(value));
         };
     }
 
+    private static @NonNull String getMessage(Object value) {
+        String name = value.getClass().getName();
+        return "Unsupported type in CodeBuilder.render: " + name + " (value=" + value + ")";
+    }
+
     private static @NonNull String formatMap(Map<?, ?> map) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("new java.util.HashMap<Object, Object>() {{\n");
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
-            sb.append("        put(")
-                    .append(render(entry.getKey()))
-                    .append(", ")
-                    .append(render(entry.getValue()))
-                    .append(");\n");
-        }
-        sb.append("    }}");
-        return sb.toString();
+        return map.entrySet().stream()
+                .map(entry -> "\n" + indentOnly("io.github.pulpogato.common.util.LinkedHashMapBuilder.entry(")
+                        + render(entry.getKey()) + ", " + render(entry.getValue()) + ")")
+                .collect(Collectors.joining(",", "io.github.pulpogato.common.util.LinkedHashMapBuilder.of(", ")"));
     }
 
     private static @NonNull String formatDateTime(OffsetDateTime odt) {
@@ -117,16 +122,7 @@ public class CodeBuilder {
     }
 
     private static @NonNull String formatList(List<?> list) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("List.of(\n");
-        for (int i = 0; i < list.size(); i++) {
-            sb.append("        ").append(render(list.get(i)));
-            if (i < list.size() - 1) {
-                sb.append(",\n");
-            }
-        }
-        sb.append("\n    )");
-        return sb.toString();
+        return list.stream().map(it -> "\n" + indentOnly(render(it))).collect(Collectors.joining(",", "List.of(", ")"));
     }
 
     /**

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/util/LinkedHashMapBuilder.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/util/LinkedHashMapBuilder.java
@@ -1,5 +1,6 @@
 package io.github.pulpogato.common.util;
 
+import java.util.AbstractMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -12,6 +13,20 @@ public class LinkedHashMapBuilder {
      */
     private LinkedHashMapBuilder() {
         // Empty Default Private Constructor. This should not be instantiated.
+    }
+
+    /**
+     * Creates a Map.Entry from the provided key and value.
+     * This entry supports null values.
+     *
+     * @param key   the key
+     * @param value the value
+     * @param <K>   the type of key
+     * @param <V>   the type of value
+     * @return a Map.Entry containing the provided key and value
+     */
+    public static <K, V> Map.Entry<K, V> entry(K key, V value) {
+        return new AbstractMap.SimpleEntry<>(key, value);
     }
 
     /**

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/SingularOrPluralTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/SingularOrPluralTest.java
@@ -348,10 +348,9 @@ class SingularOrPluralTest {
 
             var expectedCode = """
                     io.github.pulpogato.common.SingularOrPlural.plural(List.of(
-                            "one",
-                            "two",
-                            "three"
-                        ))""";
+                        "one",
+                        "two",
+                        "three"))""";
             assertThat(code).isEqualTo(expectedCode);
         }
 
@@ -364,8 +363,8 @@ class SingularOrPluralTest {
 
             var expectedCode = """
                     io.github.pulpogato.common.SingularOrPlural.singular(io.github.pulpogato.common.StringOrInteger.builder()
-                          .stringValue("test")
-                          .build())""";
+                        .stringValue("test")
+                        .build())""";
             assertThat(code).isEqualTo(expectedCode);
         }
     }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/StringOrIntegerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/StringOrIntegerTest.java
@@ -16,8 +16,8 @@ class StringOrIntegerTest {
         StringOrInteger value = StringOrInteger.builder().integerValue(3L).build();
         assertThat(value.toCode()).isEqualTo("""
                         io.github.pulpogato.common.StringOrInteger.builder()
-                            .integerValue(3L)
-                            .build()""");
+                          .integerValue(3L)
+                          .build()""");
     }
 
     @Test
@@ -25,8 +25,8 @@ class StringOrIntegerTest {
         StringOrInteger value = StringOrInteger.builder().stringValue("example").build();
         assertThat(value.toCode()).isEqualTo("""
                         io.github.pulpogato.common.StringOrInteger.builder()
-                            .stringValue("example")
-                            .build()""");
+                          .stringValue("example")
+                          .build()""");
     }
 
     @Builder

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/util/CodeBuilderTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/util/CodeBuilderTest.java
@@ -1,0 +1,24 @@
+package io.github.pulpogato.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CodeBuilderTest {
+
+    @Test
+    void shouldRenderMapWithNullValuesUsingLinkedHashMapBuilder() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", null);
+
+        String rendered = CodeBuilder.render(map);
+
+        assertThat(rendered).contains("io.github.pulpogato.common.util.LinkedHashMapBuilder.of");
+        assertThat(rendered)
+                .contains("io.github.pulpogato.common.util.LinkedHashMapBuilder.entry(\"key1\", \"value1\")");
+        assertThat(rendered).contains("io.github.pulpogato.common.util.LinkedHashMapBuilder.entry(\"key2\", null)");
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/util/LinkedHashMapBuilderTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/util/LinkedHashMapBuilderTest.java
@@ -1,0 +1,30 @@
+package io.github.pulpogato.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class LinkedHashMapBuilderTest {
+
+    @Test
+    void shouldHandleNullValues() {
+        Map<String, String> map = LinkedHashMapBuilder.of(
+                LinkedHashMapBuilder.entry("key1", "value1"), LinkedHashMapBuilder.entry("key2", null));
+
+        assertThat(map).hasSize(2);
+        assertThat(map.get("key1")).isEqualTo("value1");
+        assertThat(map.get("key2")).isNull();
+        assertThat(map).containsEntry("key2", null);
+    }
+
+    @Test
+    void shouldPreserveOrder() {
+        Map<String, String> map = LinkedHashMapBuilder.of(
+                LinkedHashMapBuilder.entry("c", "3"),
+                LinkedHashMapBuilder.entry("a", "1"),
+                LinkedHashMapBuilder.entry("b", "2"));
+
+        assertThat(map.keySet()).containsExactly("c", "a", "b");
+    }
+}


### PR DESCRIPTION
- Refactor CodeBuilder to use stream-based rendering for lists and maps
- Standardize indentation in generated code using 2-space increments
- Enhance error handling for unsupported types in CodeBuilder
- Add unit tests for LinkedHashMapBuilder and CodeBuilder
