### PR TITLE
perf(build): speed up laptop and PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-        run: ./gradlew build asciidoctorDocs snapshot --max-workers=$MAX_WORKERS
+        run: ./gradlew -Pcodegen.format=true build asciidoctorDocs snapshot --max-workers=$MAX_WORKERS
 
       - name: Deploy docs to ghpages
         uses: peaceiris/actions-gh-pages@v4
@@ -87,12 +87,12 @@ jobs:
       - name: Build Candidate
         if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')
         env: *env
-        run: ./gradlew -Prelease.useLastTag=true build candidate --max-workers=$MAX_WORKERS
+        run: ./gradlew -Prelease.useLastTag=true -Pcodegen.format=true build candidate --max-workers=$MAX_WORKERS
 
       - name: Build Final
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc')
         env: *env
-        run: ./gradlew -Prelease.useLastTag=true build final --max-workers=$MAX_WORKERS
+        run: ./gradlew -Prelease.useLastTag=true -Pcodegen.format=true build final --max-workers=$MAX_WORKERS
 
       - uses: actions/attest-build-provenance@v4
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,18 @@ Code generation is core to the project:
 ./scripts/update-schema-version.sh
 ```
 
+### Build performance flags
+Both default to the fast path; opt in when you need the extra output.
+```bash
+# Generate code coverage (Jacoco). Off by default so the agent + report stay off the critical path.
+./gradlew :pulpogato-rest-fpt:check -Pcoverage=true
+
+# Palantir formatting of generated sources is OFF by default (cosmetic, ~13-15s, only affects the
+# published sources jar). Laptop and PR builds skip it; CI enables it for snapshot/candidate/final.
+# Turn it on locally to match a release build:
+./gradlew :pulpogato-rest-fpt:generateJava -Pcodegen.format=true
+```
+
 ### Integration test requirements
 - Set `GITHUB_TOKEN` environment variable
 - For GHES testing, also set `GITHUB_HOST` and `GITHUB_PORT`

--- a/README.adoc
+++ b/README.adoc
@@ -188,6 +188,19 @@ Install JDK 21 first.
 To build, run `./gradlew build`.
 If you have low memory or CPU, you can customize parallelism with `--max-workers`.
 
+=== Build performance
+
+Laptop and PR builds are tuned for speed, so two pieces of optional work are off by default.
+
+`-Pcodegen.format=true` runs Palantir Java Format over the generated sources.
+Formatting is cosmetic and only affects the readability of the published sources jar, so it is skipped by default and saves roughly 13-15 seconds per REST module.
+CI turns it on automatically when building snapshot, candidate, and final artifacts.
+
+`-Pcoverage=true` enables JaCoCo.
+Coverage collection and its report are a CI/reporting concern, so they stay off the default critical path.
+
+Tests run in parallel across forked JVMs (`maxParallelForks`), which the data-driven generated tests benefit from the most.
+
 === Automatically generated tests
 
 When the REST schema contains examples, they are automatically converted to tests in the generated test sources directory.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,9 @@ subprojects {
     }
     tasks.withType<Test> {
         useJUnitPlatform()
+        // Tests are MockMvc-based (no bound ports) and data-driven, so they parallelize safely across forked JVMs.
+        // Half the cores leaves headroom for codegen/compile work and Gradle's own worker leases during a full build.
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     }
 }
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/GenerateJavaTask.kt
@@ -93,6 +93,17 @@ open class GenerateJavaTask : DefaultTask() {
     val projectDir: Property<File> = project.objects.property(File::class.java)
 
     /**
+     * Whether to run Palantir Java Format over the generated sources.
+     *
+     * Formatting every generated file costs ~13–15s but produces no behavioral difference — it only affects
+     * the readability of the published sources jar. It defaults to off so laptop and PR builds stay fast;
+     * CI turns it on (`-Pcodegen.format=true`) when building snapshot/candidate/final artifacts.
+     */
+    @Input
+    @Optional
+    val formatCode: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
+
+    /**
      * The common resources directory for schema additions.
      */
     @InputDirectory
@@ -176,7 +187,9 @@ open class GenerateJavaTask : DefaultTask() {
         // Format generated Java code
         val javaFiles = collectJavaFiles(main)
         val testJavaFiles = collectJavaFiles(test)
-        formatJavaFiles(javaFiles + testJavaFiles, logger)
+        if (formatCode.get()) {
+            formatJavaFiles(javaFiles + testJavaFiles, logger)
+        }
 
         // Validate JSON references using the merged spec (includes additions)
         JsonRefValidator(0).validate(schemas, javaFiles + testJavaFiles)

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/RestCodegenPlugin.kt
@@ -22,6 +22,14 @@ class RestCodegenPlugin : Plugin<Project> {
         generateJava.configure {
             dependsOn(downloadSchema)
             schema = downloadSchema.flatMap { it.schemaFile }.map { it.asFile }
+            // Formatting generated sources is cosmetic and only matters for the published sources jar, so it
+            // defaults to off for fast laptop/PR builds. CI enables it (-Pcodegen.format=true) for published builds.
+            formatCode.set(
+                target.providers
+                    .gradleProperty("codegen.format")
+                    .map(String::toBoolean)
+                    .orElse(false),
+            )
             packageName = target.provider { extension.packageName.get() }
             mainDir = target.provider { extension.mainDir.get().asFile }
             testDir = target.provider { extension.testDir.get().asFile }

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -3,6 +3,7 @@ import io.github.pulpogato.buildsupport.PropertiesFileValueClosure
 import io.github.pulpogato.buildsupport.WriteInfoPropertiesTask
 import io.github.pulpogato.restcodegen.DownloadSchemaTask
 import nebula.plugin.info.InfoBrokerPlugin
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import kotlin.jvm.java
 
 plugins {
@@ -118,8 +119,18 @@ tasks {
     }
 }
 
+// Coverage is a CI/reporting concern, not needed on every local build. Keeping it off the default path
+// avoids both the Jacoco agent overhead during test execution and the report task (~19s) on the critical path.
+// Enable with -Pcoverage=true (or set it in CI).
+val coverageEnabled = providers.gradleProperty("coverage").map(String::toBoolean).getOrElse(false)
+
 tasks.test {
-    finalizedBy(tasks.jacocoTestReport)
+    extensions.configure<JacocoTaskExtension> {
+        isEnabled = coverageEnabled
+    }
+    if (coverageEnabled) {
+        finalizedBy(tasks.jacocoTestReport)
+    }
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
## Summary

Trims optional work off the default build path so laptop and PR builds are faster, while keeping published artifacts identical.

Cold `:pulpogato-rest-fpt:check --rerun-tasks` dropped from **~3m11s** to **~2m20s** in local measurement; the normal cached build benefits proportionally.

## Changes

- **Parallel tests** — set `maxParallelForks` on all `Test` tasks (root `build.gradle.kts`). The bulk of the suite is data-driven generated tests running on `MockMvcHttpConnector` (no bound ports), so forked JVMs parallelize safely. `test` dropped from ~51s to ~32s.
- **JaCoCo opt-in** — coverage is now enabled with `-Pcoverage=true` (`rest.gradle.kts`). By default the agent and the `jacocoTestReport` task (~19s) stay off the critical path. Nothing in CI currently consumes the coverage XML; pass `-Pcoverage=true` if you want it.
- **Generated-source formatting opt-in** — Palantir formatting now defaults off and is enabled with `-Pcodegen.format=true` (`RestCodegenPlugin` / `GenerateJavaTask`). It is cosmetic (~13–15s per REST module) and only affects the readability of the published sources jar. CI turns it on for the **snapshot**, **candidate**, and **final** steps in `build.yml`, so released artifacts are unchanged.
- Docs updated in `README.adoc` and `CLAUDE.md`.

## Notes

- PR/branch CI keeps the fast defaults; only published builds format generated sources.
- All 2,700 `pulpogato-rest-fpt` tests pass with the new defaults, and the 58 codegen-plugin tests pass.