### PR TITLE
fix: add copy buttons to docs code blocks

### DIFF
--- a/pulpogato-docs/build.gradle.kts
+++ b/pulpogato-docs/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     alias(libs.plugins.asciidoctor)
 }
 
-val asciidoctorExt = configurations.create("asciidoctorExt")
-
-dependencies {
-    asciidoctorExt("com.puravida-software.asciidoctor:asciidoctor-extensions:3.0.0")
-}
-
 tasks.asciidoctor {
     notCompatibleWithConfigurationCache("Asciidoctor Gradle Plugin is not compatible with the configuration cache.")
     sourceDir(file("src"))
@@ -19,5 +13,10 @@ tasks.asciidoctor {
     outputOptions {
         separateOutputDirs = false
     }
-    configurations("asciidoctorExt")
+    attributes(
+        mapOf(
+            "docinfo" to "shared",
+            "docinfodir" to file("src/docinfo").absolutePath,
+        ),
+    )
 }

--- a/pulpogato-docs/src/docinfo/docinfo-footer.html
+++ b/pulpogato-docs/src/docinfo/docinfo-footer.html
@@ -1,0 +1,63 @@
+<script>
+(function () {
+    function copyText(text) {
+        if (navigator.clipboard && window.isSecureContext) {
+            return navigator.clipboard.writeText(text);
+        }
+
+        var textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        try {
+            document.execCommand("copy");
+            return Promise.resolve();
+        } catch (error) {
+            return Promise.reject(error);
+        } finally {
+            document.body.removeChild(textarea);
+        }
+    }
+
+    function setButtonText(button, text) {
+        button.textContent = text;
+        window.setTimeout(function () {
+            button.textContent = "Copy";
+        }, 1200);
+    }
+
+    function addCopyButton(listingBlock) {
+        var content = listingBlock.querySelector(":scope > .content");
+        var code = listingBlock.querySelector("pre code");
+
+        if (!content || !code) {
+            return;
+        }
+
+        var button = document.createElement("button");
+        button.className = "copy-code-button";
+        button.type = "button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        button.addEventListener("click", function () {
+            copyText(code.innerText).then(
+                function () {
+                    setButtonText(button, "Copied");
+                },
+                function () {
+                    setButtonText(button, "Failed");
+                },
+            );
+        });
+        content.appendChild(button);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".listingblock").forEach(addCopyButton);
+    });
+})();
+</script>

--- a/pulpogato-docs/src/docinfo/docinfo.html
+++ b/pulpogato-docs/src/docinfo/docinfo.html
@@ -1,0 +1,29 @@
+<style>
+.listingblock > .content {
+    position: relative;
+}
+
+.listingblock > .content > pre {
+    padding-right: 4.75rem;
+}
+
+.listingblock .copy-code-button {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    background: #fff;
+    color: rgba(0, 0, 0, 0.75);
+    font-family: "Open Sans", "DejaVu Sans", sans-serif;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.35rem 0.5rem;
+}
+
+.listingblock .copy-code-button:hover,
+.listingblock .copy-code-button:focus {
+    background: #f7f7f8;
+    color: rgba(0, 0, 0, 0.9);
+}
+</style>


### PR DESCRIPTION
## Summary

Replace the Puravida Asciidoctor copy extension with local docinfo assets.
Add copy buttons for every generated listing block without depending on Asciidoctor-generated block ids.

## Verification

Ran `./gradlew :pulpogato-docs:check :pulpogato-docs:asciidoctor --max-workers=3` successfully.
Opened the generated docs in the browser via localhost and verified 25 copy buttons for 25 listing blocks.
Clicked the first copy button and verified the button reported `Copied`.

## Notes

`./gradlew check --max-workers=3` is blocked locally by nodenv not having a selected Node version for the root YAML Spotless Prettier task.
A retry with `NODENV_VERSION=22.18.0` needed Gradle wrapper cache access outside the sandbox and was not approved.