### PR TITLE
feat(codegen): use sealed interface for non-discriminated oneOf schemas

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Context.kt
@@ -23,6 +23,7 @@ data class Context(
     val schemaStack: List<String>,
     val addedProperties: Map<String, Map<String, String>> = emptyMap(),
     val discriminatedOneOfGroups: List<DiscriminatedOneOfGroups.Group> = emptyList(),
+    val nonDiscriminatedOneOfGroups: List<NonDiscriminatedOneOfGroups.Group> = emptyList(),
 ) {
     // Cached schema stack reference to avoid repeated string operations
     private val cachedSchemaStackRef: String by lazy { schemaStackRef(schemaStack) }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -162,9 +162,11 @@ open class GenerateJavaTask : DefaultTask() {
 
         val schemasPackage = "$packageNamePrefix.rest.schemas"
         val discriminatedOneOfGroups = DiscriminatedOneOfGroups.compute(openAPI, schemasPackage)
-        val context = Context(openAPI, version, emptyList(), addedProperties, discriminatedOneOfGroups)
+        val nonDiscriminatedOneOfGroups = NonDiscriminatedOneOfGroups.compute(openAPI, schemasPackage)
+        val context =
+            Context(openAPI, version, emptyList(), addedProperties, discriminatedOneOfGroups, nonDiscriminatedOneOfGroups)
         val enumConverters = mutableSetOf<com.palantir.javapoet.ClassName>()
-        var enumConverterPackageName = "$packageNamePrefix.rest.api"
+        val enumConverterPackageName = "$packageNamePrefix.rest.api"
         PathsBuilder().buildApis(context, main, test, "$packageNamePrefix.rest.api", enumConverterPackageName, enumConverters, false)
         PathsBuilder().buildApis(context, main, test, "$packageNamePrefix.rest.api.reactive", enumConverterPackageName, enumConverters, true)
         WebhooksBuilder().buildWebhooks(context, main, test, "$packageNamePrefix.rest", "$packageNamePrefix.rest.webhooks")

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/NonDiscriminatedOneOfGroups.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/NonDiscriminatedOneOfGroups.kt
@@ -1,0 +1,130 @@
+package io.github.pulpogato.restcodegen
+
+import com.palantir.javapoet.ClassName
+import io.github.pulpogato.restcodegen.ext.pascalCase
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
+
+/**
+ * Computes sealed supertypes for REST API `oneOf` schemas that do NOT carry a discriminator.
+ *
+ * This is the non-discriminated counterpart to [DiscriminatedOneOfGroups]. Where a discriminator is
+ * present, [DiscriminatedOneOfGroups] lets Jackson route by reading the discriminator property; here
+ * there is nothing in the payload to route on, so the generated interface uses a custom deserializer
+ * that tries each permitted subtype in turn (the same first-match-wins behaviour as the wrapper it
+ * replaces).
+ *
+ * Naming is **context-derived**: each interface is identified by the location where the `oneOf`
+ * occurs and named after the enclosing component schema plus the property path (e.g.
+ * `integration.owner` -> `IntegrationOwner`). Unlike [DiscriminatedOneOfGroups], groups are therefore
+ * keyed by location rather than by member set: two sites that happen to share a member set become two
+ * interfaces (and the member classes implement both). That fragmentation is the accepted cost of a
+ * name that reads from the usage site instead of from the variant list.
+ *
+ * Scope (intentionally narrow for now):
+ * - Only `oneOf`s reached through component-schema properties are considered. Inline `oneOf`s in path
+ *   responses have no natural property name to derive from and keep their existing wrapper.
+ * - `empty-object` members are skipped — it is a special pulpogato type, not a generated POJO, and the
+ *   unions that contain it (e.g. `commit.author`) are exercised by hand-written tests.
+ * - The member count is capped to keep the prototype focused on the simple cases; large unions
+ *   (`repository-rule`, `secret-scanning-location` details) are left as wrappers.
+ */
+object NonDiscriminatedOneOfGroups {
+    data class Group(
+        val supertype: ClassName,
+        val memberSchemaKeys: List<String>,
+        /** JSON-pointer location of the `oneOf`, matching [Context.getSchemaStackRef]. */
+        val locationRef: String,
+    )
+
+    private const val COMPONENTS_SCHEMAS_PREFIX = "#/components/schemas/"
+    private const val EMPTY_OBJECT = "empty-object"
+    private const val MIN_MEMBERS = 2
+    private const val MAX_MEMBERS = 4
+
+    // Structural path segments carry no meaning in the human-facing type name.
+    private val STRUCTURAL_SEGMENTS = setOf("properties", "items", "additionalProperties", "oneOf", "anyOf", "allOf")
+
+    fun compute(
+        openAPI: OpenAPI,
+        schemasPackage: String,
+    ): List<Group> {
+        val componentSchemas = openAPI.components?.schemas ?: return emptyList()
+        // Keyed by locationRef; LinkedHashMap keeps generation order stable across runs.
+        val groups = LinkedHashMap<String, Group>()
+
+        componentSchemas.forEach { (key, schema) ->
+            walk(schema, "$COMPONENTS_SCHEMAS_PREFIX$key", componentSchemas, schemasPackage, groups)
+        }
+
+        return groups.values.toList()
+    }
+
+    /**
+     * Recurses into inline subschemas only, threading the JSON-pointer [ref] of the current node.
+     * `$ref`s are treated as leaves, which bounds the recursion even for mutually recursive schemas.
+     */
+    private fun walk(
+        schema: Schema<*>?,
+        ref: String,
+        componentSchemas: Map<String, Schema<*>>,
+        schemasPackage: String,
+        groups: MutableMap<String, Group>,
+    ) {
+        if (schema == null || schema.`$ref` != null) return
+
+        consider(schema, ref, componentSchemas, schemasPackage, groups)
+
+        schema.properties?.forEach { (key, value) -> walk(value, "$ref/properties/$key", componentSchemas, schemasPackage, groups) }
+        schema.items?.let { walk(it, "$ref/items", componentSchemas, schemasPackage, groups) }
+        (schema.additionalProperties as? Schema<*>)?.let { walk(it, "$ref/additionalProperties", componentSchemas, schemasPackage, groups) }
+        listOf("oneOf" to schema.oneOf, "anyOf" to schema.anyOf, "allOf" to schema.allOf).forEach { (label, branches) ->
+            branches?.filterNotNull()?.forEachIndexed { index, branch ->
+                walk(branch, "$ref/$label/$index", componentSchemas, schemasPackage, groups)
+            }
+        }
+    }
+
+    private fun consider(
+        schema: Schema<*>,
+        ref: String,
+        componentSchemas: Map<String, Schema<*>>,
+        schemasPackage: String,
+        groups: MutableMap<String, Group>,
+    ) {
+        if (schema.discriminator != null) return
+        val oneOf = schema.oneOf?.filterNotNull()?.takeIf { it.isNotEmpty() } ?: return
+
+        val refKeys = oneOf.mapNotNull { it.`$ref`?.removePrefix(COMPONENTS_SCHEMAS_PREFIX) }
+        // Every branch must be a $ref to a component schema.
+        if (refKeys.size != oneOf.size) return
+        if (refKeys.size !in MIN_MEMBERS..MAX_MEMBERS) return
+        if (refKeys.any { it == EMPTY_OBJECT }) return
+
+        val allObjects =
+            refKeys.all { key ->
+                val s = componentSchemas[key] ?: return@all false
+                s.types == null || s.types.contains("object") || s.properties != null
+            }
+        if (!allObjects) return
+
+        // Sort members so the `permits` clause and the deserializer's candidate order are stable
+        // regardless of branch declaration order. For a well-formed oneOf exactly one branch validates,
+        // so try-order has no functional effect on correct payloads. The name comes from the location,
+        // so it is already independent of branch order.
+        val memberKeys = refKeys.sorted()
+        groups[ref] = Group(ClassName.get(schemasPackage, contextName(ref)), memberKeys, ref)
+    }
+
+    /**
+     * Derives a type name from the `oneOf` location: the enclosing component schema plus the property
+     * path, dropping structural segments and array indices. e.g.
+     * `#/components/schemas/integration/properties/owner` -> `IntegrationOwner`.
+     */
+    private fun contextName(ref: String): String =
+        ref
+            .removePrefix(COMPONENTS_SCHEMAS_PREFIX)
+            .split("/")
+            .filter { it.isNotEmpty() && it !in STRUCTURAL_SEGMENTS && it.toIntOrNull() == null }
+            .joinToString("") { it.pascalCase() }
+}

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
@@ -5,6 +5,7 @@ import com.palantir.javapoet.ClassName
 import com.palantir.javapoet.CodeBlock
 import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.MethodSpec
+import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
 import io.github.pulpogato.restcodegen.Annotations.generated
@@ -17,6 +18,7 @@ class SchemasBuilder {
     private companion object {
         // jackson-annotations keeps this package for both Jackson 2 and Jackson 3.
         const val PACKAGE_JACKSON_ANNOTATION = "com.fasterxml.jackson.annotation"
+        const val PACKAGE_PULPOGATO_JACKSON = "io.github.pulpogato.common.jackson"
         const val TYPE_CLASS_FORMAT = "\$T.class"
     }
 
@@ -33,17 +35,24 @@ class SchemasBuilder {
         // group before generating, so each member class can be tagged as a permitted subtype.
         val supertypeGroups = WebhookSupertypes.compute(openAPI, packageName)
         val discriminatedGroups = context.discriminatedOneOfGroups
+        val nonDiscriminatedGroups = context.nonDiscriminatedOneOfGroups
         // A body schema can belong to more than one subcategory (e.g. the `exemption-request-*` bodies
         // are shared by several `*_request_*` events), so a member may be permitted by multiple sealed
-        // interfaces and must implement all of them. Discriminated REST API oneOf groups are included.
+        // interfaces and must implement all of them. Discriminated and non-discriminated REST API oneOf
+        // groups are included alongside the webhook supertypes.
         val schemaKeyToSupertypes =
             (
                 supertypeGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } } +
-                    discriminatedGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } }
+                    discriminatedGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } } +
+                    nonDiscriminatedGroups.flatMap { g -> g.memberSchemaKeys.map { it to g.supertype } }
             ).groupBy({ it.first }, { it.second })
 
         // Captured per member schema so we can later derive the getters common to every member.
         val memberFieldsByKey = mutableMapOf<String, Map<String, TypeName>>()
+
+        // Members of a non-discriminated group need their inherited @JsonDeserialize cancelled (see
+        // enrichMember): the interface carries the deserializer and would otherwise recurse into itself.
+        val nonDiscriminatedMemberKeys = nonDiscriminatedGroups.flatMap { it.memberSchemaKeys }.toSet()
 
         openAPI.components.schemas.forEach { entry ->
             val (typeName, definition) =
@@ -52,7 +61,7 @@ class SchemasBuilder {
                 val supertypes = schemaKeyToSupertypes[entry.key]
                 val typeSpec =
                     if (!supertypes.isNullOrEmpty()) {
-                        val (accessible, enriched) = enrichMember(it, supertypes)
+                        val (accessible, enriched) = enrichMember(it, supertypes, entry.key in nonDiscriminatedMemberKeys)
                         memberFieldsByKey[entry.key] = accessible
                         enriched
                     } else {
@@ -71,6 +80,7 @@ class SchemasBuilder {
 
         writeWebhookSupertypeInterfaces(context, mainDir, packageName, supertypeGroups, memberFieldsByKey)
         writeDiscriminatedOneOfInterfaces(context, mainDir, packageName, discriminatedGroups, memberFieldsByKey)
+        writeNonDiscriminatedOneOfInterfaces(context, mainDir, packageName, nonDiscriminatedGroups, memberFieldsByKey)
     }
 
     /**
@@ -140,6 +150,7 @@ class SchemasBuilder {
         javadoc: String,
         annotations: List<AnnotationSpec>,
         memberFieldsByKey: Map<String, Map<String, TypeName>>,
+        nestedTypes: List<TypeSpec> = emptyList(),
     ) {
         val memberFields = memberSchemaKeys.map { memberFieldsByKey[it] }
         // Skip if any member did not generate as a class; otherwise `permits` would dangle.
@@ -171,7 +182,135 @@ class SchemasBuilder {
             )
         }
 
+        nestedTypes.forEach { builder.addType(it) }
+
         JavaFile.builder(packageName, builder.build()).build().writeTo(mainDir)
+    }
+
+    /**
+     * Emits one sealed interface per non-discriminated REST API oneOf group.
+     *
+     * Without a discriminator there is nothing in the payload to route on, so the interface carries a
+     * custom `@JsonDeserialize` (one per Jackson runtime) backed by nested deserializer classes that try
+     * each permitted subtype in turn. The annotation lives on the interface type — not the field — so it
+     * is reachable wherever the interface is used, including through `NullableOptional<Interface>` and
+     * collections. To stop the permitted subtypes from inheriting it (which would recurse infinitely),
+     * each member resets its own deserializer to the default; see [enrichMember]. Serialization needs no
+     * annotation: a field holds a concrete subtype, serialized by its runtime type.
+     */
+    private fun writeNonDiscriminatedOneOfInterfaces(
+        context: Context,
+        mainDir: File,
+        packageName: String,
+        groups: List<NonDiscriminatedOneOfGroups.Group>,
+        memberFieldsByKey: Map<String, Map<String, TypeName>>,
+    ) {
+        groups.forEach { group ->
+            writeSealedInterface(
+                context,
+                mainDir,
+                packageName,
+                group.supertype,
+                group.memberSchemaKeys,
+                "A sealed supertype for a non-discriminated oneOf of " +
+                    group.memberSchemaKeys.joinToString(", ") { "<code>$it</code>" } + ".\n" +
+                    "<br/>With no discriminator, each variant is tried in turn during deserialization.\n" +
+                    "<br/>Use pattern matching over the permitted subtypes to handle each variant.",
+                nonDiscriminatedDeserializeAnnotations(group),
+                memberFieldsByKey,
+                nonDiscriminatedDeserializerTypes(packageName, group),
+            )
+        }
+    }
+
+    /**
+     * The `@JsonDeserialize` pair (Jackson 3 then Jackson 2) placed on a non-discriminated interface,
+     * pointing at the nested deserializer classes from [nonDiscriminatedDeserializerTypes].
+     */
+    private fun nonDiscriminatedDeserializeAnnotations(group: NonDiscriminatedOneOfGroups.Group): List<AnnotationSpec> {
+        val base = group.supertype.simpleName()
+        return listOf(
+            AnnotationSpec
+                .builder(ClassName.get("tools.jackson.databind.annotation", "JsonDeserialize"))
+                .addMember("using", TYPE_CLASS_FORMAT, group.supertype.nestedClass("${base}Jackson3Deserializer"))
+                .build(),
+            AnnotationSpec
+                .builder(ClassName.get("com.fasterxml.jackson.databind.annotation", "JsonDeserialize"))
+                .addMember("using", TYPE_CLASS_FORMAT, group.supertype.nestedClass("${base}Jackson2Deserializer"))
+                .build(),
+        )
+    }
+
+    /**
+     * The `@JsonDeserialize(using = None.class)` pair (Jackson 3 then Jackson 2) that cancels the
+     * deserializer a member would otherwise inherit from a non-discriminated supertype, restoring
+     * default bean deserialization for the concrete member.
+     */
+    private fun deserializerResetAnnotations(): List<AnnotationSpec> =
+        listOf(
+            AnnotationSpec
+                .builder(ClassName.get("tools.jackson.databind.annotation", "JsonDeserialize"))
+                .addMember("using", TYPE_CLASS_FORMAT, ClassName.get("tools.jackson.databind", "ValueDeserializer", "None"))
+                .build(),
+            AnnotationSpec
+                .builder(ClassName.get("com.fasterxml.jackson.databind.annotation", "JsonDeserialize"))
+                .addMember("using", TYPE_CLASS_FORMAT, ClassName.get("com.fasterxml.jackson.databind", "JsonDeserializer", "None"))
+                .build(),
+        )
+
+    /**
+     * Nested no-arg deserializer classes for both Jackson runtimes. Each extends the shared
+     * `JacksonNOneOfDeserializer` and passes the interface type plus the ordered list of candidate
+     * subtypes, since `@JsonDeserialize(using = ...)` requires a no-arg-constructable deserializer.
+     */
+    private fun nonDiscriminatedDeserializerTypes(
+        packageName: String,
+        group: NonDiscriminatedOneOfGroups.Group,
+    ): List<TypeSpec> {
+        val base = group.supertype.simpleName()
+        val memberClasses = group.memberSchemaKeys.map { ClassName.get(packageName, it.pascalCase()) }
+        return listOf(
+            oneOfDeserializerType(
+                "${base}Jackson3Deserializer",
+                ClassName.get(PACKAGE_PULPOGATO_JACKSON, "Jackson3OneOfDeserializer"),
+                group.supertype,
+                memberClasses,
+            ),
+            oneOfDeserializerType(
+                "${base}Jackson2Deserializer",
+                ClassName.get(PACKAGE_PULPOGATO_JACKSON, "Jackson2OneOfDeserializer"),
+                group.supertype,
+                memberClasses,
+            ),
+        )
+    }
+
+    private fun oneOfDeserializerType(
+        simpleName: String,
+        baseClass: ClassName,
+        supertype: ClassName,
+        memberClasses: List<ClassName>,
+    ): TypeSpec {
+        val candidates = CodeBlock.builder().add($$"$T.of(", ClassName.get(List::class.java))
+        memberClasses.forEachIndexed { index, member ->
+            if (index > 0) candidates.add(", ")
+            candidates.add(TYPE_CLASS_FORMAT, member)
+        }
+        candidates.add(")")
+
+        val constructor =
+            MethodSpec
+                .constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement($$"super($T.class, $L)", supertype, candidates.build())
+                .build()
+
+        return TypeSpec
+            .classBuilder(simpleName)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .superclass(ParameterizedTypeName.get(baseClass, supertype))
+            .addMethod(constructor)
+            .build()
     }
 
     /**
@@ -274,11 +413,19 @@ class SchemasBuilder {
     private fun enrichMember(
         typeSpec: TypeSpec,
         supertypes: List<ClassName>,
+        cancelInheritedDeserializer: Boolean,
     ): Pair<Map<String, TypeName>, TypeSpec> {
         // A permitted subtype of a sealed interface must declare its own sealing; these classes are
         // open POJOs, so mark them non-sealed.
         val builder = typeSpec.toBuilder().addModifiers(Modifier.NON_SEALED)
         supertypes.forEach { builder.addSuperinterface(it) }
+
+        // A non-discriminated supertype carries a custom @JsonDeserialize that this member would inherit,
+        // sending the member's own deserialization back through the interface deserializer and recursing
+        // forever. Reset it to the default bean deserializer so reading the concrete member is direct.
+        if (cancelInheritedDeserializer) {
+            deserializerResetAnnotations().forEach { builder.addAnnotation(it) }
+        }
 
         val branches = inlineBranches(typeSpec)
         val accessible =

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -124,6 +124,18 @@ private fun findDiscriminatedGroup(
     null
 }
 
+private fun findNonDiscriminatedGroup(
+    context: Context,
+    schema: Schema<*>,
+    oneOf: List<Schema<*>>?,
+) = if (oneOf != null && schema.discriminator == null) {
+    // Interfaces are identified by where the oneOf occurs, so match on the current schema location
+    // rather than the member set (two locations may share a member set but get distinct interfaces).
+    context.nonDiscriminatedOneOfGroups.find { g -> g.locationRef == context.getSchemaStackRef() }
+} else {
+    null
+}
+
 fun referenceAndDefinition(
     context: Context,
     entry1: Map.Entry<String, Schema<*>?>,
@@ -145,6 +157,7 @@ fun referenceAndDefinition(
     val oneOf = entry.value.oneOf?.filterNotNull()
     val allOf = entry.value.allOf?.filterNotNull()
     val discriminatedGroup = findDiscriminatedGroup(context, entry.value, oneOf)
+    val nonDiscriminatedGroup = findNonDiscriminatedGroup(context, entry.value, oneOf)
 
     return when {
         entry.key == "empty-object" -> {
@@ -201,6 +214,10 @@ fun referenceAndDefinition(
 
         discriminatedGroup != null -> {
             Pair(discriminatedGroup.supertype.annotated(typeGenerated()), null)
+        }
+
+        nonDiscriminatedGroup != null -> {
+            Pair(nonDiscriminatedGroup.supertype.annotated(typeGenerated()), null)
         }
 
         oneOf != null -> {

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2OneOfDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2OneOfDeserializer.java
@@ -1,0 +1,57 @@
+package io.github.pulpogato.common.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Jackson 2 deserializer for a non-discriminated {@code oneOf} modeled as a sealed interface.
+ *
+ * <p>With no discriminator property to route on, each candidate subtype is tried in declaration
+ * order and the first that parses without unknown properties wins. This is the same disambiguation
+ * the wrapper-based {@link Jackson2FancyDeserializer} performs in {@link io.github.pulpogato.common.Mode#ONE_OF},
+ * but it yields the concrete subtype directly instead of a wrapper holding one field per branch.
+ *
+ * @param <T> The sealed interface type
+ */
+public class Jackson2OneOfDeserializer<T> extends StdDeserializer<T> {
+
+    // FAIL_ON_UNKNOWN_PROPERTIES is what lets a wrong candidate be rejected: a payload shaped for one
+    // branch will carry properties the other branch does not declare, so it fails and we move on.
+    private static final ObjectMapper om = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private final transient List<Class<? extends T>> candidates;
+
+    /**
+     * Constructs a deserializer.
+     *
+     * @param vc         The sealed interface type
+     * @param candidates The permitted subtypes, tried in order
+     */
+    public Jackson2OneOfDeserializer(Class<T> vc, List<Class<? extends T>> candidates) {
+        super(vc);
+        this.candidates = candidates;
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        final var map = ctxt.readValue(p, Map.class);
+        final var json = om.writeValueAsString(map);
+        for (final var candidate : candidates) {
+            try {
+                return om.readValue(json, candidate);
+            } catch (Exception e) {
+                // Not this branch; try the next candidate.
+            }
+        }
+        return null;
+    }
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3OneOfDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3OneOfDeserializer.java
@@ -1,0 +1,55 @@
+package io.github.pulpogato.common.jackson;
+
+import java.util.List;
+import java.util.Map;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * A Jackson 3 deserializer for a non-discriminated {@code oneOf} modeled as a sealed interface.
+ *
+ * <p>With no discriminator property to route on, each candidate subtype is tried in declaration
+ * order and the first that parses without unknown properties wins. This is the same disambiguation
+ * the wrapper-based {@link Jackson3FancyDeserializer} performs in {@link io.github.pulpogato.common.Mode#ONE_OF},
+ * but it yields the concrete subtype directly instead of a wrapper holding one field per branch.
+ *
+ * @param <T> The sealed interface type
+ */
+public class Jackson3OneOfDeserializer<T> extends StdDeserializer<T> {
+
+    // FAIL_ON_UNKNOWN_PROPERTIES is what lets a wrong candidate be rejected: a payload shaped for one
+    // branch will carry properties the other branch does not declare, so it fails and we move on.
+    private static final JsonMapper om = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+
+    private final transient List<Class<? extends T>> candidates;
+
+    /**
+     * Constructs a deserializer.
+     *
+     * @param vc         The sealed interface type
+     * @param candidates The permitted subtypes, tried in order
+     */
+    public Jackson3OneOfDeserializer(Class<T> vc, List<Class<? extends T>> candidates) {
+        super(vc);
+        this.candidates = candidates;
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) {
+        final var map = ctxt.readValue(p, Map.class);
+        final var json = om.writeValueAsString(map);
+        for (final var candidate : candidates) {
+            try {
+                return om.readValue(json, candidate);
+            } catch (Exception e) {
+                // Not this branch; try the next candidate.
+            }
+        }
+        return null;
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson2OneOfDeserializerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson2OneOfDeserializerTest.java
@@ -1,0 +1,74 @@
+package io.github.pulpogato.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.github.pulpogato.common.jackson.Jackson2OneOfDeserializer;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class Jackson2OneOfDeserializerTest {
+
+    @JsonDeserialize(using = ShapeDeserializer.class)
+    sealed interface Shape permits Circle, Square {}
+
+    // The None.class reset prevents this class from inheriting the interface's deserializer,
+    // which would otherwise cause infinite recursion.
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    record Circle(@JsonProperty("radius") double radius) implements Shape {}
+
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    record Square(@JsonProperty("side") double side) implements Shape {}
+
+    static class ShapeDeserializer extends Jackson2OneOfDeserializer<Shape> {
+        public ShapeDeserializer() {
+            super(Shape.class, List.of(Circle.class, Square.class));
+        }
+    }
+
+    static class Wrapper {
+        public Shape shape;
+    }
+
+    static Stream<Arguments> correctBranchParams() {
+        return Stream.of(
+                Arguments.of("{\"shape\":{\"radius\":3.0}}", Circle.class, 3.0, 0.0),
+                Arguments.of("{\"shape\":{\"side\":5.0}}", Square.class, 0.0, 5.0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("correctBranchParams")
+    void picksCorrectBranch(String json, Class<?> expectedType, double radius, double side) throws Exception {
+        var om = new com.fasterxml.jackson.databind.ObjectMapper();
+        var result = om.readValue(json, Wrapper.class);
+        assertThat(result.shape).isInstanceOf(expectedType);
+        if (result.shape instanceof Circle c) {
+            assertThat(c.radius()).isEqualTo(radius);
+        } else if (result.shape instanceof Square s) {
+            assertThat(s.side()).isEqualTo(side);
+        }
+    }
+
+    @Test
+    void firstCandidateWinsWhenBothCouldMatch() throws Exception {
+        // Both Circle and Square could accept a payload with only shared fields;
+        // Circle is first in the candidate list, so it wins.
+        var om = new com.fasterxml.jackson.databind.ObjectMapper();
+        var result = om.readValue("{\"shape\":{}}", Wrapper.class);
+        assertThat(result.shape).isInstanceOf(Circle.class);
+    }
+
+    @Test
+    void returnsNullWhenNoMatchFound() throws Exception {
+        // A payload with a field unknown to all candidates fails every branch and returns null.
+        var om = new com.fasterxml.jackson.databind.ObjectMapper();
+        var result = om.readValue("{\"shape\":{\"unknown_field\":true}}", Wrapper.class);
+        assertThat(result.shape).isNull();
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson3OneOfDeserializerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson3OneOfDeserializerTest.java
@@ -1,0 +1,76 @@
+package io.github.pulpogato.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.pulpogato.common.jackson.Jackson3OneOfDeserializer;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+class Jackson3OneOfDeserializerTest {
+
+    @JsonDeserialize(using = ShapeDeserializer.class)
+    sealed interface Shape permits Circle, Square {}
+
+    // The None.class reset prevents this class from inheriting the interface's deserializer,
+    // which would otherwise cause infinite recursion.
+    @JsonDeserialize(using = ValueDeserializer.None.class)
+    record Circle(@JsonProperty("radius") double radius) implements Shape {}
+
+    @JsonDeserialize(using = ValueDeserializer.None.class)
+    record Square(@JsonProperty("side") double side) implements Shape {}
+
+    static class ShapeDeserializer extends Jackson3OneOfDeserializer<Shape> {
+        public ShapeDeserializer() {
+            super(Shape.class, List.of(Circle.class, Square.class));
+        }
+    }
+
+    static class Wrapper {
+        public Shape shape;
+    }
+
+    static Stream<Arguments> correctBranchParams() {
+        return Stream.of(
+                Arguments.of("{\"shape\":{\"radius\":3.0}}", Circle.class, 3.0, 0.0),
+                Arguments.of("{\"shape\":{\"side\":5.0}}", Square.class, 0.0, 5.0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("correctBranchParams")
+    void picksCorrectBranch(String json, Class<?> expectedType, double radius, double side) {
+        var om = new ObjectMapper();
+        var result = om.readValue(json, Wrapper.class);
+        assertThat(result.shape).isInstanceOf(expectedType);
+        if (result.shape instanceof Circle c) {
+            assertThat(c.radius()).isEqualTo(radius);
+        } else if (result.shape instanceof Square s) {
+            assertThat(s.side()).isEqualTo(side);
+        }
+    }
+
+    @Test
+    void firstCandidateWinsWhenBothCouldMatch() {
+        // Both Circle and Square could accept a payload with only shared fields;
+        // Circle is first in the candidate list, so it wins.
+        var om = new ObjectMapper();
+        var result = om.readValue("{\"shape\":{}}", Wrapper.class);
+        // Empty object matches Circle first (it is listed first).
+        assertThat(result.shape).isInstanceOf(Circle.class);
+    }
+
+    @Test
+    void returnsNullWhenNoMatchFound() {
+        // A payload with a field unknown to all candidates fails every branch and returns null.
+        var om = new ObjectMapper();
+        var result = om.readValue("{\"shape\":{\"unknown_field\":true}}", Wrapper.class);
+        assertThat(result.shape).isNull();
+    }
+}

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/NullableOptionalTest.java
@@ -3,7 +3,13 @@ package io.github.pulpogato.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.pulpogato.common.jackson.Jackson2OneOfDeserializer;
+import io.github.pulpogato.common.jackson.Jackson3OneOfDeserializer;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class NullableOptionalTest {
@@ -204,5 +210,85 @@ class NullableOptionalTest {
 
     static class TestWrapper {
         public NullableOptional<String> field = NullableOptional.notSet();
+    }
+
+    // -- NullableOptional<SealedInterface> tests ---------------------------------------------------
+    // This combination is the critical path: NullableOptionalJacksonNDeserializer reads the inner
+    // value via the interface's declared type, so the interface's @JsonDeserialize must be present
+    // on the type itself. The None.class reset on each member prevents the inherited annotation from
+    // causing a StackOverflowError when the inner deserializer tries a concrete subtype.
+
+    @tools.jackson.databind.annotation.JsonDeserialize(using = ColorJackson3Deserializer.class)
+    @JsonDeserialize(using = ColorJackson2Deserializer.class)
+    sealed interface Color permits RedColor, BlueColor {}
+
+    @tools.jackson.databind.annotation.JsonDeserialize(using = tools.jackson.databind.ValueDeserializer.None.class)
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    record RedColor(@JsonProperty("red") int red) implements Color {}
+
+    @tools.jackson.databind.annotation.JsonDeserialize(using = tools.jackson.databind.ValueDeserializer.None.class)
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    record BlueColor(@JsonProperty("blue") int blue) implements Color {}
+
+    static class ColorJackson3Deserializer extends Jackson3OneOfDeserializer<Color> {
+        public ColorJackson3Deserializer() {
+            super(Color.class, List.of(RedColor.class, BlueColor.class));
+        }
+    }
+
+    static class ColorJackson2Deserializer extends Jackson2OneOfDeserializer<Color> {
+        public ColorJackson2Deserializer() {
+            super(Color.class, List.of(RedColor.class, BlueColor.class));
+        }
+    }
+
+    static class ColorWrapper {
+        public NullableOptional<Color> color = NullableOptional.notSet();
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceAbsentJackson3() {
+        var om = new tools.jackson.databind.ObjectMapper();
+        var result = om.readValue("{}", ColorWrapper.class);
+        assertThat(result.color.isNotSet()).isTrue();
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceNullJackson3() {
+        var om = new tools.jackson.databind.ObjectMapper();
+        var result = om.readValue("{\"color\":null}", ColorWrapper.class);
+        assertThat(result.color.isNull()).isTrue();
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceValueJackson3() {
+        var om = new tools.jackson.databind.ObjectMapper();
+        var result = om.readValue("{\"color\":{\"red\":255}}", ColorWrapper.class);
+        assertThat(result.color.isValue()).isTrue();
+        assertThat(result.color.getValue()).isInstanceOf(RedColor.class);
+        assertThat(((RedColor) result.color.getValue()).red()).isEqualTo(255);
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceAbsentJackson2() throws Exception {
+        var om = new com.fasterxml.jackson.databind.ObjectMapper().registerModule(new JavaTimeModule());
+        var result = om.readValue("{}", ColorWrapper.class);
+        assertThat(result.color.isNotSet()).isTrue();
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceNullJackson2() throws Exception {
+        var om = new com.fasterxml.jackson.databind.ObjectMapper().registerModule(new JavaTimeModule());
+        var result = om.readValue("{\"color\":null}", ColorWrapper.class);
+        assertThat(result.color.isNull()).isTrue();
+    }
+
+    @Test
+    void testNullableOptionalSealedInterfaceValueJackson2() throws Exception {
+        var om = new com.fasterxml.jackson.databind.ObjectMapper().registerModule(new JavaTimeModule());
+        var result = om.readValue("{\"color\":{\"blue\":128}}", ColorWrapper.class);
+        assertThat(result.color.isValue()).isTrue();
+        assertThat(result.color.getValue()).isInstanceOf(BlueColor.class);
+        assertThat(((BlueColor) result.color.getValue()).blue()).isEqualTo(128);
     }
 }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/AppsApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/AppsApiIntegrationTest.java
@@ -1,0 +1,29 @@
+package io.github.pulpogato.rest.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.pulpogato.rest.schemas.IntegrationOwner;
+import io.github.pulpogato.rest.schemas.SimpleUser;
+import org.junit.jupiter.api.Test;
+
+class AppsApiIntegrationTest extends BaseApiIntegrationTest {
+
+    @Test
+    void testGetBySlugResolvesOwnerToSimpleUser() {
+        var api = new RestClients(webClient).getAppsApi();
+        // GET /apps/{app_slug} is a public endpoint; renovate is a well-known GitHub App
+        // owned by renovate-bot (a user account), so the owner field always resolves to SimpleUser.
+        var response = api.getBySlug("renovate");
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        var integration = response.getBody();
+        assertThat(integration).isNotNull();
+        assertThat(integration.getSlug()).isEqualTo("renovate");
+
+        IntegrationOwner owner = integration.getOwner();
+        assertThat(owner).isNotNull().isInstanceOf(SimpleUser.class);
+        var simpleUser = (SimpleUser) owner;
+        assertThat(simpleUser.getLogin()).isEqualTo("mend");
+        assertThat(simpleUser.getId()).isEqualTo(105765982L);
+    }
+}

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CopilotApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/CopilotApiIntegrationTest.java
@@ -1,0 +1,26 @@
+package io.github.pulpogato.rest.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CopilotApiIntegrationTest extends BaseApiIntegrationTest {
+
+    // Replace with an org and user who has a Copilot seat assigned via a team.
+    private static final String ORG = "example";
+    private static final String USER_WITH_TEAM_SEAT = "rahulsom";
+
+    @Test
+    void testGetCopilotSeatDetailsForUserWithDirectAssignment() {
+        var api = new RestClients(webClient).getCopilotApi();
+        var response = api.getCopilotSeatDetailsForUser(ORG, USER_WITH_TEAM_SEAT);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        var seat = response.getBody();
+        assertThat(seat).isNotNull();
+
+        var assigningTeam = seat.getAssigningTeam();
+        assertThat(assigningTeam).isNotNull();
+        assertThat(assigningTeam.isNotSet()).isTrue();
+    }
+}

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/AppsApiIntegrationTest/testGetBySlugResolvesOwnerToSimpleUser.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/AppsApiIntegrationTest/testGetBySlugResolvesOwnerToSimpleUser.yml
@@ -1,0 +1,61 @@
+- request:
+    method: GET
+    uri: /apps/renovate
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    bodyIsBinary: false
+    body: |-
+      {
+        "id" : 2740,
+        "client_id" : "Iv1.9f820358a2aa6747",
+        "slug" : "renovate",
+        "node_id" : "MDM6QXBwMjc0MA==",
+        "owner" : {
+          "login" : "mend",
+          "id" : 105765982,
+          "node_id" : "O_kgDOBk3cXg",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/105765982?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/mend",
+          "html_url" : "https://github.com/mend",
+          "followers_url" : "https://api.github.com/users/mend/followers",
+          "following_url" : "https://api.github.com/users/mend/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/mend/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/mend/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/mend/subscriptions",
+          "organizations_url" : "https://api.github.com/users/mend/orgs",
+          "repos_url" : "https://api.github.com/users/mend/repos",
+          "events_url" : "https://api.github.com/users/mend/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/mend/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "name" : "Renovate",
+        "description" : "## Automated Dependency Updates\r\n\r\n[Mend Renovate](https://www.mend.io/renovate/) keeps source code dependencies up-to-date using automated Pull Requests. It will scan repositories for package manager files (e.g. from npm/Yarn, Bundler, Composer, Go Modules, Pip/Pipenv/Poetry, Maven/Gradle, Dockerfile/k8s, and many more), and submit Pull Requests with updated versions whenever they are found.\r\n\r\nThis app is free to install for both public and private repositories. Service is provided complimentary of Mend (formerly known as WhiteSource) and no paid plan is required.\r\n\r\n### Intelligent, helpful onboarding\r\n\r\n![Onboarding](https://docs.renovatebot.com/assets/images/onboarding.png)\r\n\r\nInstall Mend Renovate risk-free and you'll first receive an onboarding Pull Request in each repository. It analyzes the repository files and describes what will happen next, so there's no surprises. \r\n\r\n### Unopinionated, highly flexible configuration\r\n\r\n```json\r\n{\r\n  \"rangeStrategy\": \"pin\",\r\n  \"ignorePaths\": [\"examples/**\"],\r\n  \"packageRules\": [{\r\n    \"packagePatterns\": [\"^angular.*\"],\r\n    \"groupName\": \"angular\",\r\n    \"automerge\": true\r\n  }]\r\n}\r\n```\r\n\r\nModify any of Renovate's smart defaults with custom overrides at the repository, package file, dependency type, and package levels. \r\n\r\n### Support for monorepo directory structures\r\n\r\nRenovate will scan all files in each repository to look for relevant package files. It will also group upgrades from the same monorepo into a single PR to ensure tests pass and PR noise is reduced. Natively supports Lerna and Yarn Workspaces with zero configuration necessary.\r\n\r\nIt is also works fine with a mix of package managers / languages within the same repository.\r\n\r\n### Automatic lock file and checksum support\r\n\r\nRenovate will generate updated lock files such as `package-lock.json` or `yarn.lock` if you're already using them. It will also automatically resolve any conflicts after merges.\r\n\r\n### Ease the noise with custom schedules\r\n\r\n```json\r\n{\r\n  \"timezone\": \"America/New_York\",\r\n  \"schedule\": \"before 5am every weekday\",\r\n  \"lockFileMaintenance\": {\r\n    \"enabled\": true,\r\n    \"schedule\": \"after 10pm on sunday\"\r\n  },\r\n  \"packageRules\": [{\r\n    \"packageNames\": [\"aws-sdk\"],\r\n    \"schedule\": \"before 5am every wednesday\"\r\n  }]\r\n}\r\n```\r\n\r\nThrottle updates however you want with schedules, configurable right down to the per-package level.\r\n\r\n### Rules-based automerging\r\n\r\n![automerging](https://docs.renovatebot.com/assets/images/automerged-pr.png)\r\n\r\nMerge some updates without human intervention if they pass tests and satisfy your automerge rules.",
+        "external_url" : "https://www.mend.io/renovate/",
+        "html_url" : "https://github.com/apps/renovate",
+        "created_at" : "2017-06-02T07:04:12Z",
+        "updated_at" : "2025-12-15T14:03:12Z",
+        "permissions" : {
+          "administration" : "read",
+          "checks" : "write",
+          "contents" : "write",
+          "emails" : "read",
+          "issues" : "write",
+          "members" : "read",
+          "metadata" : "read",
+          "packages" : "read",
+          "pull_requests" : "write",
+          "statuses" : "write",
+          "vulnerability_alerts" : "read",
+          "workflows" : "write"
+        },
+        "events" : [ "issues", "issue_comment", "pull_request", "pull_request_review_comment", "push", "repository" ]
+      }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/CopilotApiIntegrationTest/testGetCopilotSeatDetailsForUserWithDirectAssignment.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/CopilotApiIntegrationTest/testGetCopilotSeatDetailsForUserWithDirectAssignment.yml
@@ -1,0 +1,43 @@
+- request:
+    method: GET
+    uri: /orgs/example/members/rahulsom/copilot
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    bodyIsBinary: false
+    body: |-
+      {
+        "created_at" : "2023-09-18T21:39:11-07:00",
+        "assignee" : {
+          "login" : "rahulsom",
+          "id" : 193047,
+          "node_id" : "MDQ6VXNlcjE5MzA0Nw==",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/193047?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/rahulsom",
+          "html_url" : "https://github.com/rahulsom",
+          "followers_url" : "https://api.github.com/users/rahulsom/followers",
+          "following_url" : "https://api.github.com/users/rahulsom/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/rahulsom/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/rahulsom/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/rahulsom/subscriptions",
+          "organizations_url" : "https://api.github.com/users/rahulsom/orgs",
+          "repos_url" : "https://api.github.com/users/rahulsom/repos",
+          "events_url" : "https://api.github.com/users/rahulsom/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/rahulsom/received_events",
+          "type" : "User",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "pending_cancellation_date" : null,
+        "plan_type" : "business",
+        "last_authenticated_at" : "2026-06-27T16:14:35Z",
+        "updated_at" : "2024-10-15T00:00:00-07:00",
+        "last_activity_at" : "2026-06-27T09:14:32-07:00",
+        "last_activity_editor" : "unknown/GitHubCopilotChat/0.53.1"
+      }


### PR DESCRIPTION
## Summary

- Generalizes the discriminated oneOf pattern to OpenAPI schemas that have no discriminator. The codegen now emits a sealed interface for each non-discriminated oneOf group, with paired `@JsonDeserialize` annotations (Jackson 3 and Jackson 2) pointing at nested deserializer classes baked into the interface.
- Each deserializer tries the permitted subtypes in order using `FAIL_ON_UNKNOWN_PROPERTIES` to pick the first branch that parses cleanly. Member classes reset the inherited `@JsonDeserialize` to the default bean deserializer to prevent the interface-level deserializer from recursing into itself — this reset is required both for direct `Interface` fields and for `NullableOptional<Interface>` fields.
- Adds unit tests for `Jackson2OneOfDeserializer` and `Jackson3OneOfDeserializer`, `NullableOptional<SealedInterface>` tests for both Jackson runtimes, and integration tests against recorded API tapes exercising the generated `IntegrationOwner` and `CopilotSeatDetailsAssigningTeam` sealed interfaces.

Follows on from #1226 (discriminated oneOf sealed interfaces).