### PR TITLE
feat: use sealed interface for discriminated oneOf schemas

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
@@ -22,6 +22,7 @@ data class Context(
     val version: String,
     val schemaStack: List<String>,
     val addedProperties: Map<String, Map<String, String>> = emptyMap(),
+    val discriminatedOneOfGroups: List<DiscriminatedOneOfGroups.Group> = emptyList(),
 ) {
     // Cached schema stack reference to avoid repeated string operations
     private val cachedSchemaStackRef: String by lazy { schemaStackRef(schemaStack) }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/DiscriminatedOneOfGroups.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/DiscriminatedOneOfGroups.kt
@@ -1,0 +1,119 @@
+package io.github.pulpogato.restcodegen
+
+import com.palantir.javapoet.ClassName
+import io.github.pulpogato.restcodegen.ext.pascalCase
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
+
+/**
+ * Computes sealed supertypes for REST API `oneOf` schemas that carry a discriminator.
+ *
+ * A qualifying schema must have all branches pointing to component-schema `$ref`s that resolve
+ * to object types (not arrays). Duplicate groups (same member set appearing in multiple paths)
+ * are collapsed into a single entry.
+ *
+ * Shared by [SchemasBuilder] (which emits the interfaces and tags member classes) and
+ * [SchemaExtensions] (which returns the interface type instead of a wrapper class when a
+ * discriminated oneOf is encountered inline in a path response).
+ */
+object DiscriminatedOneOfGroups {
+    data class Group(
+        val supertype: ClassName,
+        val memberSchemaKeys: List<String>,
+        val discriminatorProperty: String,
+        /** Maps each member schema key to the discriminator values that select it. */
+        val valuesByKey: Map<String, List<String>>,
+    )
+
+    fun compute(
+        openAPI: OpenAPI,
+        schemasPackage: String,
+    ): List<Group> {
+        val componentSchemas = openAPI.components?.schemas ?: return emptyList()
+        val groups = mutableMapOf<Set<String>, Group>()
+
+        openAPI.paths?.values?.forEach { pathItem ->
+            pathItem.readOperationsMap().values.forEach { operation ->
+                operation.responses?.values?.forEach { response ->
+                    response?.content?.values?.forEach { mediaType ->
+                        processSchema(mediaType?.schema, componentSchemas, schemasPackage, groups)
+                    }
+                }
+            }
+        }
+
+        return groups.values.toList()
+    }
+
+    private fun processSchema(
+        schema: Schema<*>?,
+        componentSchemas: Map<String, Schema<*>>,
+        schemasPackage: String,
+        groups: MutableMap<Set<String>, Group>,
+    ) {
+        val discriminator = schema?.discriminator ?: return
+        val discriminatorProperty = discriminator.propertyName ?: return
+        val mapping = discriminator.mapping ?: return
+        val oneOf = schema.oneOf?.filterNotNull()?.takeIf { it.isNotEmpty() } ?: return
+
+        // All branches must be $refs to component schemas
+        val memberKeys =
+            oneOf.mapNotNull { branch ->
+                branch.`$ref`?.removePrefix("#/components/schemas/")
+            }
+        if (memberKeys.size != oneOf.size) return
+
+        // All referenced schemas must be object types (not arrays)
+        val allObjects =
+            memberKeys.all { key ->
+                val s = componentSchemas[key] ?: return@all false
+                s.types == null || s.types.contains("object") || s.properties != null
+            }
+        if (!allObjects) return
+
+        val memberSet = memberKeys.toSet()
+        if (memberSet in groups) return
+
+        val valuesByKey = mutableMapOf<String, MutableList<String>>()
+        mapping.forEach { (value, ref) ->
+            val key = ref.removePrefix("#/components/schemas/")
+            if (key in memberSet) {
+                valuesByKey.getOrPut(key) { mutableListOf() }.add(value)
+            }
+        }
+
+        val interfaceName = computeInterfaceName(memberKeys, discriminatorProperty)
+        val supertype = ClassName.get(schemasPackage, interfaceName)
+        groups[memberSet] = Group(supertype, memberKeys, discriminatorProperty, valuesByKey)
+    }
+
+    /**
+     * Derives the interface name from the common suffix (or prefix) of the member schema key parts.
+     * Falls back to PascalCase of the discriminator property name.
+     */
+    fun computeInterfaceName(
+        memberKeys: List<String>,
+        discriminatorProperty: String,
+    ): String {
+        val parts = memberKeys.map { it.split("-") }
+        val first = parts.first()
+
+        // Common suffix
+        for (len in first.size downTo 1) {
+            val suffix = first.takeLast(len)
+            if (parts.all { it.size >= len && it.takeLast(len) == suffix }) {
+                return suffix.joinToString("") { it.pascalCase() }
+            }
+        }
+
+        // Common prefix
+        for (len in first.size downTo 1) {
+            val prefix = first.take(len)
+            if (parts.all { it.size >= len && it.take(len) == prefix }) {
+                return prefix.joinToString("") { it.pascalCase() }
+            }
+        }
+
+        return discriminatorProperty.pascalCase()
+    }
+}

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -160,13 +160,15 @@ open class GenerateJavaTask : DefaultTask() {
         val openAPI = result.openAPI
         val version = projectName.get().replace("pulpogato-rest-", "")
 
-        val context = Context(openAPI, version, emptyList(), addedProperties)
+        val schemasPackage = "$packageNamePrefix.rest.schemas"
+        val discriminatedOneOfGroups = DiscriminatedOneOfGroups.compute(openAPI, schemasPackage)
+        val context = Context(openAPI, version, emptyList(), addedProperties, discriminatedOneOfGroups)
         val enumConverters = mutableSetOf<com.palantir.javapoet.ClassName>()
         var enumConverterPackageName = "$packageNamePrefix.rest.api"
         PathsBuilder().buildApis(context, main, test, "$packageNamePrefix.rest.api", enumConverterPackageName, enumConverters, false)
         PathsBuilder().buildApis(context, main, test, "$packageNamePrefix.rest.api.reactive", enumConverterPackageName, enumConverters, true)
         WebhooksBuilder().buildWebhooks(context, main, test, "$packageNamePrefix.rest", "$packageNamePrefix.rest.webhooks")
-        SchemasBuilder().buildSchemas(context, main, "$packageNamePrefix.rest.schemas", enumConverters)
+        SchemasBuilder().buildSchemas(context, main, schemasPackage, enumConverters)
         EnumConvertersBuilder().buildEnumConverters(context, main, enumConverterPackageName, enumConverters)
 
         // Format generated Java code

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
@@ -17,6 +17,7 @@ class SchemasBuilder {
     private companion object {
         // jackson-annotations keeps this package for both Jackson 2 and Jackson 3.
         const val PACKAGE_JACKSON_ANNOTATION = "com.fasterxml.jackson.annotation"
+        const val TYPE_CLASS_FORMAT = "\$T.class"
     }
 
     fun buildSchemas(
@@ -31,13 +32,15 @@ class SchemasBuilder {
         // sealed supertype so callers can pattern match. Work out which body schemas belong to a
         // group before generating, so each member class can be tagged as a permitted subtype.
         val supertypeGroups = WebhookSupertypes.compute(openAPI, packageName)
+        val discriminatedGroups = context.discriminatedOneOfGroups
         // A body schema can belong to more than one subcategory (e.g. the `exemption-request-*` bodies
         // are shared by several `*_request_*` events), so a member may be permitted by multiple sealed
-        // interfaces and must implement all of them.
+        // interfaces and must implement all of them. Discriminated REST API oneOf groups are included.
         val schemaKeyToSupertypes =
-            supertypeGroups
-                .flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } }
-                .groupBy({ it.first }, { it.second })
+            (
+                supertypeGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } } +
+                    discriminatedGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } }
+            ).groupBy({ it.first }, { it.second })
 
         // Captured per member schema so we can later derive the getters common to every member.
         val memberFieldsByKey = mutableMapOf<String, Map<String, TypeName>>()
@@ -67,6 +70,7 @@ class SchemasBuilder {
         }
 
         writeWebhookSupertypeInterfaces(context, mainDir, packageName, supertypeGroups, memberFieldsByKey)
+        writeDiscriminatedOneOfInterfaces(context, mainDir, packageName, discriminatedGroups, memberFieldsByKey)
     }
 
     /**
@@ -81,47 +85,136 @@ class SchemasBuilder {
         memberFieldsByKey: Map<String, Map<String, TypeName>>,
     ) {
         groups.forEach { group ->
-            val memberFields = group.memberSchemaKeys.map { memberFieldsByKey[it] }
-            // Skip if any member did not generate as a class; otherwise `permits` would dangle.
-            if (memberFields.any { it == null }) return@forEach
-            val present = memberFields.filterNotNull()
-            val commonFields = present.first().filter { (name, type) -> present.all { it[name] == type } }
+            val annotations =
+                if (group.discriminable) jsonSubTypesAnnotations(packageName, group) else emptyList()
+            writeSealedInterface(
+                context,
+                mainDir,
+                packageName,
+                group.supertype,
+                group.memberSchemaKeys,
+                "A sealed supertype for the <code>${group.subcategory}</code> webhook payloads, " +
+                    "exposing the fields common to every event variant.\n" +
+                    "<br/>Use pattern matching over the permitted subtypes to handle individual variants.",
+                annotations,
+                memberFieldsByKey,
+            )
+        }
+    }
 
-            val builder =
-                TypeSpec
-                    .interfaceBuilder(group.supertype)
-                    .addModifiers(Modifier.PUBLIC, Modifier.SEALED)
-                    .addSuperinterface(ClassName.get(Types.COMMON_PACKAGE, "PulpogatoType"))
-                    .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
-                    .addJavadoc(
-                        $$"$L",
-                        "A sealed supertype for the <code>${group.subcategory}</code> webhook payloads, " +
-                            "exposing the fields common to every event variant.\n" +
-                            "<br/>Use pattern matching over the permitted subtypes to handle individual variants.",
-                    )
+    /**
+     * Emits one sealed interface per discriminated REST API oneOf group.
+     *
+     * Each interface is annotated with `@JsonTypeInfo` and `@JsonSubTypes` so Jackson can pick the
+     * correct concrete subtype directly from the discriminator property in the payload.
+     */
+    private fun writeDiscriminatedOneOfInterfaces(
+        context: Context,
+        mainDir: File,
+        packageName: String,
+        groups: List<DiscriminatedOneOfGroups.Group>,
+        memberFieldsByKey: Map<String, Map<String, TypeName>>,
+    ) {
+        groups.forEach { group ->
+            writeSealedInterface(
+                context,
+                mainDir,
+                packageName,
+                group.supertype,
+                group.memberSchemaKeys,
+                "A sealed supertype for the <code>${group.discriminatorProperty}</code>-discriminated oneOf, " +
+                    "deserializable directly via Jackson using the discriminator property.\n" +
+                    "<br/>Use pattern matching over the permitted subtypes to handle each variant.",
+                jsonDiscriminatorAnnotations(packageName, group),
+                memberFieldsByKey,
+            )
+        }
+    }
 
-            // When every member is distinguished by a distinct `action` value, wire up Jackson so the
-            // supertype deserializes straight to the right subtype.
-            if (group.discriminable) {
-                jsonSubTypesAnnotations(packageName, group).forEach { builder.addAnnotation(it) }
-            }
+    private fun writeSealedInterface(
+        context: Context,
+        mainDir: File,
+        packageName: String,
+        supertype: ClassName,
+        memberSchemaKeys: List<String>,
+        javadoc: String,
+        annotations: List<AnnotationSpec>,
+        memberFieldsByKey: Map<String, Map<String, TypeName>>,
+    ) {
+        val memberFields = memberSchemaKeys.map { memberFieldsByKey[it] }
+        // Skip if any member did not generate as a class; otherwise `permits` would dangle.
+        if (memberFields.any { it == null }) return
+        val present = memberFields.filterNotNull()
+        val commonFields = present.first().filter { (name, type) -> present.all { it[name] == type } }
 
-            group.memberSchemaKeys.forEach { key ->
-                builder.addPermittedSubclass(ClassName.get(packageName, key.pascalCase()))
-            }
+        val builder =
+            TypeSpec
+                .interfaceBuilder(supertype)
+                .addModifiers(Modifier.PUBLIC, Modifier.SEALED)
+                .addSuperinterface(ClassName.get(Types.COMMON_PACKAGE, "PulpogatoType"))
+                .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
+                .addJavadoc($$"$L", javadoc)
 
-            commonFields.forEach { (name, type) ->
-                builder.addMethod(
-                    MethodSpec
-                        .methodBuilder("get${name.pascalCase()}")
-                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                        .returns(type)
+        annotations.forEach { builder.addAnnotation(it) }
+
+        memberSchemaKeys.forEach { key ->
+            builder.addPermittedSubclass(ClassName.get(packageName, key.pascalCase()))
+        }
+
+        commonFields.forEach { (name, type) ->
+            builder.addMethod(
+                MethodSpec
+                    .methodBuilder("get${name.pascalCase()}")
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(type)
+                    .build(),
+            )
+        }
+
+        JavaFile.builder(packageName, builder.build()).build().writeTo(mainDir)
+    }
+
+    /**
+     * Builds the `@JsonTypeInfo` / `@JsonSubTypes` pair for a discriminated REST API oneOf group.
+     *
+     * Uses `EXISTING_PROPERTY` so the discriminator field stays in the payload and each subtype
+     * continues to deserialize it into its own field.
+     */
+    private fun jsonDiscriminatorAnnotations(
+        packageName: String,
+        group: DiscriminatedOneOfGroups.Group,
+    ): List<AnnotationSpec> {
+        val jsonTypeInfo = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonTypeInfo")
+        val jsonSubTypes = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonSubTypes")
+        val subTypesType = ClassName.get(PACKAGE_JACKSON_ANNOTATION, "JsonSubTypes", "Type")
+
+        val defaultImplClass = ClassName.get(packageName, group.memberSchemaKeys.first().pascalCase())
+        val typeInfo =
+            AnnotationSpec
+                .builder(jsonTypeInfo)
+                .addMember("use", $$"$T.Id.NAME", jsonTypeInfo)
+                .addMember("include", $$"$T.As.EXISTING_PROPERTY", jsonTypeInfo)
+                .addMember("property", $$"$S", group.discriminatorProperty)
+                .addMember("defaultImpl", TYPE_CLASS_FORMAT, defaultImplClass)
+                .build()
+
+        val subTypes = AnnotationSpec.builder(jsonSubTypes)
+        group.memberSchemaKeys.forEach { key ->
+            val memberClass = ClassName.get(packageName, key.pascalCase())
+            group.valuesByKey[key].orEmpty().forEach { value ->
+                subTypes.addMember(
+                    "value",
+                    $$"$L",
+                    AnnotationSpec
+                        .builder(subTypesType)
+                        .addMember("value", TYPE_CLASS_FORMAT, memberClass)
+                        .addMember("name", $$"$S", value)
                         .build(),
                 )
             }
-
-            JavaFile.builder(packageName, builder.build()).build().writeTo(mainDir)
         }
+
+        return listOf(typeInfo, subTypes.build())
     }
 
     /**
@@ -159,7 +252,7 @@ class SchemasBuilder {
                     $$"$L",
                     AnnotationSpec
                         .builder(subTypesType)
-                        .addMember("value", $$"$T.class", memberClass)
+                        .addMember("value", TYPE_CLASS_FORMAT, memberClass)
                         .addMember("name", $$"$S", value)
                         .build(),
                 )

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -34,6 +34,7 @@ import javax.lang.model.element.Modifier
 
 private const val PACKAGE_PULPOGATO_COMMON = "io.github.pulpogato.common"
 private const val PACKAGE_COMMONS_LANG3_BUILDER = "org.apache.commons.lang3.builder"
+private const val COMPONENTS_SCHEMAS_PREFIX = "#/components/schemas/"
 
 fun Map.Entry<String, Schema<*>>.className() = key.pascalCase()
 
@@ -108,6 +109,21 @@ private fun isOnlyForValidation(
     }
 }
 
+private fun findDiscriminatedGroup(
+    context: Context,
+    schema: Schema<*>,
+    oneOf: List<Schema<*>>?,
+) = if (oneOf != null && schema.discriminator != null) {
+    val memberKeys = oneOf.mapNotNull { it.`$ref`?.removePrefix(COMPONENTS_SCHEMAS_PREFIX) }
+    if (memberKeys.size == oneOf.size) {
+        context.discriminatedOneOfGroups.find { g -> g.memberSchemaKeys.toSet() == memberKeys.toSet() }
+    } else {
+        null
+    }
+} else {
+    null
+}
+
 fun referenceAndDefinition(
     context: Context,
     entry1: Map.Entry<String, Schema<*>?>,
@@ -128,6 +144,7 @@ fun referenceAndDefinition(
             ?.filter { it.types != setOf("null") }
     val oneOf = entry.value.oneOf?.filterNotNull()
     val allOf = entry.value.allOf?.filterNotNull()
+    val discriminatedGroup = findDiscriminatedGroup(context, entry.value, oneOf)
 
     return when {
         entry.key == "empty-object" -> {
@@ -180,6 +197,10 @@ fun referenceAndDefinition(
 
         oneOf != null && isOneOfOnlyForValidation(oneOf, entry.value) -> {
             buildType("${prefix}${entry.className()}", parentClass) { buildSimpleObject(context, entry, it) }
+        }
+
+        discriminatedGroup != null -> {
+            Pair(discriminatedGroup.supertype.annotated(typeGenerated()), null)
         }
 
         oneOf != null -> {
@@ -374,7 +395,7 @@ private fun buildReferenceAndDefinitionFromRef(
     context: Context,
     entry: Map.Entry<String, Schema<*>>,
 ): Pair<TypeName, TypeSpec?> {
-    val schemaName = entry.value.`$ref`.replace("#/components/schemas/", "")
+    val schemaName = entry.value.`$ref`.replace(COMPONENTS_SCHEMAS_PREFIX, "")
     val entries =
         context.openAPI.components.schemas
             .filter { (k, _) -> k == schemaName }
@@ -464,7 +485,7 @@ private fun buildFancyObject(
         .mapIndexed { index, it ->
             var newKey = entry.key + index
             if (it.`$ref` != null) {
-                newKey = it.`$ref`.replace("#/components/schemas/", "")
+                newKey = it.`$ref`.replace(COMPONENTS_SCHEMAS_PREFIX, "")
             } else if (it.title != null) {
                 newKey = it.title
             }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import io.github.pulpogato.rest.schemas.BasicError;
 import io.github.pulpogato.rest.schemas.PrivateUser;
+import io.github.pulpogato.rest.schemas.PublicUser;
 import io.github.pulpogato.rest.schemas.SimpleUser;
 import io.github.pulpogato.rest.schemas.ValidationErrorSimple;
 import java.util.List;
@@ -23,18 +24,17 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         var authenticated = api.getAuthenticated(); // <4>
         // end::getAuthenticatedPublic[]
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(UsersApi.GetAuthenticated200.class);
+        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(PublicUser.class);
         // tag::getBody[]
         var body = authenticated.getBody();
         // end::getBody[]
-        // TODO: This should be a PublicUser
         // tag::getUser[]
-        var privateUser = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PublicUser.class);
+        var publicUser = (PublicUser) body;
         // end::getUser[]
-        assertThat(body.getPrivateUser()).isNotNull();
-        assertThat(privateUser.getId()).isEqualTo(193047L);
+        assertThat(publicUser.getId()).isEqualTo(193047L);
         // tag::getLogin[]
-        var login = privateUser.getLogin();
+        var login = publicUser.getLogin();
         // end::getLogin[]
         assertThat(login).isEqualTo("rahulsom");
     }
@@ -44,11 +44,11 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         var api = new RestClients(webClient).getUsersApi();
         var authenticated = api.getAuthenticated();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(UsersApi.GetAuthenticated200.class);
+        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(PrivateUser.class);
         var body = authenticated.getBody();
 
-        assertThat(body.getPrivateUser()).isNotNull();
-        var privateUser = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PrivateUser.class);
+        var privateUser = (PrivateUser) body;
         assertThat(privateUser.getId()).isEqualTo(193047L);
         assertThat(privateUser.getLogin()).isEqualTo("rahulsom");
         assertThat(privateUser.getPlan()).isNotNull();
@@ -263,13 +263,8 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-        assertThat(response.getBody()).isNotNull();
-        var body = response.getBody();
-
-        // TODO: This should be a PublicUser
-        assertThat(body.getPrivateUser()).isNotNull();
-
-        var user = body.getPrivateUser();
+        assertThat(response.getBody()).isNotNull().isInstanceOf(PublicUser.class);
+        var user = (PublicUser) response.getBody();
 
         assertThat(user.getLogin()).isEqualTo("sghill");
         assertThat(user.getName()).isEqualTo("Steve Hill");
@@ -291,13 +286,8 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-        assertThat(response.getBody()).isNotNull();
-        var body = response.getBody();
-
-        // TODO: This should be a PublicUser
-        assertThat(body.getPrivateUser()).isNotNull();
-
-        var user = body.getPrivateUser();
+        assertThat(response.getBody()).isNotNull().isInstanceOf(PublicUser.class);
+        var user = (PublicUser) response.getBody();
 
         assertThat(user.getLogin()).isEqualTo("sghill");
         assertThat(user.getName()).isEqualTo("Steve Hill");

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/UsersApiIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import io.github.pulpogato.rest.api.BaseApiIntegrationTest;
 import io.github.pulpogato.rest.schemas.BasicError;
 import io.github.pulpogato.rest.schemas.PrivateUser;
+import io.github.pulpogato.rest.schemas.PublicUser;
 import io.github.pulpogato.rest.schemas.SimpleUser;
 import io.github.pulpogato.rest.schemas.ValidationErrorSimple;
 import java.util.List;
@@ -25,18 +26,17 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         var authenticated = responseEntityMono.block(); // <5>
         // end::getAuthenticatedPublic[]
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(UsersApi.GetAuthenticated200.class);
+        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(PublicUser.class);
         // tag::getBody[]
         var body = authenticated.getBody();
         // end::getBody[]
-        // TODO: This should be a PublicUser
         // tag::getUser[]
-        var privateUser = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PublicUser.class);
+        var publicUser = (PublicUser) body;
         // end::getUser[]
-        assertThat(body.getPrivateUser()).isNotNull();
-        assertThat(privateUser.getId()).isEqualTo(193047L);
+        assertThat(publicUser.getId()).isEqualTo(193047L);
         // tag::getLogin[]
-        var login = privateUser.getLogin();
+        var login = publicUser.getLogin();
         // end::getLogin[]
         assertThat(login).isEqualTo("rahulsom");
     }
@@ -46,11 +46,11 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         var api = new RestClients(webClient).getUsersApi();
         var authenticated = api.getAuthenticated().block();
         assertThat(authenticated.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(UsersApi.GetAuthenticated200.class);
+        assertThat(authenticated.getBody()).isNotNull().isInstanceOf(PrivateUser.class);
         var body = authenticated.getBody();
 
-        assertThat(body.getPrivateUser()).isNotNull();
-        var privateUser = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PrivateUser.class);
+        var privateUser = (PrivateUser) body;
         assertThat(privateUser.getId()).isEqualTo(193047L);
         assertThat(privateUser.getLogin()).isEqualTo("rahulsom");
         assertThat(privateUser.getPlan()).isNotNull();
@@ -267,13 +267,8 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-        assertThat(response.getBody()).isNotNull();
-        var body = response.getBody();
-
-        // TODO: This should be a PublicUser
-        assertThat(body.getPrivateUser()).isNotNull();
-
-        var user = body.getPrivateUser();
+        assertThat(response.getBody()).isNotNull().isInstanceOf(PublicUser.class);
+        var user = (PublicUser) response.getBody();
 
         assertThat(user.getLogin()).isEqualTo("sghill");
         assertThat(user.getName()).isEqualTo("Steve Hill");
@@ -295,13 +290,8 @@ class UsersApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
-        assertThat(response.getBody()).isNotNull();
-        var body = response.getBody();
-
-        // TODO: This should be a PublicUser
-        assertThat(body.getPrivateUser()).isNotNull();
-
-        var user = body.getPrivateUser();
+        assertThat(response.getBody()).isNotNull().isInstanceOf(PublicUser.class);
+        var user = (PublicUser) response.getBody();
 
         assertThat(user.getLogin()).isEqualTo("sghill");
         assertThat(user.getName()).isEqualTo("Steve Hill");

--- a/pulpogato-rest-ghestest/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
+++ b/pulpogato-rest-ghestest/src/test/java/io/github/pulpogato/rest/api/UsersApiIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.pulpogato.rest.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.pulpogato.rest.schemas.PublicUser;
 import io.github.pulpogato.test.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
 
@@ -19,10 +20,8 @@ class UsersApiIntegrationTest extends BaseIntegrationTest {
         assertThat(response.getBody()).isNotNull();
         var body = response.getBody();
 
-        assertThat(body.getPrivateUser()).isNotNull();
-        assertThat(body.getPublicUser()).isNull();
-
-        var user = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PublicUser.class);
+        var user = (PublicUser) body;
 
         assertThat(user.getLogin()).isEqualTo("user1");
         assertThat(user.getName()).isEqualTo("User One");
@@ -48,10 +47,8 @@ class UsersApiIntegrationTest extends BaseIntegrationTest {
         assertThat(response.getBody()).isNotNull();
         var body = response.getBody();
 
-        assertThat(body.getPrivateUser()).isNotNull();
-        assertThat(body.getPublicUser()).isNull();
-
-        var user = body.getPrivateUser();
+        assertThat(body).isInstanceOf(PublicUser.class);
+        var user = (PublicUser) body;
 
         assertThat(user.getLogin()).isEqualTo("user2");
         assertThat(user.getName()).isEqualTo("User Two");


### PR DESCRIPTION
## Summary

- Introduces `DiscriminatedOneOfGroups` which scans path responses for `oneOf` schemas that have a `discriminator.propertyName` and `discriminator.mapping`, where all branches are `$ref`s to object-type component schemas
- Generates a sealed interface (e.g. `User`) annotated with `@JsonTypeInfo(use=NAME, include=EXISTING_PROPERTY)` and `@JsonSubTypes`, so Jackson routes deserialization to the correct concrete subtype via the discriminator property
- Replaces the composition wrapper pattern (a class with one field per branch) for these cases, which was broken: the first branch always won because `FancyDeserializerSupport` tried branches in declaration order and stopped at the first successful parse
- The `user_view_type` discriminator now correctly selects `PrivateUser` or `PublicUser` for `GET /user`, `GET /user/{account_id}`, and `GET /users/{username}`
- Updates `UsersApiIntegrationTest` (blocking and reactive) to assert the concrete type and cast accordingly

## Verification

- Codegen plugin: 54 tests passing
- `pulpogato-rest-fpt` tests: all passing (2597 passing, 90 pending)
- `UsersApiIntegrationTest.testGetAuthenticatedPublic` now correctly returns `PublicUser`; `testGetAuthenticatedPrivate` returns `PrivateUser`

## Notes

- `GET /repos/{owner}/{repo}/contents/{path}` has a `type`-discriminated `oneOf` but one branch (`content-directory`) is `type: array`, so it is excluded from this pattern and continues to use the composition wrapper
- OpenAPI examples that predate `user_view_type` are handled via `defaultImpl` on `@JsonTypeInfo`, falling back to the first declared branch when the discriminator property is absent