### PR TITLE
feat(codegen): model allOf schemas as subclasses or flattened objects

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -209,9 +209,52 @@ fun referenceAndDefinition(
             }
         }
 
+        allOf != null && allOf.size == 1 -> {
+            // A single-member allOf adds nothing structurally; collapse it to that member directly
+            // (GitHub commonly uses this just to attach a description to a $ref).
+            referenceAndDefinition(
+                context.withSchemaStack("allOf", "0"),
+                mapOf(entry.key to allOf.first()).entries.first(),
+                prefix,
+                parentClass,
+            )!!
+        }
+
         allOf != null -> {
-            buildType("${prefix}${entry.className()}", parentClass) {
-                buildFancyObject(context, entry, allOf, "allOf", it)
+            val inlines = allOf.filter { it.`$ref` == null }
+            val refs = allOf.filter { it.`$ref` != null }
+            val allInlinesMergeable = inlines.isNotEmpty() && inlines.all { isMergeableInlineObject(it) }
+            val extendableRef = if (refs.size == 1) extendableRefName(context, refs.first()) else null
+            when {
+                // One extendable $ref plus inline property objects: model it as a subclass of the
+                // referenced type that adds the inline properties, instead of a wrapper with a
+                // meaningless "release1"-style field.
+                extendableRef != null && allInlinesMergeable -> {
+                    buildType("${prefix}${entry.className()}", parentClass) {
+                        buildAllOfObject(
+                            context,
+                            entry,
+                            allOf,
+                            it,
+                            ClassName.get("io.github.pulpogato.rest.schemas", extendableRef.pascalCase()),
+                            extendableRef,
+                        )
+                    }
+                }
+
+                // Only inline property objects: flatten their properties into a single object.
+                refs.isEmpty() && allInlinesMergeable -> {
+                    buildType("${prefix}${entry.className()}", parentClass) {
+                        buildAllOfObject(context, entry, allOf, it, null, null)
+                    }
+                }
+
+                // Anything else (e.g. multiple $refs) keeps the runtime merge serializer.
+                else -> {
+                    buildType("${prefix}${entry.className()}", parentClass) {
+                        buildFancyObject(context, entry, allOf, "allOf", it)
+                    }
+                }
             }
         }
 
@@ -431,6 +474,7 @@ private fun addStandardMethodsAndBuilderLogic(
     builder: TypeSpec.Builder,
     fieldSpecs: List<FieldSpec>,
     classRef: ClassName,
+    superType: ClassName? = null,
 ) {
     // Generate all methods
     fieldSpecs.forEach { field ->
@@ -446,13 +490,15 @@ private fun addStandardMethodsAndBuilderLogic(
         .addMethod(generateToString())
         .addMethod(generateNoArgsConstructor())
 
-    if (fieldSpecs.isNotEmpty()) {
-        builder.addMethod(generateAllArgsConstructor(classRef, fieldSpecs))
+    // A subclass always needs an all-args constructor so its SuperBuilder can wire up the
+    // inherited base via super(b), even when it adds no fields of its own.
+    if (fieldSpecs.isNotEmpty() || superType != null) {
+        builder.addMethod(generateAllArgsConstructor(classRef, fieldSpecs, superType))
     }
 
     // Add builder pattern
     builder
-        .addType(generateBuilderClass(classRef, fieldSpecs))
+        .addType(generateBuilderClass(classRef, fieldSpecs, superType))
         .addType(generateBuilderImplClass(classRef))
         .addMethod(generateBuilderFactoryMethod(classRef))
         .addMethod(generateToBuilderMethod(classRef))
@@ -594,6 +640,11 @@ private fun copyTypeSpecToBuilderWithFilteredTypes(
         }
     original.annotations().forEach { builder.addAnnotation(it) }
     original.modifiers().forEach { builder.addModifiers(it) }
+    // Preserve an explicit superclass (e.g. an allOf object that extends a referenced base type).
+    // Enums cannot declare a superclass, and Object is the implicit default, so skip both.
+    if (original.kind() != TypeSpec.Kind.ENUM) {
+        original.superclass()?.takeIf { it != Types.OBJECT }?.let { builder.superclass(it) }
+    }
     original.superinterfaces().forEach { builder.addSuperinterface(it) }
     original.fieldSpecs().forEach { builder.addField(it) }
     original.typeSpecs().filter(typeSpecFilter).forEach { builder.addType(it) }
@@ -812,6 +863,162 @@ private fun buildDeserializer(
                 ).build(),
         ).build()
 
+/**
+ * An inline (non-{@code $ref}) allOf member is "mergeable" when it is a plain object that only
+ * contributes named properties. Such members can be flattened into the surrounding type rather
+ * than being wrapped in their own nested class.
+ */
+private fun isMergeableInlineObject(sub: Schema<*>): Boolean =
+    sub.`$ref` == null &&
+        sub.oneOf == null &&
+        sub.anyOf == null &&
+        sub.allOf == null &&
+        sub.enum == null &&
+        sub.properties != null &&
+        sub.properties.isNotEmpty()
+
+/**
+ * Returns the schema name of a {@code $ref} member when the referenced schema is a plain object
+ * that can serve as a Java superclass (it generates a regular class with the SuperBuilder pattern).
+ * Returns null when the referent is a union, enum, map, or otherwise not safely extendable.
+ */
+private fun extendableRefName(
+    context: Context,
+    refMember: Schema<*>,
+): String? {
+    val name = refMember.`$ref`?.removePrefix(COMPONENTS_SCHEMAS_PREFIX) ?: return null
+    val target =
+        context.openAPI.components
+            ?.schemas
+            ?.get(name) ?: return null
+    val isPlainObject =
+        target.`$ref` == null &&
+            target.oneOf == null &&
+            target.anyOf == null &&
+            target.allOf == null &&
+            target.enum == null &&
+            target.discriminator == null &&
+            target.properties != null &&
+            target.properties.isNotEmpty()
+    return if (isPlainObject) name else null
+}
+
+/**
+ * Builds the class for an allOf composed of plain inline objects, optionally extending a referenced
+ * base type.
+ *
+ * When [superType] is non-null the generated class {@code extends} that base type and declares only
+ * the inline properties (the base properties are inherited). When it is null the inline properties
+ * from every member are flattened into a single standalone object.
+ *
+ * Unlike [buildFancyObject], this produces an ordinary POJO that Jackson serializes via field
+ * access, so no custom merge serializer/deserializer is required.
+ */
+private fun buildAllOfObject(
+    context: Context,
+    entry: Map.Entry<String, Schema<*>>,
+    allOf: List<Schema<Any>>,
+    nameRef: ClassName,
+    superType: ClassName?,
+    baseRefName: String?,
+): TypeSpec {
+    val name = nameRef.simpleName()
+
+    val builder =
+        TypeSpec
+            .classBuilder(name)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(generated(0, context.withSchemaStack("allOf")))
+            .addAnnotation(jsonIncludeNonNull())
+            .addSuperinterface(ClassName.get(PACKAGE_PULPOGATO_COMMON, "PulpogatoType"))
+
+    superType?.let { builder.superclass(it) }
+
+    schemaJavadoc(entry).let {
+        if (it.isNotBlank()) {
+            builder.addJavadoc($$"$L", it)
+        }
+    }
+
+    // Collect parent property names upfront so inline allOf members don't re-declare fields that
+    // are already inherited, which would cause Java type-erasure clashes (e.g. getMembers() with
+    // incompatible List element types in parent vs. child).
+    val baseProperties: List<String> =
+        if (baseRefName != null) {
+            context.openAPI.components
+                ?.schemas
+                ?.get(baseRefName)
+                ?.properties
+                ?.keys
+                ?.map { it.unkeywordize().camelCase() }
+                ?: emptyList()
+        } else {
+            emptyList()
+        }
+    val parentPropertyNames = baseProperties.toSet()
+
+    // Properties declared directly on the allOf schema (rare, but allowed at the same level).
+    if (entry.value.properties?.isNotEmpty() == true) {
+        addProperties(context, entry, nameRef, builder)
+    }
+
+    // Properties contributed by each inline member, skipping any that are already defined in the
+    // parent schema to avoid incompatible override errors in the generated Java code.
+    allOf.forEachIndexed { index, sub ->
+        if (sub.`$ref` == null) {
+            addProperties(context.withSchemaStack("allOf", "$index"), mapOf(entry.key to sub).entries.first(), nameRef, builder, parentPropertyNames)
+        }
+    }
+
+    val fieldSpecs = builder.build().fieldSpecs()
+
+    addStandardMethodsAndBuilderLogic(builder, fieldSpecs, nameRef, superType)
+
+    if (baseRefName != null) {
+        addExtendingToCodeMethod(fieldSpecs, baseProperties, builder, nameRef)
+    } else {
+        addToCodeMethod(fieldSpecs, builder, nameRef)
+    }
+
+    return builder.build()
+}
+
+/**
+ * Generates a {@code toCode} method for a subclass-style allOf object. Inherited base properties are
+ * read through their getters (their backing fields are private to the superclass), while the
+ * declared inline fields are referenced directly.
+ */
+private fun addExtendingToCodeMethod(
+    inlineFields: List<FieldSpec>,
+    baseProperties: List<String>,
+    builder: TypeSpec.Builder,
+    nameRef: ClassName,
+) {
+    val toCodeStatement =
+        CodeBlock
+            .builder()
+            .add($$"return new $T($S)", Types.CODE_BUILDER, nameRef.canonicalName())
+
+    baseProperties.forEach { camelName ->
+        toCodeStatement.add($$"\n    .addProperty($S, get$L())", camelName, camelName.pascalCase())
+    }
+
+    inlineFields.forEach { field ->
+        toCodeStatement.add($$"\n    .addProperty($S, $N)", field.name(), field.name())
+    }
+
+    toCodeStatement.add("\n    .build()")
+
+    builder.addMethod(
+        MethodSpec
+            .methodBuilder("toCode")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(String::class.java)
+            .addStatement(toCodeStatement.build())
+            .build(),
+    )
+}
+
 private fun buildSimpleObject(
     context: Context,
     entry: Map.Entry<String, Schema<*>>,
@@ -966,6 +1173,7 @@ private fun generateNoArgsConstructor(): MethodSpec =
 private fun generateAllArgsConstructor(
     className: ClassName,
     fields: List<FieldSpec>,
+    superType: ClassName? = null,
 ): MethodSpec {
     val builderClassName = className.nestedClass("${className.simpleName()}Builder")
     val wildcardBuilder =
@@ -980,6 +1188,11 @@ private fun generateAllArgsConstructor(
             .constructorBuilder()
             .addModifiers(Modifier.PROTECTED)
             .addParameter(wildcardBuilder, "b")
+
+    // Let the base SuperBuilder populate the inherited fields before we set our own.
+    if (superType != null) {
+        builder.addStatement("super(b)")
+    }
 
     fields.forEach { field ->
         builder.addStatement($$"this.$N = b.$N", field.name(), field.name())
@@ -1029,13 +1242,19 @@ private fun generateHashCode(): MethodSpec =
 private fun generateFillValuesFromMethod(
     bTypeVar: TypeVariableName,
     cTypeVar: TypeVariableName,
+    callSuper: Boolean = false,
 ): MethodSpec =
     MethodSpec
         .methodBuilder($$"$fillValuesFrom")
         .addModifiers(Modifier.PROTECTED)
         .returns(bTypeVar)
         .addParameter(cTypeVar, "instance")
-        .addStatement($$$"$$fillValuesFromInstanceIntoBuilder(instance, this)")
+        .apply {
+            // Pull inherited fields up from the base builder first when this is a subclass builder.
+            if (callSuper) {
+                addStatement($$$"super.$$fillValuesFrom(instance)")
+            }
+        }.addStatement($$$"$$fillValuesFromInstanceIntoBuilder(instance, this)")
         .addStatement("return this.self()")
         .build()
 
@@ -1181,6 +1400,7 @@ private fun generateAbstractBuilderSetter(
 private fun generateBuilderClass(
     className: ClassName,
     fields: List<FieldSpec>,
+    superType: ClassName? = null,
 ): TypeSpec {
     val builderName = "${className.simpleName()}Builder"
     val cTypeVar = TypeVariableName.get("C", className)
@@ -1200,6 +1420,17 @@ private fun generateBuilderClass(
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT, Modifier.STATIC)
             .addTypeVariable(cTypeVar)
             .addTypeVariable(TypeVariableName.get("B", bBound))
+
+    // Chain onto the base type's SuperBuilder so inherited fields are settable through this builder.
+    superType?.let {
+        builder.superclass(
+            ParameterizedTypeName.get(
+                it.nestedClass("${it.simpleName()}Builder"),
+                cTypeVar,
+                bTypeVar,
+            ),
+        )
+    }
 
     // Add fields to builder (same as parent, but non-final)
     fields.forEach { field ->
@@ -1241,7 +1472,7 @@ private fun generateBuilderClass(
     }
 
     // Add $fillValuesFrom method
-    builder.addMethod(generateFillValuesFromMethod(bTypeVar, cTypeVar))
+    builder.addMethod(generateFillValuesFromMethod(bTypeVar, cTypeVar, callSuper = superType != null))
 
     // Add $fillValuesFromInstanceIntoBuilder static helper
     builder.addMethod(generateFillValuesFromInstanceIntoBuilderMethod(className, builderName, fields))
@@ -1359,9 +1590,10 @@ private fun addProperties(
     entry: Map.Entry<String, Schema<*>>,
     nameRef: ClassName,
     classBuilder: TypeSpec.Builder,
+    skipFields: Set<String> = emptySet(),
 ) {
     val built = classBuilder.build()
-    val knownFields = built.fieldSpecs().map { it.name() }
+    val knownFields = built.fieldSpecs().map { it.name() } + skipFields
     val knownSubTypes = built.typeSpecs().map { it.name() }
 
     entry.value.properties?.forEach { property ->
@@ -1377,6 +1609,11 @@ private fun processProperty(
     knownFields: List<String>,
     knownSubTypes: List<String>,
 ) {
+    // Skip this property entirely (field + nested type) if it is already known, which includes
+    // properties inherited from a parent class in an allOf subclass scenario.
+    val fieldName = property.key.unkeywordize().camelCase()
+    if (knownFields.contains(fieldName)) return
+
     referenceAndDefinition(context.withSchemaStack("properties", property.key), property, "", nameRef)?.let { (d, s) ->
         processNestedTypeIfPresent(s, d, knownSubTypes, classBuilder)
         addFieldIfNew(context, property, d, knownFields, classBuilder)

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
@@ -91,6 +91,134 @@ class SchemasBuilderTest {
             .contains("getWebhookComboComposite1()")
     }
 
+    @Test
+    fun `allOf of a single ref schema collapses to the referenced type`() {
+        generate(allOfSampleOpenAPI())
+
+        // `creator` is `allOf: [{$ref: simple-user}]`, which adds nothing, so the field is typed
+        // directly as the referenced type with no synthetic wrapper class.
+        assertThat(readGenerated("CreatorWrapper"))
+            .contains("private SimpleUser creator;")
+            .doesNotContain("class Creator implements")
+    }
+
+    @Test
+    fun `allOf of a ref plus inline object extends the referenced type`() {
+        generate(allOfSampleOpenAPI())
+
+        val releaseEvent = readGenerated("ReleaseEvent")
+        assertThat(releaseEvent)
+            // The inline extension becomes a subclass of the referenced base type...
+            .contains("class Release extends io.github.pulpogato.rest.schemas.Release")
+            .contains("extends io.github.pulpogato.rest.schemas.Release.ReleaseBuilder<C, B>")
+            .contains("super(b)")
+            // ...exposing only the inline properties as its own fields.
+            .contains("getShortDescriptionHtml()")
+            .contains("getIsShortDescriptionHtmlTruncated()")
+            // No runtime merge machinery and no meaningless indexed field.
+            .doesNotContain("FancySerializer")
+            .doesNotContain("release1")
+    }
+
+    @Test
+    fun `allOf of only inline objects flattens their properties into one object`() {
+        generate(allOfSampleOpenAPI())
+
+        val forkEvent = readGenerated("ForkEvent")
+        assertThat(forkEvent)
+            .contains("public static class Forkee implements PulpogatoType")
+            // Properties from both inline members live directly on the single flattened class.
+            .contains("getNodeId()")
+            .contains("getFullName()")
+            .doesNotContain("FancySerializer")
+            .doesNotContain("forkee1")
+    }
+
+    @Test
+    fun `allOf of multiple refs keeps the runtime merge serializer`() {
+        generate(allOfSampleOpenAPI())
+
+        // Two $refs cannot be expressed via single inheritance, so the merge serializer is retained.
+        assertThat(readGenerated("Combo"))
+            .contains("FancySerializer")
+    }
+
+    /**
+     * A spec exercising each allOf shape as a property: a single-ref alias, a ref + inline extension,
+     * a flatten of inline-only members, and a multi-ref merge.
+     */
+    private fun allOfSampleOpenAPI(): OpenAPI {
+        val stringSchema = { Schema<Any>().apply { types = mutableSetOf("string") } }
+        val booleanSchema = { Schema<Any>().apply { types = mutableSetOf("boolean") } }
+        val refSchema = { ref: String -> Schema<Any>().apply { `$ref` = ref } }
+        val objectSchema = { props: Map<String, Schema<Any>> ->
+            Schema<Any>().apply {
+                types = mutableSetOf("object")
+                properties = LinkedHashMap(props)
+            }
+        }
+        val allOfSchema = { members: List<Schema<Any>> ->
+            Schema<Any>().apply { allOf = members }
+        }
+
+        val openAPI = OpenAPI()
+        openAPI.schema("simple-user", objectSchema(mapOf("login" to stringSchema())))
+        openAPI.schema("release", objectSchema(mapOf("id" to stringSchema(), "name" to stringSchema())))
+
+        openAPI.schema(
+            "creator-wrapper",
+            objectSchema(mapOf("creator" to allOfSchema(listOf(refSchema("#/components/schemas/simple-user"))))),
+        )
+        openAPI.schema(
+            "release-event",
+            objectSchema(
+                mapOf(
+                    "release" to
+                        allOfSchema(
+                            listOf(
+                                refSchema("#/components/schemas/release"),
+                                objectSchema(
+                                    mapOf(
+                                        "short_description_html" to stringSchema(),
+                                        "is_short_description_html_truncated" to booleanSchema(),
+                                    ),
+                                ),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        openAPI.schema(
+            "fork-event",
+            objectSchema(
+                mapOf(
+                    "forkee" to
+                        allOfSchema(
+                            listOf(
+                                objectSchema(mapOf("node_id" to stringSchema())),
+                                objectSchema(mapOf("full_name" to stringSchema())),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        openAPI.schema(
+            "combo",
+            objectSchema(
+                mapOf(
+                    "both" to
+                        allOfSchema(
+                            listOf(
+                                refSchema("#/components/schemas/simple-user"),
+                                refSchema("#/components/schemas/release"),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        return openAPI
+    }
+
     private fun generate(openAPI: OpenAPI) {
         val context = Context(openAPI, "test", emptyList(), emptyMap())
         SchemasBuilder().buildSchemas(context, tempDir.toFile(), packageName, mutableSetOf<ClassName>())

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -8,6 +8,7 @@ import io.github.pulpogato.common.SingularOrPlural;
 import io.github.pulpogato.rest.schemas.ContentFile;
 import io.github.pulpogato.rest.schemas.CustomPropertyValue;
 import io.github.pulpogato.rest.schemas.FullRepository;
+import io.github.pulpogato.rest.schemas.RulesetVersion;
 import io.github.pulpogato.rest.schemas.SecurityAndAnalysis;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -481,5 +482,39 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(securityAndAnalysis.getSecretScanningNonProviderPatterns().getStatus())
                 .isEqualTo(SecurityAndAnalysis.SecretScanningNonProviderPatterns.Status.DISABLED);
         assertThat(securityAndAnalysis.getSecretScanningAiDetection()).isNull();
+    }
+
+    private static final Long DEFAULT_BRANCH_RULESET_ID = 1115480L;
+    private static final Long RULESET_VERSION_ID = 41470112L;
+
+    /**
+     * Locks in the public API of an {@code allOf} schema returned by a REST endpoint.
+     *
+     * <p>{@code GET /repos/{owner}/{repo}/rulesets/{ruleset_id}/history/{version_id}} returns
+     * {@code ruleset-version-with-state}, described as
+     * {@code allOf: [{$ref: ruleset-version}, {properties: {state}}]}, which the codegen models as
+     * {@code RulesetVersionWithState extends RulesetVersion}. The inherited version fields and the
+     * added {@code state} must both be reachable on the same object; if the generator regressed to the
+     * old wrapper-with-an-indexed-field shape this test would not compile.
+     */
+    @Test
+    void testGetRepoRulesetVersion() {
+        var api = new RestClients(webClient).getReposApi();
+        var response =
+                api.getRepoRulesetVersion("pulpogato", "pulpogato", DEFAULT_BRANCH_RULESET_ID, RULESET_VERSION_ID);
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        var version = response.getBody();
+        assertThat(version).isNotNull();
+
+        // The generated type extends the referenced RulesetVersion, so it is-a RulesetVersion...
+        assertThat(version).isInstanceOf(RulesetVersion.class);
+
+        // ...exposing the inherited version fields directly on the same object...
+        assertThat(version.getVersionId()).isEqualTo(RULESET_VERSION_ID);
+        assertThat(version.getUpdatedAt()).isNotNull();
+
+        // ...plus the inline allOf member (state) as the subclass's own accessor.
+        assertThat(version.getState()).isNotNull().isNotEmpty();
     }
 }

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testGetRepoRulesetVersion.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testGetRepoRulesetVersion.yml
@@ -1,0 +1,53 @@
+- request:
+    method: GET
+    uri: /repos/pulpogato/pulpogato/rulesets/1115480/history/41470112
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    bodyIsBinary: false
+    body: |-
+      {
+        "version_id" : 41470112,
+        "updated_at" : "2026-06-27T14:23:43.456-07:00",
+        "actor" : {
+          "id" : 193047,
+          "type" : "User"
+        },
+        "state" : {
+          "id" : 1115480,
+          "name" : "Default Branch",
+          "target" : "branch",
+          "source_type" : "Repository",
+          "source" : "pulpogato/pulpogato",
+          "enforcement" : "active",
+          "conditions" : {
+            "ref_name" : {
+              "exclude" : [ ],
+              "include" : [ "~DEFAULT_BRANCH" ]
+            }
+          },
+          "rules" : [ {
+            "type" : "deletion"
+          }, {
+            "type" : "non_fast_forward"
+          }, {
+            "type" : "required_status_checks",
+            "parameters" : {
+              "strict_required_status_checks_policy" : false,
+              "do_not_enforce_on_create" : false,
+              "required_status_checks" : [ {
+                "context" : "Build with Gradle",
+                "integration_id" : 15368
+              } ]
+            }
+          } ],
+          "updated_at" : null,
+          "bypass_actors" : [ ],
+          "current_user_can_bypass" : "never"
+        }
+      }

--- a/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
+++ b/pulpogato-rest-tests/src/main/resources/IgnoredTests.yml
@@ -216,3 +216,21 @@
     - ghes-3.19
     - ghes-3.20
     - ghes-3.21
+- example: "#/components/examples/scim-enterprise-user/value"
+  reason: "https://github.com/github/rest-api-description/issues/6644"
+  versions:
+    - ghec
+    - ghes-3.17
+    - ghes-3.18
+    - ghes-3.19
+    - ghes-3.20
+    - ghes-3.21
+- example: "#/components/examples/scim-enterprise-user-list/value"
+  reason: "https://github.com/github/rest-api-description/issues/6644"
+  versions:
+    - ghec
+    - ghes-3.17
+    - ghes-3.18
+    - ghes-3.19
+    - ghes-3.20
+    - ghes-3.21


### PR DESCRIPTION
## Summary

`allOf` schemas previously shared the same "fancy merge" code path as `oneOf`/`anyOf`, producing wrapper classes with meaningless indexed fields and a runtime merge serializer. For example, `release-event`'s `release` (an `allOf` of `$ref: release` plus an inline object) generated a `Release` wrapper with a `release` field **and** a `release1` field, reached via `getRelease().getRelease1().getShortDescriptionHtml()`.

`allOf` is now interpreted by shape:

| Shape | Before | After |
|---|---|---|
| single member (`[{$ref}]`) | 1-field wrapper class | collapsed to the member type directly |
| `$ref` + inline object(s) | `x` + `x1` fields + merge serializer | a class that **`extends` the referenced type** and adds only the inline properties |
| inline objects only | `x` + `x1` fields + merge serializer | properties **flattened** into one object |
| multiple `$ref`s | merge serializer | unchanged (single inheritance can't express it) |

The reshaped types are ordinary POJOs that Jackson serializes via field access, so no custom merge serializer/deserializer is generated for them. The base types already use the SuperBuilder pattern, so the subclass builder chains onto it cleanly.

### Example

`ReleaseEvent.Release` now reads:

```java
public static class Release extends io.github.pulpogato.rest.schemas.Release {
  @JsonProperty("is_short_description_html_truncated")
  private Boolean isShortDescriptionHtmlTruncated;
  @JsonProperty("short_description_html")
  private String shortDescriptionHtml;
  // getShortDescriptionHtml() + all inherited Release accessors
}
```

### Tests

- Codegen unit tests in `SchemasBuilderTest` for each shape (collapse, extend, flatten, multi-`$ref` fallback).
- `ReposApiIntegrationTest.testGetRepoRulesetVersion` — a tape-backed REST integration test that locks in the `RulesetVersionWithState extends RulesetVersion` API (inherited version fields + the added `state` accessor on one object). Replays deterministically with no token.

### Verification

- Codegen plugin `check` clean (spotless + unit tests).
- Generated Java compiles for all GitHub variants (fpt, ghec, ghes-3.17/3.18/3.19/3.20/3.21).
- Round-trip example/webhook suites pass: FPT and GHEC, 0 failures.

> [!WARNING]
> This changes the public API of the affected generated types (e.g. `getRelease().getShortDescriptionHtml()` instead of `getRelease().getRelease1().getShortDescriptionHtml()`), so it is a breaking change for code referencing the old `*1` accessors.