### PR TITLE
fix: follow redirects when fetching artifacts from GitHub Packages

### DIFF
--- a/scripts/republish-to-central.sh
+++ b/scripts/republish-to-central.sh
@@ -31,7 +31,10 @@ CHECKSUM_SUFFIXES=("" ".asc" ".md5" ".sha1" ".sha256" ".sha512" ".asc.md5" ".asc
 
 fetch() {
     local url="$1" out="$2"
-    if curl -sf -u "x-access-token:${GITHUB_TOKEN}" -o "$out" "$url"; then
+    # GitHub Packages redirects downloads to pre-signed S3 URLs (3xx); -f alone
+    # doesn't catch that, so without -L curl "succeeds" while saving the HTML
+    # redirect body instead of the real artifact.
+    if curl -sfL -u "x-access-token:${GITHUB_TOKEN}" -o "$out" "$url"; then
         return 0
     fi
     rm -f "$out"


### PR DESCRIPTION
## Summary
- GitHub Packages Maven registry redirects file downloads to pre-signed S3 URLs (3xx). `curl -f` doesn't treat redirects as failures, so without `-L` the script silently wrote the small HTML redirect body instead of the real artifact into `build/repos/releases`, corrupting the POM XML and breaking `jreleaserDeploy`.
- Added `-L` to the `fetch()` curl call in `scripts/republish-to-central.sh` so it follows the redirect to the actual S3-hosted file.

Verified by dispatching `republish-to-central.yml` for version 3.1.0 against this branch (run 28606311713) — fetch and POM inspection both succeeded, and `Deploy to Maven Central` ran cleanly instead of failing with the previous `SAXParseException`.