### PR TITLE
docs(codegen): explain GitHub schema naming quirks

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/githubfilescodegen/ObjectGenerator.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/githubfilescodegen/ObjectGenerator.kt
@@ -10,6 +10,11 @@ import io.github.pulpogato.restcodegen.MarkdownHelper
 import javax.lang.model.element.Modifier
 
 object ObjectGenerator {
+    // The GitHub Actions workflow `on:` trigger (object form) lets each event be written with a null
+    // value (e.g. `on: { push: }`) to mean "trigger with defaults". Marking this class's fields
+    // @JsonSetter(nulls = AS_EMPTY) makes those nulls deserialize as empty objects instead of null.
+    private const val WORKFLOW_ON_OBJECT_CLASS = "GithubWorkflowOnVariant2"
+
     private val LOMBOK_DATA = ClassName.get("lombok", "Data")
     private val LOMBOK_BUILDER = ClassName.get("lombok", "Builder")
     private val LOMBOK_NO_ARGS = ClassName.get("lombok", "NoArgsConstructor")
@@ -30,7 +35,7 @@ object ObjectGenerator {
         schemaRef: String,
         sourceFile: String,
     ): TypeSpec {
-        val nullsAsEmpty = name == "GithubWorkflowOnVariant2"
+        val nullsAsEmpty = name == WORKFLOW_ON_OBJECT_CLASS
         val builder =
             TypeSpec
                 .classBuilder(name)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -475,8 +475,15 @@ private fun buildType(
     val refName =
         when {
             parentClass == null -> ClassName.get("io.github.pulpogato.rest.schemas", className)
+
             parentClass.simpleName() == className -> parentClass.nestedClass("${className}Inner")
+
+            // Java forbids a nested type from sharing its simple name with an enclosing type. In the
+            // repository-ruleset-edited webhook, `Updated` is itself nested inside a `Changes` type yet
+            // carries its own `changes` object; name that inner one `Changes2` to avoid clashing with the
+            // enclosing `Changes`. (The immediate parent == child clash is handled by the branch above.)
             parentClass.simpleName() == "Updated" && className == "Changes" -> parentClass.nestedClass("Changes2")
+
             else -> parentClass.nestedClass(className)
         }
 


### PR DESCRIPTION
## What
Documents two GitHub-schema special cases that previously hard-coded a class name with no explanation:

- `SchemaExtensions.buildType` — the `Updated`/`Changes` → `Changes2` rename now has a comment.
- `ObjectGenerator` — the `GithubWorkflowOnVariant2` nulls-as-empty case is now a named constant (`WORKFLOW_ON_OBJECT_CLASS`) with a comment.

## Why
Both were unexplained magic strings tied to one specific schema. The `Changes2` rename works around Java's rule that a nested type cannot share its simple name with an enclosing type (the repository-ruleset-edited webhook nests an `Updated` type inside a `Changes` type that itself has a `changes` object). The `GithubWorkflowOnVariant2` case applies `@JsonSetter(nulls = AS_EMPTY)` because the GitHub Actions `on:` trigger object lets each event be written with a null value to mean "trigger with defaults".