### PR TITLE
feat: add workflow to retry Maven Central deploy from GitHub Packages

### DIFF
--- a/.github/workflows/republish-to-central.yml
+++ b/.github/workflows/republish-to-central.yml
@@ -1,0 +1,49 @@
+name: Republish to Maven Central
+
+# Sonatype deploys can fail or time out independently of the GitHub Packages
+# publish (see run 28482090964, which timed out at 6h waiting on Central).
+# Rather than re-running the whole release, this fetches the already-published
+# artifacts for a given version back from GitHub Packages and retries only the
+# Central deploy.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version already published to GitHub Packages (e.g. 3.0.5)"
+        required: true
+
+jobs:
+  republish:
+    name: "Republish ${{ inputs.version }} to Maven Central"
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+
+    permissions:
+      packages: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: gradle/actions/wrapper-validation@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: zulu
+          cache: gradle
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - name: Fetch artifacts from GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/republish-to-central.sh "${{ inputs.version }}"
+
+      - name: Deploy to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
+        run: ./gradlew jreleaserDeploy --max-workers=2

--- a/scripts/republish-to-central.sh
+++ b/scripts/republish-to-central.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Mirrors already-published artifacts from GitHub Packages into the local Maven repo
+# layout jreleaserDeploy reads from (build/repos/releases), so a Central-only failure
+# can be retried without rebuilding or re-publishing to GitHub Packages.
+#
+# Arguments:
+#   $1 - version to republish (e.g. 3.0.5)
+#
+# Requires GITHUB_TOKEN (read:packages) in the environment.
+
+VERSION="${1:?Usage: republish-to-central.sh <version>}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
+
+REPO="pulpogato/pulpogato"
+GROUP_PATH="io/github/pulpogato"
+DEST_ROOT="build/repos/releases/${GROUP_PATH}"
+
+GH_VERSIONS=(fpt ghec ghes-3.17 ghes-3.18 ghes-3.19 ghes-3.20 ghes-3.21)
+
+ARTIFACTS=(pulpogato-common pulpogato-bom pulpogato-github-files)
+for gh_version in "${GH_VERSIONS[@]}"; do
+    ARTIFACTS+=("pulpogato-rest-${gh_version}" "pulpogato-graphql-${gh_version}")
+done
+
+# Every real file (pom/module/jar/sources/javadoc) is signed and checksummed the
+# same way, so the set of possible sibling files is fixed regardless of artifact.
+CHECKSUM_SUFFIXES=("" ".asc" ".md5" ".sha1" ".sha256" ".sha512" ".asc.md5" ".asc.sha1" ".asc.sha256" ".asc.sha512")
+
+fetch() {
+    local url="$1" out="$2"
+    if curl -sf -u "x-access-token:${GITHUB_TOKEN}" -o "$out" "$url"; then
+        return 0
+    fi
+    rm -f "$out"
+    return 1
+}
+
+for artifact in "${ARTIFACTS[@]}"; do
+    dir="${DEST_ROOT}/${artifact}/${VERSION}"
+    mkdir -p "${dir}"
+    base_url="https://maven.pkg.github.com/${REPO}/${GROUP_PATH}/${artifact}/${VERSION}"
+
+    echo "Fetching ${artifact}:${VERSION}"
+    fetched_count=0
+
+    # pom/module have no classifier; jar/sources/javadoc share the "jar" extension.
+    files=("${artifact}-${VERSION}.pom" "${artifact}-${VERSION}.module")
+    for classifier in "" "-sources" "-javadoc"; do
+        files+=("${artifact}-${VERSION}${classifier}.jar")
+    done
+
+    for file in "${files[@]}"; do
+        for suffix in "${CHECKSUM_SUFFIXES[@]}"; do
+            if fetch "${base_url}/${file}${suffix}" "${dir}/${file}${suffix}"; then
+                fetched_count=$((fetched_count + 1))
+            fi
+        done
+    done
+
+    if [ "${fetched_count}" -eq 0 ]; then
+        echo "No files found for ${artifact}:${VERSION} — is the version correct?" >&2
+        exit 1
+    fi
+    echo "  fetched ${fetched_count} files"
+done


### PR DESCRIPTION
## Summary
- Run 28482090964 (v3.1.0) timed out after 6h on the Maven Central deploy (`jreleaserDeploy`) even though the GitHub Packages publish had already succeeded.
- Adds a `workflow_dispatch` workflow (`republish-to-central.yml`) that takes a `version` input, mirrors that version's already-published artifacts back from GitHub Packages into the local Maven repo layout `jreleaserDeploy` reads from, and retries only the Central deploy — no rebuild or re-publish to GitHub Packages needed.
- `scripts/republish-to-central.sh` does the mirroring: fetches pom/module/jar/sources/javadoc plus their `.asc` signatures and checksums for every published module.