### PR TITLE
feat: follow redirects transparently in generated REST clients

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -29,6 +29,7 @@ import javax.lang.model.element.Modifier
 private const val PACKAGE_SPRING_FORMAT_SUPPORT = "org.springframework.format.support"
 private const val PACKAGE_SPRING_WEBCLIENT = "org.springframework.web.reactive.function.client"
 private const val PACKAGE_SPRING_HTTP = "org.springframework.http"
+private const val PACKAGE_PULPOGATO_CLIENT = "io.github.pulpogato.common.client"
 
 /**
  * A builder class that generates REST API client code based on OpenAPI specifications.
@@ -115,13 +116,6 @@ class PathsBuilder {
                     UsersApi users = clients.getUsersApi();
                     ResponseEntity<User> response = users.getAuthenticated();
                     }</pre>
-
-                    <p>The constructor automatically applies {@code DefaultHeadersExchangeFunction}
-                    (adds {@code X-GitHub-Api-Version} and {@code X-Pulpogato-Version} headers)
-                    and {@code NoContentExchangeFunction} (handles 204 responses).
-
-                    @see io.github.pulpogato.common.client.DefaultHeadersExchangeFunction
-                    @see io.github.pulpogato.common.client.NoContentExchangeFunction
                     """.trimIndent(),
                 ).addField(
                     FieldSpec
@@ -252,22 +246,48 @@ class PathsBuilder {
                 )
             }
 
-        // Add a constructor that initializes all API fields
+        // Add a constructor that accepts an explicit filter chain and initializes all API fields
         val constructorBuilder =
             MethodSpec
                 .constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(
+                .addJavadoc(
+                    """
+                    Constructs a client with an explicit filter chain.
+
+                    <p>The given {@code filters} are applied, in order, to {@code restWebClient}.
+                    Use this constructor to customize, reorder, or omit the default filters
+                    ({@code RedirectExchangeFunction}, {@code DefaultHeadersExchangeFunction},
+                    {@code NoContentExchangeFunction}) applied by {@link #RestClients(WebClient)}.
+
+                    @see io.github.pulpogato.common.client.RedirectExchangeFunction
+                    @see io.github.pulpogato.common.client.DefaultHeadersExchangeFunction
+                    @see io.github.pulpogato.common.client.NoContentExchangeFunction
+                    """.trimIndent(),
+                ).addParameter(
                     ParameterSpec
                         .builder(
                             ClassName.get(PACKAGE_SPRING_WEBCLIENT, "WebClient"),
                             "restWebClient",
                         ).addAnnotation(nonNull())
                         .build(),
+                ).addParameter(
+                    ParameterSpec
+                        .builder(
+                            ParameterizedTypeName.get(
+                                ClassName.get("java.util", "List"),
+                                ClassName.get(PACKAGE_SPRING_WEBCLIENT, "ExchangeFilterFunction"),
+                            ),
+                            "filters",
+                        ).addAnnotation(nonNull())
+                        .build(),
                 ).addStatement(
-                    $$"this.restWebClient = restWebClient.mutate().filter(new $T()).filter(new $T()).build()",
-                    ClassName.get("io.github.pulpogato.common.client", "DefaultHeadersExchangeFunction"),
-                    ClassName.get("io.github.pulpogato.common.client", "NoContentExchangeFunction"),
+                    $$"$T builder = restWebClient.mutate()",
+                    ClassName.get(PACKAGE_SPRING_WEBCLIENT, "WebClient", "Builder"),
+                ).addStatement(
+                    "filters.forEach(builder::filter)",
+                ).addStatement(
+                    "this.restWebClient = builder.build()",
                 ).addStatement(
                     $$"this.conversionService = new $T()",
                     ClassName.get(PACKAGE_SPRING_FORMAT_SUPPORT, "DefaultFormattingConversionService"),
@@ -293,6 +313,41 @@ class PathsBuilder {
         }
 
         restClients.addMethod(constructorBuilder.build())
+
+        // Convenience constructor that applies the default filter chain
+        restClients.addMethod(
+            MethodSpec
+                .constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(
+                    ParameterSpec
+                        .builder(
+                            ClassName.get(PACKAGE_SPRING_WEBCLIENT, "WebClient"),
+                            "restWebClient",
+                        ).addAnnotation(nonNull())
+                        .build(),
+                ).addJavadoc(
+                    """
+                    Constructs a client with the default filter chain: 
+                    <ul>
+                      <li>{@code RedirectExchangeFunction}
+                    (follows 3xx redirects, e.g. for renamed repositories)</li>
+                      <li>{@code DefaultHeadersExchangeFunction}
+                    (adds {@code X-GitHub-Api-Version} and {@code X-Pulpogato-Version} headers)</li>
+                      <li>{@code NoContentExchangeFunction} (handles 204 responses)</li>
+                    <ul>
+
+                    @see #RestClients(WebClient, List)
+                    """.trimIndent(),
+                ).addStatement(
+                    $$"this($N, $T.of(new $T(), new $T(), new $T()))",
+                    "restWebClient",
+                    ClassName.get("java.util", "List"),
+                    ClassName.get(PACKAGE_PULPOGATO_CLIENT, "RedirectExchangeFunction"),
+                    ClassName.get(PACKAGE_PULPOGATO_CLIENT, "DefaultHeadersExchangeFunction"),
+                    ClassName.get(PACKAGE_PULPOGATO_CLIENT, "NoContentExchangeFunction"),
+                ).build(),
+        )
 
         JavaFile.builder(packageName, restClients.build()).build().writeTo(mainDir)
     }

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/client/RedirectExchangeFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/client/RedirectExchangeFunction.java
@@ -1,0 +1,37 @@
+package io.github.pulpogato.common.client;
+
+import java.net.URI;
+import org.jspecify.annotations.NonNull;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+/**
+ * An {@link ExchangeFilterFunction} that transparently follows 3xx redirects, such as the ones
+ * GitHub returns when a repository has been renamed. Without this, callers would see the raw
+ * redirect response instead of the resource at its new location.
+ */
+public class RedirectExchangeFunction implements ExchangeFilterFunction {
+
+    private static final int MAX_REDIRECTS = 5;
+
+    @Override
+    @NonNull
+    public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        return exchange(request, next, MAX_REDIRECTS);
+    }
+
+    private static Mono<ClientResponse> exchange(ClientRequest request, ExchangeFunction next, int remainingRedirects) {
+        return next.exchange(request).flatMap(response -> {
+            URI location = response.headers().asHttpHeaders().getLocation();
+            if (remainingRedirects > 0 && response.statusCode().is3xxRedirection() && location != null) {
+                ClientRequest redirected =
+                        ClientRequest.from(request).url(location).build();
+                return exchange(redirected, next, remainingRedirects - 1);
+            }
+            return Mono.just(response);
+        });
+    }
+}

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -192,6 +192,18 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
     }
 
     @Test
+    void testGetAfterRename() {
+        var api = new RestClients(webClient).getReposApi();
+        var response = api.get("pulpogato", "create-demo");
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        var body = response.getBody();
+        assertThat(body.getName()).isEqualTo("rename-demo");
+        assertThat(body.getFullName()).isEqualTo("pulpogato/rename-demo");
+        assertThat(body.getOwner().getLogin()).isEqualTo("pulpogato");
+    }
+
+    @Test
     void testGetBranch() {
         var api = new RestClients(webClient).getReposApi();
         var response = api.getBranch("pulpogato", "pulpogato", "main");

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testGetAfterRename.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testGetAfterRename.yml
@@ -1,0 +1,194 @@
+- request:
+    method: GET
+    uri: /repos/pulpogato/create-demo
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 301
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Location: https://api.github.com/repositories/952818951
+    bodyIsBinary: false
+    body: |-
+      {
+        "message" : "Moved Permanently",
+        "url" : "https://api.github.com/repositories/952818951",
+        "documentation_url" : "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
+      }
+- request:
+    method: GET
+    uri: /repositories/952818951
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    bodyIsBinary: false
+    body: |-
+      {
+        "id" : 952818951,
+        "node_id" : "R_kgDOOMrdBw",
+        "name" : "rename-demo",
+        "full_name" : "pulpogato/rename-demo",
+        "private" : false,
+        "owner" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "html_url" : "https://github.com/pulpogato/rename-demo",
+        "description" : "create demo",
+        "fork" : false,
+        "url" : "https://api.github.com/repos/pulpogato/rename-demo",
+        "forks_url" : "https://api.github.com/repos/pulpogato/rename-demo/forks",
+        "keys_url" : "https://api.github.com/repos/pulpogato/rename-demo/keys{/key_id}",
+        "collaborators_url" : "https://api.github.com/repos/pulpogato/rename-demo/collaborators{/collaborator}",
+        "teams_url" : "https://api.github.com/repos/pulpogato/rename-demo/teams",
+        "hooks_url" : "https://api.github.com/repos/pulpogato/rename-demo/hooks",
+        "issue_events_url" : "https://api.github.com/repos/pulpogato/rename-demo/issues/events{/number}",
+        "events_url" : "https://api.github.com/repos/pulpogato/rename-demo/events",
+        "assignees_url" : "https://api.github.com/repos/pulpogato/rename-demo/assignees{/user}",
+        "branches_url" : "https://api.github.com/repos/pulpogato/rename-demo/branches{/branch}",
+        "tags_url" : "https://api.github.com/repos/pulpogato/rename-demo/tags",
+        "blobs_url" : "https://api.github.com/repos/pulpogato/rename-demo/git/blobs{/sha}",
+        "git_tags_url" : "https://api.github.com/repos/pulpogato/rename-demo/git/tags{/sha}",
+        "git_refs_url" : "https://api.github.com/repos/pulpogato/rename-demo/git/refs{/sha}",
+        "trees_url" : "https://api.github.com/repos/pulpogato/rename-demo/git/trees{/sha}",
+        "statuses_url" : "https://api.github.com/repos/pulpogato/rename-demo/statuses/{sha}",
+        "languages_url" : "https://api.github.com/repos/pulpogato/rename-demo/languages",
+        "stargazers_url" : "https://api.github.com/repos/pulpogato/rename-demo/stargazers",
+        "contributors_url" : "https://api.github.com/repos/pulpogato/rename-demo/contributors",
+        "subscribers_url" : "https://api.github.com/repos/pulpogato/rename-demo/subscribers",
+        "subscription_url" : "https://api.github.com/repos/pulpogato/rename-demo/subscription",
+        "commits_url" : "https://api.github.com/repos/pulpogato/rename-demo/commits{/sha}",
+        "git_commits_url" : "https://api.github.com/repos/pulpogato/rename-demo/git/commits{/sha}",
+        "comments_url" : "https://api.github.com/repos/pulpogato/rename-demo/comments{/number}",
+        "issue_comment_url" : "https://api.github.com/repos/pulpogato/rename-demo/issues/comments{/number}",
+        "contents_url" : "https://api.github.com/repos/pulpogato/rename-demo/contents/{+path}",
+        "compare_url" : "https://api.github.com/repos/pulpogato/rename-demo/compare/{base}...{head}",
+        "merges_url" : "https://api.github.com/repos/pulpogato/rename-demo/merges",
+        "archive_url" : "https://api.github.com/repos/pulpogato/rename-demo/{archive_format}{/ref}",
+        "downloads_url" : "https://api.github.com/repos/pulpogato/rename-demo/downloads",
+        "issues_url" : "https://api.github.com/repos/pulpogato/rename-demo/issues{/number}",
+        "pulls_url" : "https://api.github.com/repos/pulpogato/rename-demo/pulls{/number}",
+        "milestones_url" : "https://api.github.com/repos/pulpogato/rename-demo/milestones{/number}",
+        "notifications_url" : "https://api.github.com/repos/pulpogato/rename-demo/notifications{?since,all,participating}",
+        "labels_url" : "https://api.github.com/repos/pulpogato/rename-demo/labels{/name}",
+        "releases_url" : "https://api.github.com/repos/pulpogato/rename-demo/releases{/id}",
+        "deployments_url" : "https://api.github.com/repos/pulpogato/rename-demo/deployments",
+        "created_at" : "2025-03-22T00:07:42Z",
+        "updated_at" : "2026-06-30T20:20:51Z",
+        "pushed_at" : "2025-12-04T20:58:35Z",
+        "git_url" : "git://github.com/pulpogato/rename-demo.git",
+        "ssh_url" : "git@github.com:pulpogato/rename-demo.git",
+        "clone_url" : "https://github.com/pulpogato/rename-demo.git",
+        "svn_url" : "https://github.com/pulpogato/rename-demo",
+        "homepage" : "https://github.com/pulpogato/create-demo",
+        "size" : 0,
+        "stargazers_count" : 0,
+        "watchers_count" : 0,
+        "language" : null,
+        "has_issues" : true,
+        "has_projects" : true,
+        "has_downloads" : true,
+        "has_wiki" : true,
+        "has_pages" : false,
+        "has_discussions" : false,
+        "forks_count" : 0,
+        "mirror_url" : null,
+        "archived" : false,
+        "disabled" : false,
+        "open_issues_count" : 3,
+        "license" : null,
+        "allow_forking" : true,
+        "is_template" : false,
+        "web_commit_signoff_required" : false,
+        "has_pull_requests" : true,
+        "pull_request_creation_policy" : "all",
+        "topics" : [ ],
+        "visibility" : "public",
+        "forks" : 0,
+        "open_issues" : 3,
+        "watchers" : 0,
+        "default_branch" : "main",
+        "permissions" : {
+          "admin" : true,
+          "maintain" : true,
+          "push" : true,
+          "triage" : true,
+          "pull" : true
+        },
+        "temp_clone_token" : "",
+        "allow_squash_merge" : true,
+        "allow_merge_commit" : true,
+        "allow_rebase_merge" : true,
+        "allow_auto_merge" : false,
+        "delete_branch_on_merge" : false,
+        "allow_update_branch" : false,
+        "use_squash_pr_title_as_default" : false,
+        "squash_merge_commit_message" : "COMMIT_MESSAGES",
+        "squash_merge_commit_title" : "COMMIT_OR_PR_TITLE",
+        "merge_commit_message" : "PR_TITLE",
+        "merge_commit_title" : "MERGE_MESSAGE",
+        "custom_properties" : { },
+        "organization" : {
+          "login" : "pulpogato",
+          "id" : 183456368,
+          "node_id" : "O_kgDOCu9ScA",
+          "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+          "gravatar_id" : "",
+          "url" : "https://api.github.com/users/pulpogato",
+          "html_url" : "https://github.com/pulpogato",
+          "followers_url" : "https://api.github.com/users/pulpogato/followers",
+          "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+          "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+          "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+          "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+          "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+          "repos_url" : "https://api.github.com/users/pulpogato/repos",
+          "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+          "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+          "type" : "Organization",
+          "user_view_type" : "public",
+          "site_admin" : false
+        },
+        "security_and_analysis" : {
+          "secret_scanning" : {
+            "status" : "enabled"
+          },
+          "secret_scanning_push_protection" : {
+            "status" : "enabled"
+          },
+          "dependabot_security_updates" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_non_provider_patterns" : {
+            "status" : "disabled"
+          },
+          "secret_scanning_validity_checks" : {
+            "status" : "disabled"
+          }
+        },
+        "network_count" : 0,
+        "subscribers_count" : 0
+      }

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/ProxyController.java
@@ -37,8 +37,10 @@ public class ProxyController {
     private final RestTemplate restTemplate;
 
     public ProxyController() {
-        // Configure RestTemplate with Apache HttpClient to support the PATCH method
-        var httpClient = HttpClients.createDefault();
+        // Configure RestTemplate with Apache HttpClient to support the PATCH method.
+        // Redirects must not be followed transparently here, since GitHub uses 3xx
+        // responses (e.g. renamed repos) that callers need to observe directly.
+        var httpClient = HttpClients.custom().disableRedirectHandling().build();
         var requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
         this.restTemplate = new RestTemplate(requestFactory);
     }

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Tape.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/Tape.java
@@ -2,6 +2,7 @@ package io.github.pulpogato.test;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +41,12 @@ public class Tape implements Closeable {
 
         List<Exchange> exchanges;
 
-        try (var stream = Tape.class.getResourceAsStream("/" + resourceName)) {
+        // Read from the source file directly rather than the classpath: within a single test,
+        // a tape can be written and re-read multiple times (e.g. when following a redirect),
+        // but the classpath copy is only refreshed by processTestResources between runs.
+        var file = new File(fileName);
+        try (var stream =
+                file.isFile() ? new FileInputStream(file) : Tape.class.getResourceAsStream("/" + resourceName)) {
             if (stream != null) {
                 exchanges = new ObjectMapper(new YAMLFactory()).readValue(stream, new TypeReference<>() {});
                 log.info("Loaded {} exchanges from tape: {}", exchanges.size(), resourceName);


### PR DESCRIPTION
## Summary
- Add `RedirectExchangeFunction`, an `ExchangeFilterFunction` that transparently follows 3xx redirects (up to 5 hops), e.g. for renamed repositories.
- Wire it into the generated `RestClients` constructor by default, alongside `DefaultHeadersExchangeFunction` and `NoContentExchangeFunction`.
- Overload the `RestClients` constructor to accept an explicit `List<ExchangeFilterFunction>`, so callers can customize, reorder, or omit the defaults; split the class/constructor Javadoc accordingly.
- Fix `ProxyController` to stop silently following redirects when recording test tapes, so tapes capture GitHub's real status codes.
- Fix `Tape` to read from the source file directly rather than the classpath copy, since a single test can now record more than one exchange (e.g. a redirect followed by its target).