### PR TITLE
fix(ci): pass GITHUB_TOKEN to publish steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew -Pcodegen.format=true build asciidoctorDocs snapshot --max-workers=$MAX_WORKERS
 
       - name: Deploy docs to ghpages


### PR DESCRIPTION
## Summary

- The `&env` anchor used by Build Snapshot, Candidate, and Final steps only included Sonatype and signing credentials
- GitHub Actions does not automatically expose `GITHUB_TOKEN` as an environment variable, so Gradle's `publishNebulaPublicationToGithubPackagesRepository` task received a 401 when trying to PUT artifacts to `maven.pkg.github.com`
- Adding `GITHUB_TOKEN` to the anchor covers all three publish steps

Fixes the failure in https://github.com/pulpogato/pulpogato/actions/runs/28340381407/job/83953711536.