### PR TITLE
refactor(codegen): convert IssueStatus to a data class

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/issues/IssueStatus.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/issues/IssueStatus.kt
@@ -3,22 +3,16 @@ package io.github.pulpogato.issues
 /**
  * Represents the status of a GitHub issue.
  * This class holds information about a GitHub issue's state, number, and URL.
+ *
+ * Kept as mutable [var]s with an all-args primary constructor so that the plain
+ * [com.fasterxml.jackson.databind.ObjectMapper] (no Kotlin module registered) can
+ * deserialize `gh issue view` JSON via either the constructor or the setters.
  */
-internal class IssueStatus {
+internal data class IssueStatus(
     /** The issue number on GitHub */
-    var number: Int? = null
-
+    var number: Int? = null,
     /** The current state of the issue (e.g., OPEN, CLOSED) */
-    var state: String? = null
-
+    var state: String? = null,
     /** The URL of the GitHub issue */
-    var url: String? = null
-
-    constructor(number: Int?, state: String?, url: String?) {
-        this.number = number
-        this.state = state
-        this.url = url
-    }
-
-    override fun toString(): String = "IssueStatus(number=$number, state=$state, url=$url)"
-}
+    var url: String? = null,
+)


### PR DESCRIPTION
## What
Converts `issues/IssueStatus` from a hand-written class (manual constructor + `toString`) to a Kotlin `data class`.

## Why
Removes boilerplate and gains `equals`/`hashCode` for free. The properties stay mutable `var`s with the identical all-args primary constructor, so the plain `ObjectMapper` (no Kotlin module registered) deserializes `gh issue view` JSON exactly as before, and the auto-generated `toString` reproduces the previous manual format.