### PR TITLE
refactor(codegen): remove stray println in SchemaExtensions

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -338,8 +338,10 @@ private fun buildReferenceAndDefinitionFromObject(
                 )!!
                     .let { Pair(ParameterizedTypeName.get(Types.MAP, Types.STRING, it.first), it.second) }
             } else {
-                val message = additionalProperties.javaClass
-                println(message)
+                // additionalProperties is a non-Schema value (e.g. a bare `additionalProperties: true`)
+                // that we don't model yet. Emit the sentinel Todo type, which doesn't exist and so fails
+                // the generated-code compile loudly, rather than silently producing a wrong mapping.
+                // No current GitHub schema variant reaches this branch.
                 Pair(Types.TODO, null)
             }
         }


### PR DESCRIPTION
## What
Removes a leftover `println(message)` debug breadcrumb in `SchemaExtensions.buildReferenceAndDefinitionFromObject`, replacing it with a comment explaining the branch.

## Why
The branch handles `additionalProperties` set to a non-`Schema` value (e.g. a bare `additionalProperties: true`). It emits the sentinel `Types.TODO` (`io.github.pulpogato.common.Todo`) — a type that does not exist — so the generated code fails to compile loudly rather than producing a silently-wrong mapping. The `println` added nothing the compile error wouldn't already surface.

No current GitHub schema variant reaches this branch (`Todo` appears in zero generated files across all 12 variants).