### PR TITLE
fix: specify UTF-8 charset when decoding base64 content in tests

### DIFF
--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -129,7 +129,7 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
 
         var content = body.getContent().replace("\n", "");
         assertThat(content).isNotNull();
-        var decoded = new String(Base64.getDecoder().decode(content));
+        var decoded = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
         assertThat(decoded).startsWith("= Pulpogato");
     }
 
@@ -146,7 +146,7 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
 
         var content = body.getContentFile().getContent().replace("\n", "");
         assertThat(content).isNotNull();
-        var decoded = new String(Base64.getDecoder().decode(content));
+        var decoded = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
         assertThat(decoded).startsWith("= Pulpogato");
     }
 

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/ReposApiIntegrationTest.java
@@ -10,6 +10,7 @@ import io.github.pulpogato.rest.schemas.ContentFile;
 import io.github.pulpogato.rest.schemas.CustomPropertyValue;
 import io.github.pulpogato.rest.schemas.FullRepository;
 import io.github.pulpogato.rest.schemas.SecurityAndAnalysis;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +137,7 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
 
         var content = body.getContent().replace("\n", "");
         assertThat(content).isNotNull();
-        var decoded = new String(Base64.getDecoder().decode(content));
+        var decoded = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
         assertThat(decoded).startsWith("= Pulpogato");
     }
 
@@ -154,7 +155,7 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
 
         var content = body.getContentFile().getContent().replace("\n", "");
         assertThat(content).isNotNull();
-        var decoded = new String(Base64.getDecoder().decode(content));
+        var decoded = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
         assertThat(decoded).startsWith("= Pulpogato");
     }
 


### PR DESCRIPTION
## Summary
- Base64-decoded content in `ReposApiIntegrationTest` (blocking and reactive) was converted to `String` using the platform default charset, which can produce inconsistent results across environments.
- Explicitly decode using `StandardCharsets.UTF_8` for consistent, deterministic behavior.