### PR TITLE
test(common): improve coverage for LinkedHashMapBuilder

### DIFF
--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/util/LinkedHashMapBuilderTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/util/LinkedHashMapBuilderTest.java
@@ -27,4 +27,45 @@ class LinkedHashMapBuilderTest {
 
         assertThat(map.keySet()).containsExactly("c", "a", "b");
     }
+
+    @Test
+    void shouldReturnEmptyMapWhenNoEntriesProvided() {
+        Map<String, String> map = LinkedHashMapBuilder.of();
+
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    void shouldHandleSingleEntry() {
+        Map<String, String> map = LinkedHashMapBuilder.of(LinkedHashMapBuilder.entry("only", "value"));
+
+        assertThat(map).hasSize(1);
+        assertThat(map.get("only")).isEqualTo("value");
+    }
+
+    @Test
+    void shouldHandleNullKeys() {
+        Map<String, String> map = LinkedHashMapBuilder.of(LinkedHashMapBuilder.entry(null, "value"));
+
+        assertThat(map).hasSize(1);
+        assertThat(map.get(null)).isEqualTo("value");
+    }
+
+    @Test
+    void shouldOverwriteOnDuplicateKeys() {
+        Map<String, String> map = LinkedHashMapBuilder.of(
+                LinkedHashMapBuilder.entry("key", "first"), LinkedHashMapBuilder.entry("key", "second"));
+
+        assertThat(map).hasSize(1);
+        assertThat(map.get("key")).isEqualTo("second");
+    }
+
+    @Test
+    void shouldSupportMixedNumericValueTypes() {
+        Map<String, Number> map = LinkedHashMapBuilder.of(
+                LinkedHashMapBuilder.entry("int", 1), LinkedHashMapBuilder.entry("float", 1.5f));
+
+        assertThat(map.get("int")).isEqualTo(1);
+        assertThat(map.get("float")).isEqualTo(1.5f);
+    }
 }


### PR DESCRIPTION
## Summary

Add tests for previously untested cases of `LinkedHashMapBuilder`:

- `of()` with no entries (empty map)
- `of()` with a single entry
- null keys
- duplicate keys (last writer wins)
- mixed numeric value types (`Integer` + `Float` inferred as `Number`)