### PR TITLE
Generate sealed supertypes for multi-event webhooks

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
@@ -1,11 +1,24 @@
 package io.github.pulpogato.restcodegen
 
+import com.palantir.javapoet.AnnotationSpec
 import com.palantir.javapoet.ClassName
+import com.palantir.javapoet.CodeBlock
 import com.palantir.javapoet.JavaFile
+import com.palantir.javapoet.MethodSpec
+import com.palantir.javapoet.TypeName
+import com.palantir.javapoet.TypeSpec
+import io.github.pulpogato.restcodegen.Annotations.generated
+import io.github.pulpogato.restcodegen.ext.pascalCase
 import io.github.pulpogato.restcodegen.ext.referenceAndDefinition
 import java.io.File
+import javax.lang.model.element.Modifier
 
 class SchemasBuilder {
+    private companion object {
+        // jackson-annotations keeps this package for both Jackson 2 and Jackson 3.
+        const val PACKAGE_JACKSON_ANNOTATION = "com.fasterxml.jackson.annotation"
+    }
+
     fun buildSchemas(
         context: Context,
         mainDir: File,
@@ -13,11 +26,37 @@ class SchemasBuilder {
         enumConverters: MutableSet<ClassName>,
     ) {
         val openAPI = context.openAPI
+
+        // Webhook events that share a subcategory (e.g. all `check_run` events) get a generated
+        // sealed supertype so callers can pattern match. Work out which body schemas belong to a
+        // group before generating, so each member class can be tagged as a permitted subtype.
+        val supertypeGroups = WebhookSupertypes.compute(openAPI, packageName)
+        // A body schema can belong to more than one subcategory (e.g. the `exemption-request-*` bodies
+        // are shared by several `*_request_*` events), so a member may be permitted by multiple sealed
+        // interfaces and must implement all of them.
+        val schemaKeyToSupertypes =
+            supertypeGroups
+                .flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } }
+                .groupBy({ it.first }, { it.second })
+
+        // Captured per member schema so we can later derive the getters common to every member.
+        val memberFieldsByKey = mutableMapOf<String, Map<String, TypeName>>()
+
         openAPI.components.schemas.forEach { entry ->
             val (typeName, definition) =
                 referenceAndDefinition(context.withSchemaStack("#", "components", "schemas", entry.key), entry, "", null)!!
             definition?.let {
-                JavaFile.builder(packageName, it).build().writeTo(mainDir)
+                val supertypes = schemaKeyToSupertypes[entry.key]
+                val typeSpec =
+                    if (!supertypes.isNullOrEmpty()) {
+                        val (accessible, enriched) = enrichMember(it, supertypes)
+                        memberFieldsByKey[entry.key] = accessible
+                        enriched
+                    } else {
+                        it
+                    }
+
+                JavaFile.builder(packageName, typeSpec).build().writeTo(mainDir)
 
                 // If this is an enum, add its converter to the set
                 if (it.enumConstants().isNotEmpty() && typeName is ClassName) {
@@ -26,5 +65,188 @@ class SchemasBuilder {
                 }
             }
         }
+
+        writeWebhookSupertypeInterfaces(context, mainDir, packageName, supertypeGroups, memberFieldsByKey)
+    }
+
+    /**
+     * Emits one sealed interface per webhook supertype group. The interface permits each member body
+     * class and declares the getters whose name and type are identical across every member.
+     */
+    private fun writeWebhookSupertypeInterfaces(
+        context: Context,
+        mainDir: File,
+        packageName: String,
+        groups: List<WebhookSupertypes.Group>,
+        memberFieldsByKey: Map<String, Map<String, TypeName>>,
+    ) {
+        groups.forEach { group ->
+            val memberFields = group.memberSchemaKeys.map { memberFieldsByKey[it] }
+            // Skip if any member did not generate as a class; otherwise `permits` would dangle.
+            if (memberFields.any { it == null }) return@forEach
+            val present = memberFields.filterNotNull()
+            val commonFields = present.first().filter { (name, type) -> present.all { it[name] == type } }
+
+            val builder =
+                TypeSpec
+                    .interfaceBuilder(group.supertype)
+                    .addModifiers(Modifier.PUBLIC, Modifier.SEALED)
+                    .addSuperinterface(ClassName.get(Types.COMMON_PACKAGE, "PulpogatoType"))
+                    .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
+                    .addJavadoc(
+                        $$"$L",
+                        "A sealed supertype for the <code>${group.subcategory}</code> webhook payloads, " +
+                            "exposing the fields common to every event variant.\n" +
+                            "<br/>Use pattern matching over the permitted subtypes to handle individual variants.",
+                    )
+
+            // When every member is distinguished by a distinct `action` value, wire up Jackson so the
+            // supertype deserializes straight to the right subtype.
+            if (group.discriminable) {
+                jsonSubTypesAnnotations(packageName, group).forEach { builder.addAnnotation(it) }
+            }
+
+            group.memberSchemaKeys.forEach { key ->
+                builder.addPermittedSubclass(ClassName.get(packageName, key.pascalCase()))
+            }
+
+            commonFields.forEach { (name, type) ->
+                builder.addMethod(
+                    MethodSpec
+                        .methodBuilder("get${name.pascalCase()}")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(type)
+                        .build(),
+                )
+            }
+
+            JavaFile.builder(packageName, builder.build()).build().writeTo(mainDir)
+        }
+    }
+
+    /**
+     * Builds the `@JsonTypeInfo` / `@JsonSubTypes` pair that lets Jackson deserialize the supertype
+     * directly to the correct member based on the `action` discriminator. Only called for groups that
+     * are [discriminable][WebhookSupertypes.Group.discriminable].
+     *
+     * The Jackson 2 and Jackson 3 runtimes both read these `com.fasterxml.jackson.annotation` types,
+     * so a single annotation pair covers both.
+     */
+    private fun jsonSubTypesAnnotations(
+        packageName: String,
+        group: WebhookSupertypes.Group,
+    ): List<AnnotationSpec> {
+        val jsonTypeInfo = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonTypeInfo")
+        val jsonSubTypes = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonSubTypes")
+        val subTypesType = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonSubTypes", "Type")
+
+        // EXISTING_PROPERTY: the `action` value already lives in the payload, so it is not consumed and
+        // each subtype keeps populating its own `action` field as usual.
+        val typeInfo =
+            AnnotationSpec
+                .builder(jsonTypeInfo)
+                .addMember("use", $$"$T.Id.NAME", jsonTypeInfo)
+                .addMember("include", $$"$T.As.EXISTING_PROPERTY", jsonTypeInfo)
+                .addMember("property", $$"$S", "action")
+                .build()
+
+        val subTypes = AnnotationSpec.builder(jsonSubTypes)
+        group.memberSchemaKeys.forEach { key ->
+            val memberClass = ClassName.get(packageName, key.pascalCase())
+            group.actionsByKey[key].orEmpty().forEach { value ->
+                subTypes.addMember(
+                    "value",
+                    $$"$L",
+                    AnnotationSpec
+                        .builder(subTypesType)
+                        .addMember("value", $$"$T.class", memberClass)
+                        .addMember("name", $$"$S", value)
+                        .build(),
+                )
+            }
+        }
+
+        return listOf(typeInfo, subTypes.build())
+    }
+
+    /**
+     * Marks a member body class as a permitted subtype of its sealed supertype(s) and returns the
+     * fields callers can read off the supertype.
+     *
+     * A plain object exposes its own instance fields. A composite (`oneOf`/`anyOf`) body stores its
+     * variants as branch objects rather than flattened fields, so we expose the fields common to every
+     * branch and add delegating getters that read from whichever branch is populated — letting those
+     * fields participate in the supertype's common getters.
+     */
+    private fun enrichMember(
+        typeSpec: TypeSpec,
+        supertypes: List<ClassName>,
+    ): Pair<Map<String, TypeName>, TypeSpec> {
+        // A permitted subtype of a sealed interface must declare its own sealing; these classes are
+        // open POJOs, so mark them non-sealed.
+        val builder = typeSpec.toBuilder().addModifiers(Modifier.NON_SEALED)
+        supertypes.forEach { builder.addSuperinterface(it) }
+
+        val branches = inlineBranches(typeSpec)
+        val accessible =
+            if (branches.isEmpty()) {
+                instanceFields(typeSpec)
+            } else {
+                val common = branchCommonFields(branches)
+                val branchGetters = branches.map { it.first }
+                common.forEach { (name, type) -> builder.addMethod(delegatingGetter(name, type, branchGetters)) }
+                common
+            }
+        return accessible to builder.build()
+    }
+
+    private fun instanceFields(typeSpec: TypeSpec): Map<String, TypeName> =
+        typeSpec
+            .fieldSpecs()
+            .filter { Modifier.STATIC !in it.modifiers() }
+            .associate { it.name() to it.type().withoutAnnotations() }
+
+    /**
+     * For a composite (`oneOf`/`anyOf`) body, the (getter-name, branch-type) pairs of its inline branch
+     * classes, in declaration order. Empty when the type isn't composite or any variant isn't an inline
+     * nested branch (e.g. a `oneOf` of `$ref`s), in which case branch fields can't be read locally.
+     */
+    private fun inlineBranches(typeSpec: TypeSpec): List<Pair<String, TypeSpec>> {
+        val isComposite = typeSpec.typeSpecs().any { it.name()?.endsWith("Jackson3Deserializer") == true }
+        if (!isComposite) return emptyList()
+
+        val nestedByName = typeSpec.typeSpecs().associateBy { it.name() }
+        val fields = typeSpec.fieldSpecs().filter { Modifier.STATIC !in it.modifiers() }
+        if (fields.isEmpty()) return emptyList()
+        return fields.map { field ->
+            val branchName = (field.type().withoutAnnotations() as? ClassName)?.simpleName()
+            val branch = branchName?.let { nestedByName[it] } ?: return emptyList()
+            "get${field.name().pascalCase()}" to branch
+        }
+    }
+
+    private fun branchCommonFields(branches: List<Pair<String, TypeSpec>>): Map<String, TypeName> {
+        val perBranch = branches.map { (_, branch) -> instanceFields(branch) }
+        return perBranch.first().filter { (name, type) -> perBranch.all { it[name] == type } }
+    }
+
+    private fun delegatingGetter(
+        name: String,
+        type: TypeName,
+        branchGetters: List<String>,
+    ): MethodSpec {
+        val code = CodeBlock.builder()
+        branchGetters.forEach { branchGetter ->
+            code.beginControlFlow($$"if ($L() != null)", branchGetter)
+            code.addStatement($$"return $L().get$L()", branchGetter, name.pascalCase())
+            code.endControlFlow()
+        }
+        code.addStatement("return null")
+        return MethodSpec
+            .methodBuilder("get${name.pascalCase()}")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(type)
+            .addCode(code.build())
+            .build()
     }
 }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhookSupertypes.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhookSupertypes.kt
@@ -1,0 +1,110 @@
+package io.github.pulpogato.restcodegen
+
+import com.palantir.javapoet.ClassName
+import io.github.pulpogato.restcodegen.ext.pascalCase
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.media.Schema
+
+/**
+ * Computes the sealed supertypes generated for webhook subcategories that have more than one event.
+ *
+ * Shared by [SchemasBuilder] (which emits the interfaces and tags the member body classes) and
+ * [WebhooksBuilder] (which routes the synthetic handler straight to the typed supertype when it can be
+ * discriminated). Keeping the grouping in one place ensures both builders agree on which subcategories
+ * have a supertype and whether it can be deserialized polymorphically.
+ */
+object WebhookSupertypes {
+    data class Group(
+        val subcategory: String,
+        val supertype: ClassName,
+        val memberSchemaKeys: List<String>,
+        val actionsByKey: Map<String, List<String>?>,
+    ) {
+        /**
+         * True when every member is identified by a distinct `action` value, so Jackson can pick the
+         * concrete subtype from the payload. When false the supertype is still generated for pattern
+         * matching, but callers must deserialize the members themselves.
+         */
+        val discriminable: Boolean =
+            memberSchemaKeys.all { !actionsByKey[it].isNullOrEmpty() } &&
+                memberSchemaKeys.flatMap { actionsByKey[it].orEmpty() }.let { it.size == it.toSet().size }
+    }
+
+    fun compute(
+        openAPI: OpenAPI,
+        schemasPackage: String,
+    ): List<Group> {
+        val webhooks = openAPI.webhooks ?: return emptyList()
+        val existingSchemaNames =
+            openAPI.components.schemas.keys
+                .map { it.pascalCase() }
+                .toSet()
+        return webhooks.entries
+            .groupBy {
+                subcategoryOf(
+                    it.value
+                        .readOperationsMap()
+                        .values
+                        .first(),
+                )
+            }.mapNotNull { (subcategory, members) ->
+                if (members.size <= 1) return@mapNotNull null
+                val interfaceName = "Webhook${subcategory.pascalCase()}"
+                // A single-event subcategory's body is itself named webhook-<subcategory>; never clobber
+                // a real schema with a synthetic supertype of the same name.
+                if (interfaceName in existingSchemaNames) return@mapNotNull null
+                val memberKeys = members.mapNotNull { requestBodySchemaKey(it.value) }.distinct()
+                if (memberKeys.size <= 1) return@mapNotNull null
+                val actions = memberKeys.associateWith { key -> discriminatorValues(openAPI.components.schemas[key]) }
+                Group(subcategory, ClassName.get(schemasPackage, interfaceName), memberKeys, actions)
+            }
+    }
+
+    /**
+     * The distinct values of a schema's `action` discriminator, or null when it can't be determined.
+     *
+     * Plain object bodies declare `action` directly. Composite (`oneOf`/`anyOf`) bodies — e.g.
+     * `webhook-pull-request-review-requested` — declare it inside every branch instead; those are
+     * supported as long as every branch agrees on the same enum value(s).
+     */
+    private fun discriminatorValues(schema: Schema<*>?): List<String>? {
+        if (schema == null) return null
+        actionEnum(schema)?.let { return it }
+
+        val branches = (schema.oneOf.orEmpty() + schema.anyOf.orEmpty()).filterNotNull()
+        if (branches.isEmpty()) return null
+        val perBranch = branches.map { actionEnum(it) }
+        // Every branch must contribute a discriminator, otherwise the body isn't safely discriminable.
+        if (perBranch.any { it == null }) return null
+        return perBranch
+            .filterNotNull()
+            .flatten()
+            .distinct()
+            .ifEmpty { null }
+    }
+
+    private fun actionEnum(schema: Schema<*>): List<String>? {
+        val action = schema.properties?.get("action") ?: return null
+        val values = action.enum?.mapNotNull { it?.toString() } ?: return null
+        return values.ifEmpty { null }
+    }
+
+    private fun requestBodySchemaKey(pathItem: PathItem): String? {
+        val operation = pathItem.readOperationsMap().values.firstOrNull() ?: return null
+        val mediaType =
+            operation.requestBody
+                ?.content
+                ?.entries
+                ?.firstOrNull { it.key.contains("json") }
+                ?.value ?: return null
+        val ref = mediaType.schema?.`$ref` ?: return null
+        return ref.replace("#/components/schemas/", "")
+    }
+
+    private fun subcategoryOf(operation: Operation): String {
+        val xGitHub = operation.extensions["x-github"] as? Map<*, *> ?: throw RuntimeException("Missing x-github extension")
+        return xGitHub["subcategory"] as String
+    }
+}

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -3,6 +3,7 @@ package io.github.pulpogato.restcodegen
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.palantir.javapoet.AnnotationSpec
 import com.palantir.javapoet.ClassName
+import com.palantir.javapoet.CodeBlock
 import com.palantir.javapoet.FieldSpec
 import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.MethodSpec
@@ -33,6 +34,8 @@ class WebhooksBuilder {
         val interfaceBuilder: TypeSpec.Builder,
         val unitTestBuilder: TypeSpec.Builder,
         val testControllerBuilder: TypeSpec.Builder,
+        val springEndpoint: Boolean,
+        val supertype: WebhookSupertypes.Group?,
     )
 
     data class ProcessingContext(
@@ -44,6 +47,7 @@ class WebhooksBuilder {
         val builders: WebhookBuilderParams,
         val name: String,
         val testResourcesDir: File,
+        val springEndpoint: Boolean,
     )
 
     fun buildWebhooks(
@@ -58,6 +62,9 @@ class WebhooksBuilder {
         val testControllerBuilder = buildTestController()
 
         val openAPI = context.openAPI
+        // The same supertypes SchemasBuilder generates; used here to route the synthetic handler
+        // straight to the typed supertype when the subcategory can be deserialized polymorphically.
+        val supertypesBySubcategory = WebhookSupertypes.compute(openAPI, "$restPackage.schemas").associateBy { it.subcategory }
         openAPI.webhooks
             .entries
             .groupBy {
@@ -73,7 +80,16 @@ class WebhooksBuilder {
                 val unitTestBuilder = getUnitTestBuilder(subcategory)
 
                 val requestBodyTypes = mutableMapOf<String, Pair<String, ClassName>>()
-                val builders = WebhookBuilderParams(interfaceBuilder, unitTestBuilder, testControllerBuilder)
+                // For a multi-event subcategory only the synthetic process<Subcategory> is a real
+                // Spring endpoint; the per-event methods are typed callbacks it dispatches to.
+                val builders =
+                    WebhookBuilderParams(
+                        interfaceBuilder,
+                        unitTestBuilder,
+                        testControllerBuilder,
+                        springEndpoint = v.size == 1,
+                        supertype = supertypesBySubcategory[subcategory],
+                    )
                 v.forEach { (name, webhook) ->
                     val requestBody =
                         createWebhookInterface(context, name, webhook, restPackage, builders, testResourcesDir)
@@ -96,6 +112,7 @@ class WebhooksBuilder {
                         requestBodyTypes,
                         interfaceBuilder,
                         v.first().value,
+                        builders.supertype,
                     )
                 }
 
@@ -145,11 +162,13 @@ class WebhooksBuilder {
         requestBodyTypes: Map<String, Pair<String, ClassName>>,
         interfaceBuilder: TypeSpec.Builder,
         pathItem: PathItem,
+        supertype: WebhookSupertypes.Group?,
     ) {
+        val syntheticContext = context.withSchemaStack("#", "synthetic")
         val methodBuilder =
             MethodSpec
                 .methodBuilder("process${subcategory.pascalCase()}")
-                .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
+                .addAnnotation(generated(0, syntheticContext))
                 .addAnnotation(createHeaderAnnotation(subcategory))
                 .returns(ParameterizedTypeName.get(ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"), TypeVariableName.get("T")))
                 .addException(Types.EXCEPTION)
@@ -169,20 +188,28 @@ class WebhooksBuilder {
                         ParameterSpec
                             .builder(Types.STRING, it.camelCase())
                             .addAnnotation(getParameterAnnotation(it).build())
-                            .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
+                            .addAnnotation(generated(0, syntheticContext))
                             .build(),
                     )
             }
 
-        val router = buildRouter(requestBodyTypes, subcategory, headerNames)
-
-        methodBuilder
-            .addParameter(buildRequestBodyParameter(context.withSchemaStack("#", "synthetic")))
-            .addCode(router, ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"))
-
-        interfaceBuilder
-            .addMethod(methodBuilder.build())
-            .addMethod(getObjectMapperMethod())
+        if (supertype != null && supertype.discriminable) {
+            // Spring deserializes straight to the sealed supertype (via its @JsonSubTypes), so the
+            // handler just pattern matches over the permitted subtypes — no manual JSON routing.
+            // The default dispatch still calls the per-event methods, which are deprecated.
+            methodBuilder
+                .addAnnotation(suppressDeprecation())
+                .addParameter(buildTypedRequestBodyParameter(syntheticContext, supertype.supertype))
+                .addCode(buildTypedRouter(requestBodyTypes, headerNames))
+            interfaceBuilder.addMethod(methodBuilder.build())
+        } else {
+            methodBuilder
+                .addParameter(buildRequestBodyParameter(syntheticContext))
+                .addCode(buildRouter(requestBodyTypes, subcategory, headerNames), ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"))
+            interfaceBuilder
+                .addMethod(methodBuilder.build())
+                .addMethod(getObjectMapperMethod())
+        }
     }
 
     private fun getObjectMapperMethod(): MethodSpec =
@@ -204,6 +231,35 @@ class WebhooksBuilder {
             .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestBody")).build())
             .addAnnotation(generated(0, context))
             .build()
+
+    private fun buildTypedRequestBodyParameter(
+        context: Context,
+        supertype: ClassName,
+    ): ParameterSpec =
+        ParameterSpec
+            .builder(supertype, "requestBody")
+            .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestBody")).build())
+            .addAnnotation(generated(0, context))
+            .build()
+
+    /**
+     * Routes a polymorphically-deserialized webhook body to its typed handler. The switch over the
+     * sealed supertype is exhaustive, so no default branch is needed.
+     */
+    private fun buildTypedRouter(
+        requestBodyTypes: Map<String, Pair<String, ClassName>>,
+        headerNames: List<String>,
+    ): CodeBlock {
+        val code = CodeBlock.builder()
+        code.add("return switch (requestBody) {\n")
+        requestBodyTypes.forEach { (_, methodNameAndType) ->
+            val (methodName, type) = methodNameAndType
+            val args = (headerNames.map { it.camelCase() } + "body").joinToString(", ")
+            code.add($$"    case $T body -> $L($L);\n", type, methodName, args)
+        }
+        code.add("};\n")
+        return code.build()
+    }
 
     private fun buildRouter(
         requestBodyTypes: Map<String, Pair<String, ClassName>>,
@@ -338,6 +394,8 @@ class WebhooksBuilder {
                     .addStatement("return this.objectMapper")
                     .build(),
             ).addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RestController")).build())
+            // Implements the deprecated per-event callbacks to exercise the default dispatch.
+            .addAnnotation(suppressDeprecation())
             .addAnnotation(
                 AnnotationSpec
                     .builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestMapping"))
@@ -360,23 +418,51 @@ class WebhooksBuilder {
         val tests = mutableListOf<MethodSpec>()
         val (_, operation) = webhook.readOperationsMap().entries.first()
 
+        val springEndpoint = builders.springEndpoint
+        // When the subcategory has a discriminable supertype, callers are steered towards the typed
+        // process<Subcategory> handler, so these per-event methods become optional, deprecated callbacks.
+        val discriminableGroup = builders.supertype?.takeIf { it.discriminable }
+        val syntheticMethodName = builders.supertype?.let { "process${it.subcategory.pascalCase()}" }
+
         val methodName = "process" + operation.operationId.replace("/", "-").pascalCase()
         val context1 = context.withSchemaStack("#", "webhooks", name, "post")
         val methodSpecBuilder =
             MethodSpec
                 .methodBuilder(methodName)
                 .addAnnotation(generated(0, context1))
-                .addAnnotation(createPostMappingAnnotation(name))
-                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addModifiers(Modifier.PUBLIC, if (discriminableGroup != null) Modifier.DEFAULT else Modifier.ABSTRACT)
                 .returns(
                     ParameterizedTypeName.get(ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"), TypeVariableName.get("T")),
                 )
+        if (springEndpoint) {
+            methodSpecBuilder.addAnnotation(createPostMappingAnnotation(name))
+        }
+        if (discriminableGroup != null) {
+            methodSpecBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_JAVA_LANG, "Deprecated")).build())
+        }
 
         val requestBody = operation.requestBody
-        val processingContext = ProcessingContext(restPackage, operation, methodSpecBuilder, context1, tests, builders, name, testResourcesDir)
+        val processingContext =
+            ProcessingContext(restPackage, operation, methodSpecBuilder, context1, tests, builders, name, testResourcesDir, springEndpoint)
         val bodyType = processRequestBody(requestBody, processingContext)
 
-        val javadoc = buildJavadoc(operation)
+        if (discriminableGroup != null) {
+            methodSpecBuilder.addStatement(
+                $$"throw new $T($S)",
+                ClassName.get(PACKAGE_JAVA_LANG, "UnsupportedOperationException"),
+                "Implement $$syntheticMethodName and pattern match over ${discriminableGroup.supertype.simpleName()} instead.",
+            )
+        }
+
+        val javadoc = buildJavadoc(operation).toMutableList()
+        if (discriminableGroup != null) {
+            javadoc.add("")
+            javadoc.add(
+                "@deprecated Prefer implementing {@code $syntheticMethodName} and pattern matching over " +
+                    "{@link ${discriminableGroup.supertype.simpleName()}}; this per-event method is only invoked by the " +
+                    "default {@code $syntheticMethodName} dispatch.",
+            )
+        }
         val methodSpec =
             methodSpecBuilder
                 .addJavadoc($$"$L", javadoc.joinToString("\n"))
@@ -401,8 +487,15 @@ class WebhooksBuilder {
             .addMember("headers", $$"$S", "X-Github-Event=$name")
             .build()
 
+    private fun suppressDeprecation(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(PACKAGE_JAVA_LANG, "SuppressWarnings"))
+            .addMember("value", $$"$S", "deprecation")
+            .build()
+
     companion object {
         private val TEST_RESPONSE = ClassName.get("io.github.pulpogato.test", "TestWebhookResponse")
+        private const val PACKAGE_JAVA_LANG = "java.lang"
         private const val PACKAGE_SPRING_WEB_BIND_ANNOTATION = "org.springframework.web.bind.annotation"
         private const val PACKAGE_SPRING_HTTP = "org.springframework.http"
         private const val PACKAGE_PULPOGATO_TEST = "io.github.pulpogato.test"
@@ -414,7 +507,7 @@ class WebhooksBuilder {
     ): MethodSpec.Builder =
         MethodSpec
             .methodBuilder(methodName)
-            .addAnnotation(AnnotationSpec.builder(ClassName.get("java.lang", "Override")).build())
+            .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_JAVA_LANG, "Override")).build())
             .returns(
                 ParameterizedTypeName.get(
                     ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"),
@@ -486,16 +579,17 @@ class WebhooksBuilder {
                 .first { it.key == ref }
         val type = schema.className()
 
-        addHeaderParameters(ctx.operation, ctx.methodSpecBuilder, ctx.context)
+        addHeaderParameters(ctx.operation, ctx.methodSpecBuilder, ctx.context, ctx.springEndpoint)
 
         val bodyType = ClassName.get("${ctx.restPackage}.schemas", type)
-        ctx.methodSpecBuilder.addParameter(
+        val bodyParam =
             ParameterSpec
                 .builder(bodyType, "requestBody")
-                .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestBody")).build())
                 .addAnnotation(generated(0, ctx.context.withSchemaStack("requestBody")))
-                .build(),
-        )
+        if (ctx.springEndpoint) {
+            bodyParam.addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestBody")).build())
+        }
+        ctx.methodSpecBuilder.addParameter(bodyParam.build())
 
         processExamples(entry, ctx.context, ctx.tests, bodyType, ctx.testResourcesDir)
 
@@ -517,27 +611,28 @@ class WebhooksBuilder {
         operation: Operation,
         methodSpecBuilder: MethodSpec.Builder,
         context: Context,
+        springEndpoint: Boolean,
     ) {
         operation.parameters.filter { it.`in` == "header" }.forEachIndexed { idx, it ->
-            val required =
-                when {
-                    it.name.startsWith("X-Hub-Signature") -> false
-                    it.name.startsWith("X-GitHub-Enterprise") -> false
-                    else -> true
-                }
-            val parameterAnnotation =
-                getRequestHeaderAnnotation(it.name)
-            if (!required) {
-                parameterAnnotation.addMember("required", $$"$L", false)
-            }
             val contextForParameters = context.withSchemaStack("parameters", idx.toString())
-            methodSpecBuilder.addParameter(
+            val parameter =
                 ParameterSpec
                     .builder(Types.STRING, it.name.camelCase())
-                    .addAnnotation(parameterAnnotation.build())
                     .addAnnotation(generated(0, contextForParameters))
-                    .build(),
-            )
+            if (springEndpoint) {
+                val required =
+                    when {
+                        it.name.startsWith("X-Hub-Signature") -> false
+                        it.name.startsWith("X-GitHub-Enterprise") -> false
+                        else -> true
+                    }
+                val parameterAnnotation = getRequestHeaderAnnotation(it.name)
+                if (!required) {
+                    parameterAnnotation.addMember("required", $$"$L", false)
+                }
+                parameter.addAnnotation(parameterAnnotation.build())
+            }
+            methodSpecBuilder.addParameter(parameter.build())
         }
     }
 

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
@@ -1,0 +1,237 @@
+package io.github.pulpogato.restcodegen
+
+import com.palantir.javapoet.ClassName
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.parameters.RequestBody
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class SchemasBuilderTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val packageName = "com.example.schemas"
+
+    @Test
+    fun `multi-event webhook group gets a sealed supertype with only the common getters`() {
+        val openAPI = sampleOpenAPI()
+
+        generate(openAPI)
+
+        val supertype = readGenerated("WebhookThing")
+        assertThat(supertype)
+            .contains("public sealed interface WebhookThing extends PulpogatoType")
+            .contains("permits")
+            .contains("WebhookThingCreated")
+            .contains("WebhookThingDeleted")
+            // `sender` is a $ref shared by both members, so it is common.
+            .contains("SimpleUser getSender();")
+            // `value` differs in type, `extra` only exists on one, `action` is a per-member enum — none common.
+            .doesNotContain("getValue(")
+            .doesNotContain("getExtra(")
+            .doesNotContain("getAction(")
+    }
+
+    @Test
+    fun `a discriminable group gets JsonSubTypes mapping each action to its member`() {
+        generate(sampleOpenAPI())
+
+        assertThat(readGenerated("WebhookThing"))
+            .contains("@JsonTypeInfo(")
+            .contains("include = JsonTypeInfo.As.EXISTING_PROPERTY")
+            .contains("property = \"action\"")
+            .contains("@JsonSubTypes.Type(value = WebhookThingCreated.class, name = \"created\")")
+            .contains("@JsonSubTypes.Type(value = WebhookThingDeleted.class, name = \"deleted\")")
+    }
+
+    @Test
+    fun `members of a group are marked non-sealed and implement the supertype`() {
+        generate(sampleOpenAPI())
+
+        assertThat(readGenerated("WebhookThingCreated"))
+            .contains("public non-sealed class WebhookThingCreated")
+            .contains("WebhookThing")
+        assertThat(readGenerated("WebhookThingDeleted"))
+            .contains("public non-sealed class WebhookThingDeleted")
+            .contains("WebhookThing")
+    }
+
+    @Test
+    fun `single-event subcategory does not get a supertype`() {
+        generate(sampleOpenAPI())
+
+        // The lone event's body is generated as an ordinary class...
+        assertThat(generatedFile("WebhookSoloEvent")).exists()
+        assertThat(readGenerated("WebhookSoloEvent")).contains("public class WebhookSoloEvent")
+        // ...and no `Webhook<subcategory>` interface is synthesized for it.
+        assertThat(generatedFile("WebhookSolo")).doesNotExist()
+    }
+
+    @Test
+    fun `composite oneOf members expose fields common to all branches via delegating getters`() {
+        generate(compositeSampleOpenAPI())
+
+        // `sender` lives inside both branches of the composite member, so it surfaces on the supertype.
+        assertThat(readGenerated("WebhookCombo"))
+            .contains("public sealed interface WebhookCombo")
+            .contains("SimpleUser getSender();")
+
+        // The composite member gains a getter that reads from whichever branch is populated.
+        assertThat(readGenerated("WebhookComboComposite"))
+            .contains("public SimpleUser getSender()")
+            .contains("getWebhookComboComposite0()")
+            .contains("getWebhookComboComposite1()")
+    }
+
+    private fun generate(openAPI: OpenAPI) {
+        val context = Context(openAPI, "test", emptyList(), emptyMap())
+        SchemasBuilder().buildSchemas(context, tempDir.toFile(), packageName, mutableSetOf<ClassName>())
+    }
+
+    private fun generatedFile(simpleName: String): File = File(tempDir.toFile(), "com/example/schemas/$simpleName.java")
+
+    private fun readGenerated(simpleName: String): String = generatedFile(simpleName).readText()
+
+    /**
+     * A minimal spec with one multi-event subcategory (`thing` -> created + deleted) and one
+     * single-event subcategory (`solo`).
+     */
+    private fun sampleOpenAPI(): OpenAPI {
+        val stringSchema = { Schema<Any>().apply { types = mutableSetOf("string") } }
+        val integerSchema = { Schema<Any>().apply { types = mutableSetOf("integer") } }
+        val refSchema = { ref: String -> Schema<Any>().apply { `$ref` = ref } }
+        val actionSchema = { value: String ->
+            Schema<Any>().apply {
+                types = mutableSetOf("string")
+                enum = listOf(value)
+            }
+        }
+
+        val objectSchema = { props: Map<String, Schema<Any>> ->
+            Schema<Any>().apply {
+                types = mutableSetOf("object")
+                properties = LinkedHashMap(props)
+            }
+        }
+
+        val openAPI = OpenAPI()
+        openAPI.schema("simple-user", objectSchema(mapOf("login" to stringSchema())))
+        openAPI.schema(
+            "webhook-thing-created",
+            objectSchema(
+                mapOf(
+                    "action" to actionSchema("created"),
+                    "sender" to refSchema("#/components/schemas/simple-user"),
+                    "value" to stringSchema(),
+                    "extra" to stringSchema(),
+                ),
+            ),
+        )
+        openAPI.schema(
+            "webhook-thing-deleted",
+            objectSchema(
+                mapOf(
+                    "action" to actionSchema("deleted"),
+                    "sender" to refSchema("#/components/schemas/simple-user"),
+                    "value" to integerSchema(),
+                ),
+            ),
+        )
+        openAPI.schema("webhook-solo-event", objectSchema(mapOf("sender" to refSchema("#/components/schemas/simple-user"))))
+
+        openAPI.webhooks =
+            linkedMapOf(
+                "thing-created" to webhook("thing", "webhook-thing-created"),
+                "thing-deleted" to webhook("thing", "webhook-thing-deleted"),
+                "solo" to webhook("solo", "webhook-solo-event"),
+            )
+        return openAPI
+    }
+
+    /**
+     * A `combo` subcategory with a plain member and a composite (`oneOf`) member whose branches both
+     * carry `sender`.
+     */
+    private fun compositeSampleOpenAPI(): OpenAPI {
+        val stringSchema = { Schema<Any>().apply { types = mutableSetOf("string") } }
+        val refSchema = { ref: String -> Schema<Any>().apply { `$ref` = ref } }
+        val actionSchema = { value: String ->
+            Schema<Any>().apply {
+                types = mutableSetOf("string")
+                enum = listOf(value)
+            }
+        }
+        val objectSchema = { props: Map<String, Schema<Any>> ->
+            Schema<Any>().apply {
+                types = mutableSetOf("object")
+                properties = LinkedHashMap(props)
+            }
+        }
+
+        val openAPI = OpenAPI()
+        openAPI.schema("simple-user", objectSchema(mapOf("login" to stringSchema())))
+        openAPI.schema(
+            "webhook-combo-simple",
+            objectSchema(
+                mapOf(
+                    "action" to actionSchema("simple"),
+                    "sender" to refSchema("#/components/schemas/simple-user"),
+                ),
+            ),
+        )
+        openAPI.schema(
+            "webhook-combo-composite",
+            Schema<Any>().apply {
+                oneOf =
+                    listOf(
+                        objectSchema(
+                            mapOf(
+                                "action" to actionSchema("composite"),
+                                "sender" to refSchema("#/components/schemas/simple-user"),
+                            ),
+                        ),
+                        objectSchema(
+                            mapOf(
+                                "action" to actionSchema("composite"),
+                                "sender" to refSchema("#/components/schemas/simple-user"),
+                                "note" to stringSchema(),
+                            ),
+                        ),
+                    )
+            },
+        )
+
+        openAPI.webhooks =
+            linkedMapOf(
+                "combo-simple" to webhook("combo", "webhook-combo-simple"),
+                "combo-composite" to webhook("combo", "webhook-combo-composite"),
+            )
+        return openAPI
+    }
+
+    private fun webhook(
+        subcategory: String,
+        bodySchema: String,
+    ): PathItem {
+        val operation =
+            Operation().apply {
+                addExtension("x-github", mapOf("subcategory" to subcategory))
+                requestBody =
+                    RequestBody().content(
+                        Content().addMediaType(
+                            "application/json",
+                            MediaType().schema(Schema<Any>().apply { `$ref` = "#/components/schemas/$bodySchema" }),
+                        ),
+                    )
+            }
+        return PathItem().post(operation)
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2FancySerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2FancySerializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.pulpogato.common.Mode;
@@ -57,6 +58,19 @@ public class Jackson2FancySerializer<T> extends StdSerializer<T> {
      * The fields that can be read from the class
      */
     private final transient List<GettableField<T, ?>> fields;
+
+    /**
+     * Serializes the value when used as a polymorphic subtype (e.g. a sealed webhook supertype).
+     *
+     * <p>These types only ever participate in {@code @JsonTypeInfo} with {@code As.EXISTING_PROPERTY},
+     * where the discriminator is already part of the serialized body. There is therefore no separate
+     * type id to emit, so the value is written exactly as {@link #serialize}.
+     */
+    @Override
+    public void serializeWithType(T value, JsonGenerator gen, SerializerProvider provider, TypeSerializer typeSer)
+            throws IOException {
+        serialize(value, gen, provider);
+    }
 
     @Override
     public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3FancySerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3FancySerializer.java
@@ -12,6 +12,7 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
@@ -54,6 +55,18 @@ public class Jackson3FancySerializer<T> extends StdSerializer<T> {
      * The fields that can be read from the class
      */
     private final transient List<GettableField<T, ?>> fields;
+
+    /**
+     * Serializes the value when used as a polymorphic subtype (e.g. a sealed webhook supertype).
+     *
+     * <p>These types only ever participate in {@code @JsonTypeInfo} with {@code As.EXISTING_PROPERTY},
+     * where the discriminator is already part of the serialized body. There is therefore no separate
+     * type id to emit, so the value is written exactly as {@link #serialize}.
+     */
+    @Override
+    public void serializeWithType(T value, JsonGenerator gen, SerializationContext provider, TypeSerializer typeSer) {
+        serialize(value, gen, provider);
+    }
 
     @Override
     public void serialize(T value, JsonGenerator gen, SerializationContext provider) {

--- a/pulpogato-docs/src/index.adoc
+++ b/pulpogato-docs/src/index.adoc
@@ -87,8 +87,19 @@ include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/rea
 
 === Webhook Example
 
-This shows how to create a Webhook handler that listens for ping events.
-There are many other event types you can listen for.
+Most webhook events (like `pull_request`, `check_run`) have multiple action variants.
+The generated interface provides a sealed supertype — e.g. `WebhookPullRequest` — so you implement
+a single `processPullRequest` method and use pattern matching to branch on the concrete subtype.
+Jackson deserializes the payload to the right subtype automatically based on the `action` field.
+The individual per-event methods (e.g. `processPullRequestEdited`) are `@Deprecated` and dispatched
+by the default implementation; you do not need to override them.
+
+[source,java,indent=0]
+----
+include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java[tags=pull-request-webhook-controller]
+----
+
+For single-event webhooks such as `ping`, the interface has exactly one method with no dispatch layer:
 
 [source,java,indent=0]
 ----

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/schemas/WebhookSupertypeDeserializationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/schemas/WebhookSupertypeDeserializationTest.java
@@ -1,0 +1,44 @@
+package io.github.pulpogato.rest.schemas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Verifies that the generated sealed webhook supertypes carry enough Jackson metadata
+ * (@JsonTypeInfo / @JsonSubTypes) to deserialize a payload straight to the right subtype based on its
+ * {@code action} discriminator.
+ */
+class WebhookSupertypeDeserializationTest {
+    // Mirrors the mapper the generated webhook integration tests use.
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(value -> value.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .disable(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+            .build();
+
+    @ParameterizedTest
+    @MethodSource("checkRunCases")
+    void deserializesToTheConcreteSubtypeByAction(String action, Class<? extends WebhookCheckRun> expected) {
+        WebhookCheckRun result = objectMapper.readValue("{\"action\":\"" + action + "\"}", WebhookCheckRun.class);
+
+        assertThat(result).isInstanceOf(expected);
+    }
+
+    private static Stream<Arguments> checkRunCases() {
+        return Stream.of(
+                arguments("completed", WebhookCheckRunCompleted.class),
+                arguments("created", WebhookCheckRunCreated.class),
+                arguments("requested_action", WebhookCheckRunRequestedAction.class),
+                arguments("rerequested", WebhookCheckRunRerequested.class));
+    }
+}

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java
@@ -1,0 +1,104 @@
+package io.github.pulpogato.rest.webhooks;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.github.pulpogato.rest.schemas.WebhookPullRequest;
+import io.github.pulpogato.rest.schemas.WebhookPullRequestEdited;
+import io.github.pulpogato.rest.schemas.WebhookPullRequestReviewRequested;
+import io.github.pulpogato.test.TestWebhookResponse;
+import io.github.pulpogato.test.WebhookHelper;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Integration test for multi-event webhook handling via the sealed {@link WebhookPullRequest}
+ * supertype. Verifies that the framework correctly deserializes each payload to the right concrete
+ * subtype, that pattern matching in a {@code processPullRequest} implementation dispatches
+ * correctly, and that the body round-trips without loss.
+ *
+ * <p>Contrast with {@link PingWebhooksIntegrationTest}, which exercises a single-event webhook
+ * where there is only one concrete type and no sealed-supertype dispatch.
+ */
+@WebMvcTest
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = PullRequestWebhooksIntegrationTest.PullRequestTestConfig.class)
+class PullRequestWebhooksIntegrationTest {
+    @Autowired
+    MockMvc mvc;
+
+    private static Stream<Arguments> files() {
+        return WebhookHelper.getArguments("fpt").filter(args -> ((String) args.get()[0]).startsWith("pull-request"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("files")
+    void doTest(String hookname, String filename) throws Exception {
+        WebhookHelper.testWebhook(hookname, filename, mvc);
+    }
+
+    @Configuration
+    @SpringBootConfiguration
+    @EnableWebMvc
+    static class PullRequestTestConfig {
+        @Bean
+        ObjectMapper objectMapper() {
+            return JsonMapper.builder()
+                    .changeDefaultPropertyInclusion(value -> value.withValueInclusion(JsonInclude.Include.NON_NULL))
+                    .disable(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+                    .build();
+        }
+
+        @SuppressWarnings("InnerClassMayBeStatic")
+        // tag::pull-request-webhook-controller[]
+        @RestController
+        @RequestMapping("/webhooks")
+        @RequiredArgsConstructor
+        public class PullRequestWebhooksController implements PullRequestWebhooks<TestWebhookResponse> {
+            private final ObjectMapper objectMapper;
+
+            @Override
+            public ResponseEntity<TestWebhookResponse> processPullRequest(
+                    String userAgent,
+                    String xGithubHookId,
+                    String xGithubEvent,
+                    String xGithubHookInstallationTargetId,
+                    String xGithubHookInstallationTargetType,
+                    String xGitHubDelivery,
+                    String xHubSignature256,
+                    WebhookPullRequest requestBody) {
+                var hookname =
+                        switch (requestBody) {
+                            case WebhookPullRequestEdited ignored -> "pull-request-edited";
+                            case WebhookPullRequestReviewRequested ignored -> "pull-request-review-requested";
+                            default ->
+                                throw new UnsupportedOperationException("No test fixture for action: "
+                                        + requestBody.getClass().getSimpleName());
+                        };
+                return ResponseEntity.ok(TestWebhookResponse.builder()
+                        .webhookName(hookname)
+                        .body(objectMapper.writeValueAsString(requestBody))
+                        .build());
+            }
+        }
+        // end::pull-request-webhook-controller[]
+    }
+}


### PR DESCRIPTION
## What

For each webhook subcategory with more than one event, generate a sealed `Webhook<Subcategory>` interface (e.g. `WebhookCheckRun`) that permits its body classes and exposes the getters common to every variant, so callers can pattern match.

## Details

- **Sealed supertypes** — `sealed interface WebhookCheckRun permits ... extends PulpogatoType`, with the common-typed getters (`getCheckRun`, `getSender`, …). Member body classes become `non-sealed` and implement the supertype. A body schema shared by several subcategories implements all of them.
- **Polymorphic deserialization** — discriminable groups (each member has a distinct `action`, read from either top-level `properties` or `oneOf`/`anyOf` branches) get `@JsonTypeInfo`/`@JsonSubTypes` so Jackson deserializes straight to the right subtype.
- **Typed handler** — for discriminable groups the synthetic `process<Subcategory>` takes the sealed supertype and dispatches via an exhaustive sealed `switch`. The per-event methods become deprecated `default` callbacks, steering callers to implement the single typed handler.
- **Composite (`oneOf`/`anyOf`) bodies** — these store their variants as branch objects rather than flattened fields. Fields common to every branch are exposed via delegating getters (reading whichever branch is populated) so they surface on the supertype too (e.g. `WebhookPullRequest.getSender()`). Their custom serializer now implements `serializeWithType` (delegating to `serialize`, since type info is `EXISTING_PROPERTY`) so they serialize as polymorphic subtypes.

## Verification

Full `./gradlew build` passes across all variants (fpt, ghec, ghes-3.17–3.21, graphql modules). Added codegen unit tests (including composite-member getter generation) and an fpt deserialization test; the webhook integration test round-trips both plain and `oneOf` members (e.g. `pull_request/review_requested`).