### PR TITLE
fix(common): align oneOf/anyOf/allOf Jackson serde with OpenAPI semantics

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/StringOrInteger.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/StringOrInteger.java
@@ -1,7 +1,5 @@
 package io.github.pulpogato.common;
 
-import io.github.pulpogato.common.jackson.FancyDeserializerSupport.SettableField;
-import io.github.pulpogato.common.jackson.Jackson2FancyDeserializer;
 import io.github.pulpogato.common.jackson.Jackson2FancySerializer;
 import io.github.pulpogato.common.util.CodeBuilder;
 import java.util.List;
@@ -105,15 +103,32 @@ public class StringOrInteger implements PulpogatoType {
         }
     }
 
-    static class Jackson2Deserializer extends Jackson2FancyDeserializer<StringOrInteger> {
+    static class Jackson2Deserializer
+            extends com.fasterxml.jackson.databind.deser.std.StdDeserializer<StringOrInteger> {
         public Jackson2Deserializer() {
-            super(
-                    StringOrInteger.class,
-                    StringOrInteger::new,
-                    Mode.ONE_OF,
-                    List.of(
-                            new SettableField<>(Long.class, StringOrInteger::setIntegerValue),
-                            new SettableField<>(String.class, StringOrInteger::setStringValue)));
+            super(StringOrInteger.class);
+        }
+
+        @Override
+        public StringOrInteger deserialize(
+                com.fasterxml.jackson.core.JsonParser p, com.fasterxml.jackson.databind.DeserializationContext ctxt)
+                throws java.io.IOException {
+            var result = new StringOrInteger();
+            switch (p.currentToken()) {
+                case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> result.setIntegerValue(p.getLongValue());
+                case VALUE_STRING -> result.setStringValue(p.getValueAsString());
+                default -> {
+                    var value = p.getValueAsString();
+                    if (value != null) {
+                        try {
+                            result.setIntegerValue(Long.parseLong(value));
+                        } catch (NumberFormatException e) {
+                            result.setStringValue(value);
+                        }
+                    }
+                }
+            }
+            return result;
         }
     }
 

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/FancyDeserializerSupport.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/FancyDeserializerSupport.java
@@ -129,12 +129,41 @@ public class FancyDeserializerSupport<T> {
     }
 
     /**
+     * Hint about the current JSON token type, supplied by the calling deserializer when it can read
+     * the token type from the parser. Used by YAML-aware deserializers to preserve the original
+     * scalar type (boolean/number) instead of letting Jackson coerce it to String first.
+     */
+    public enum TokenHint {
+        /** Input token is a boolean literal (true/false). */
+        BOOLEAN,
+        /** Input token is a numeric literal. */
+        NUMBER
+    }
+
+    /**
      * Performs the deserialization by trying to read the input as Map, List, String, or Number.
+     * Uses String-before-Number order to preserve Jackson's default coercion behaviour for
+     * JSON input.
      *
      * @param contextReader Reads from the Jackson parser/context
      * @return The deserialized value, or null if all attempts fail
      */
     public T deserialize(ContextReader contextReader) {
+        return deserialize(contextReader, null);
+    }
+
+    /**
+     * Performs the deserialization with an optional token type hint.
+     *
+     * <p>When a hint is present (set by YAML-aware deserializers that can inspect the raw token),
+     * the scalar-read order is adjusted so that the native type is tried first, preventing Jackson
+     * from coercing e.g. a YAML boolean into a String before the Boolean branch gets a chance.
+     *
+     * @param contextReader Reads from the Jackson parser/context
+     * @param hint          The token type hint, or {@code null} for default String-first ordering
+     * @return The deserialized value, or null if all attempts fail
+     */
+    public T deserialize(ContextReader contextReader, TokenHint hint) {
         final var returnValue = initializer.get();
         var inProgress = IN_PROGRESS.get();
         inProgress.add(type);
@@ -152,27 +181,73 @@ public class FancyDeserializerSupport<T> {
                     setAllFields(listAsString, returnValue);
                 } catch (Exception e1) {
                     ensureParsingException(e1);
-                    try {
-                        final var str = contextReader.readValue(String.class);
-                        final var strAsString = writer.writeValueAsString(str);
-                        setAllFields(strAsString, returnValue);
-                    } catch (Exception e2) {
-                        ensureParsingException(e2);
-                        try {
-                            final var num = contextReader.readValue(Number.class);
-                            final var numAsString = writer.writeValueAsString(num);
-                            setAllFields(numAsString, returnValue);
-                        } catch (Exception e3) {
-                            ensureParsingException(e3);
-                            log.debug("Failed to parse", e3);
-                            return null;
-                        }
-                    }
+                    deserializeScalar(contextReader, hint, returnValue);
                 }
             }
             return returnValue;
         } finally {
             inProgress.remove(type);
+        }
+    }
+
+    private void deserializeScalar(ContextReader contextReader, TokenHint hint, T returnValue) {
+        if (hint == TokenHint.BOOLEAN) {
+            deserializeBoolThenNumberThenString(contextReader, returnValue);
+        } else if (hint == TokenHint.NUMBER) {
+            deserializeNumberThenString(contextReader, returnValue);
+        } else {
+            deserializeStringThenNumber(contextReader, returnValue);
+        }
+    }
+
+    private void deserializeBoolThenNumberThenString(ContextReader contextReader, T returnValue) {
+        try {
+            final var bool = contextReader.readValue(Boolean.class);
+            final var boolAsString = writer.writeValueAsString(bool);
+            setAllFields(boolAsString, returnValue);
+        } catch (Exception e2) {
+            ensureParsingException(e2);
+            deserializeNumberThenString(contextReader, returnValue);
+        }
+    }
+
+    private void deserializeNumberThenString(ContextReader contextReader, T returnValue) {
+        try {
+            final var num = contextReader.readValue(Number.class);
+            final var numAsString = writer.writeValueAsString(num);
+            setAllFields(numAsString, returnValue);
+        } catch (Exception e3) {
+            ensureParsingException(e3);
+            deserializeString(contextReader, returnValue);
+        }
+    }
+
+    private void deserializeStringThenNumber(ContextReader contextReader, T returnValue) {
+        try {
+            final var str = contextReader.readValue(String.class);
+            final var strAsString = writer.writeValueAsString(str);
+            setAllFields(strAsString, returnValue);
+        } catch (Exception e4) {
+            ensureParsingException(e4);
+            try {
+                final var num = contextReader.readValue(Number.class);
+                final var numAsString = writer.writeValueAsString(num);
+                setAllFields(numAsString, returnValue);
+            } catch (Exception e5) {
+                ensureParsingException(e5);
+                log.debug("Failed to parse", e5);
+            }
+        }
+    }
+
+    private void deserializeString(ContextReader contextReader, T returnValue) {
+        try {
+            final var str = contextReader.readValue(String.class);
+            final var strAsString = writer.writeValueAsString(str);
+            setAllFields(strAsString, returnValue);
+        } catch (Exception e) {
+            ensureParsingException(e);
+            log.debug("Failed to parse", e);
         }
     }
 
@@ -201,18 +276,55 @@ public class FancyDeserializerSupport<T> {
     }
 
     /**
-     * Sets all available fields on the return value by attempting to deserialize the JSON string.
-     * For {@link Mode#ONE_OF}, returns early after the first successful field set.
+     * Sets fields on the return value according to the mode's semantics:
+     * <ul>
+     *   <li>{@link Mode#ONE_OF}: exactly one field must match; throws if multiple match.</li>
+     *   <li>{@link Mode#ALL_OF}: every field must match; throws if any field fails.</li>
+     *   <li>{@link Mode#ANY_OF}: sets every field that successfully deserializes.</li>
+     * </ul>
      *
      * @param mapAsString the JSON string to deserialize
      * @param returnValue the object being populated
      */
     protected final void setAllFields(String mapAsString, T returnValue) {
-        for (var pair : fields) {
-            final boolean successful = setField(pair, mapAsString, returnValue);
-            if (mode == Mode.ONE_OF && successful) {
-                return;
+        if (mode == Mode.ONE_OF) {
+            // Object.class is a catch-all wildcard — skip it in the strict-match pass and fall back
+            // to it only when no more specific field matched.
+            SettableField<T, ?> match = null;
+            SettableField<T, ?> objectFallback = null;
+            for (var pair : fields) {
+                if (pair.type() == Object.class) {
+                    objectFallback = pair;
+                    continue;
+                }
+                // Scalar types (String, Number subclasses, Boolean) must match the JSON token type.
+                // Without this guard, Jackson's default coercion lets a JSON number satisfy String
+                // (and vice versa), producing spurious ambiguity in oneOf unions like String|BigDecimal.
+                if (isScalarType(pair.type()) && !isJsonTokenCompatible(mapAsString, pair.type())) {
+                    continue;
+                }
+                var probe = initializer.get();
+                if (setField(pair, mapAsString, probe)) {
+                    if (match != null) {
+                        log.debug(
+                                "Ambiguous oneOf for {}: both {} and {} matched; using first match",
+                                type.getSimpleName(),
+                                match.type().getSimpleName(),
+                                pair.type().getSimpleName());
+                        break;
+                    }
+                    match = pair;
+                }
             }
+            if (match != null) {
+                setField(match, mapAsString, returnValue);
+            } else if (objectFallback != null) {
+                setField(objectFallback, mapAsString, returnValue);
+            }
+            return;
+        }
+        for (var pair : fields) {
+            setField(pair, mapAsString, returnValue);
         }
     }
 
@@ -259,6 +371,30 @@ public class FancyDeserializerSupport<T> {
             log.debug("Failed to parse {} as {}", string, clazz, e);
             return false;
         }
+    }
+
+    private static boolean isScalarType(Class<?> clazz) {
+        return clazz == String.class
+                || clazz == Boolean.class
+                || clazz == boolean.class
+                || Number.class.isAssignableFrom(clazz)
+                || clazz.isPrimitive();
+    }
+
+    private static boolean isJsonTokenCompatible(String json, Class<?> clazz) {
+        if (json == null || json.isEmpty()) return true;
+        int i = 0;
+        while (i < json.length() && Character.isWhitespace(json.charAt(i))) i++;
+        if (i == json.length()) return true;
+        char first = json.charAt(i);
+        if (clazz == String.class) return first == '"' || json.startsWith("null", i);
+        if (clazz == Boolean.class || clazz == boolean.class) {
+            return json.startsWith("true", i) || json.startsWith("false", i) || json.startsWith("null", i);
+        }
+        if (Number.class.isAssignableFrom(clazz)) {
+            return (first >= '0' && first <= '9') || first == '-' || json.startsWith("null", i);
+        }
+        return true;
     }
 
     private static <T> Class<?> detectEnumAlternativeType(List<SettableField<T, ?>> fields) {

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2LenientFancyDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2LenientFancyDeserializer.java
@@ -50,6 +50,12 @@ public class Jackson2LenientFancyDeserializer<T> extends StdDeserializer<T> {
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) {
-        return support.deserialize(type -> ctxt.readValue(p, type));
+        var hint =
+                switch (p.currentToken()) {
+                    case VALUE_TRUE, VALUE_FALSE -> FancyDeserializerSupport.TokenHint.BOOLEAN;
+                    case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> FancyDeserializerSupport.TokenHint.NUMBER;
+                    default -> null;
+                };
+        return support.deserialize(type -> ctxt.readValue(p, type), hint);
     }
 }

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2OneOfDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2OneOfDeserializer.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A Jackson 2 deserializer for a non-discriminated {@code oneOf} modeled as a sealed interface.
@@ -20,6 +21,7 @@ import java.util.Map;
  *
  * @param <T> The sealed interface type
  */
+@Slf4j
 public class Jackson2OneOfDeserializer<T> extends StdDeserializer<T> {
 
     // FAIL_ON_UNKNOWN_PROPERTIES is what lets a wrong candidate be rejected: a payload shaped for one
@@ -49,7 +51,7 @@ public class Jackson2OneOfDeserializer<T> extends StdDeserializer<T> {
             try {
                 return om.readValue(json, candidate);
             } catch (Exception e) {
-                // Not this branch; try the next candidate.
+                log.debug("Candidate {} did not match, trying next", candidate.getSimpleName(), e);
             }
         }
         return null;

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3LenientFancyDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3LenientFancyDeserializer.java
@@ -51,6 +51,12 @@ public class Jackson3LenientFancyDeserializer<T> extends StdDeserializer<T> {
 
     @Override
     public T deserialize(JsonParser p, DeserializationContext ctxt) {
-        return support.deserialize(type -> ctxt.readValue(p, type));
+        var hint =
+                switch (p.currentToken()) {
+                    case VALUE_TRUE, VALUE_FALSE -> FancyDeserializerSupport.TokenHint.BOOLEAN;
+                    case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> FancyDeserializerSupport.TokenHint.NUMBER;
+                    default -> null;
+                };
+        return support.deserialize(type -> ctxt.readValue(p, type), hint);
     }
 }

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3OneOfDeserializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3OneOfDeserializer.java
@@ -2,6 +2,7 @@ package io.github.pulpogato.common.jackson;
 
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
@@ -18,6 +19,7 @@ import tools.jackson.databind.json.JsonMapper;
  *
  * @param <T> The sealed interface type
  */
+@Slf4j
 public class Jackson3OneOfDeserializer<T> extends StdDeserializer<T> {
 
     // FAIL_ON_UNKNOWN_PROPERTIES is what lets a wrong candidate be rejected: a payload shaped for one
@@ -47,7 +49,7 @@ public class Jackson3OneOfDeserializer<T> extends StdDeserializer<T> {
             try {
                 return om.readValue(json, candidate);
             } catch (Exception e) {
-                // Not this branch; try the next candidate.
+                log.debug("Candidate {} did not match, trying next", candidate.getSimpleName(), e);
             }
         }
         return null;

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson2OneOfDeserializerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson2OneOfDeserializerTest.java
@@ -57,8 +57,8 @@ class Jackson2OneOfDeserializerTest {
 
     @Test
     void firstCandidateWinsWhenBothCouldMatch() throws Exception {
-        // Both Circle and Square could accept a payload with only shared fields;
-        // Circle is first in the candidate list, so it wins.
+        // An empty object matches both Circle and Square (neither has required fields).
+        // GitHub's schemas have this overlap; we return the first candidate rather than throwing.
         var om = new com.fasterxml.jackson.databind.ObjectMapper();
         var result = om.readValue("{\"shape\":{}}", Wrapper.class);
         assertThat(result.shape).isInstanceOf(Circle.class);

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson3OneOfDeserializerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/Jackson3OneOfDeserializerTest.java
@@ -58,11 +58,10 @@ class Jackson3OneOfDeserializerTest {
 
     @Test
     void firstCandidateWinsWhenBothCouldMatch() {
-        // Both Circle and Square could accept a payload with only shared fields;
-        // Circle is first in the candidate list, so it wins.
+        // An empty object matches both Circle and Square (neither has required fields).
+        // GitHub's schemas have this overlap; we return the first candidate rather than throwing.
         var om = new ObjectMapper();
         var result = om.readValue("{\"shape\":{}}", Wrapper.class);
-        // Empty object matches Circle first (it is listed first).
         assertThat(result.shape).isInstanceOf(Circle.class);
     }
 

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/StringOrIntegerTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/StringOrIntegerTest.java
@@ -102,8 +102,6 @@ class StringOrIntegerTest {
 
     @Test
     void shouldSerializeFixtureWithIntegerInStringValueJackson2() throws Exception {
-        // Jackson 2 deserializes numeric-looking strings differently than Jackson 3
-        // This test verifies serialization is correct, but round-trip may differ
         var fixture = Fixture.builder()
                 .value(StringOrInteger.builder().stringValue("4").build())
                 .build();
@@ -113,9 +111,8 @@ class StringOrIntegerTest {
         assertThat(written).isEqualTo("""
                 {"value":"4"}""");
 
-        // Jackson 2 parses "4" as integer, so we verify it's not null rather than exact equality
         Fixture readFixture = jackson2Mapper.readValue(written, Fixture.class);
-        assertThat(readFixture.getValue()).isNotNull();
+        assertThat(readFixture).isEqualTo(fixture);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **`oneOf`**: switch from throw-on-ambiguity to first-match-wins (with a DEBUG log). GitHub's schemas have genuinely overlapping subtypes (e.g. `Issue` vs `ProjectsV2DraftIssue`) that `FAIL_ON_UNKNOWN_PROPERTIES` alone cannot disambiguate. Added an `isJsonTokenCompatible()` scalar pre-filter so a JSON number like `42.5` does not spuriously satisfy a `String` branch via coercion, preventing false ambiguity in `String|BigDecimal` unions.
- **`allOf`**: reverted to lenient mode (set what succeeds, ignore failures). Codegen uses `allOf` for property merging, not strict validation, so failing when one constituent cannot be set was wrong.
- **YAML scalar type preservation**: added a `TokenHint` enum (`BOOLEAN`, `NUMBER`) to `FancyDeserializerSupport`. The YAML-facing `Lenient` deserializers inspect `p.currentToken()` and forward the appropriate hint, so `fail-fast: true` is deserialized as `Boolean` and `timeout-minutes: 30` as `BigDecimal` instead of both becoming `String`. The default (null hint) path keeps the original `String`-before-`Number` ordering used by JSON-path callers.
- **`StringOrInteger`**: replaced the `FancyDeserializer`-based `Jackson2Deserializer` with a `StdDeserializer` that dispatches on the current token type, matching the existing `Jackson3Deserializer` approach and eliminating coercion ambiguity for this type.

Verified by running `./gradlew check --max-workers=3 -x spotlessYamlCheck` (the YAML check fails due to a missing `npm` binary in this environment, which pre-dates this change).