### PR TITLE
feat(common): add Paginate overload for list-only paginated APIs

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
@@ -1,5 +1,6 @@
 package io.github.pulpogato.common;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.function.ToIntFunction;
@@ -45,5 +46,24 @@ public class Paginate {
                 Stream.iterate(2L, page -> page + 1)
                         .limit(pages - 1)
                         .flatMap(page -> extractItems.apply(fetchPage.apply(page))));
+    }
+
+    /**
+     * Creates a stream of items from paginated API responses that don't report a total page count,
+     * such as {@code io.github.pulpogato.rest.api.ReposApi#listBranches}. Pages are fetched lazily,
+     * starting from page 1, and fetching stops as soon as a page comes back empty (or {@code maxPages}
+     * is reached), since these APIs signal the end of pagination by returning a short or empty page.
+     *
+     * @param <T>       the type of items to be extracted from each page
+     * @param maxPages  the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage function that takes a page number (1-based) and returns the list of items for that page
+     * @return a stream containing all items from the fetched pages
+     */
+    public <T> Stream<T> from(final long maxPages, final LongFunction<@NonNull List<T>> fetchPage) {
+        return Stream.iterate(1L, page -> page + 1)
+                .limit(maxPages)
+                .map(fetchPage::apply)
+                .takeWhile(items -> !items.isEmpty())
+                .flatMap(List::stream);
     }
 }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
@@ -105,4 +105,51 @@ class PaginateTest {
 
         assertThat(first).isPresent();
     }
+
+    @Mock
+    private LongFunction<List<String>> fetchListPage;
+
+    @Test
+    @DisplayName("Should return all items from a single page when there is no total page count")
+    void singlePageNoTotalPages() {
+        var paginate = new Paginate();
+        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+        when(fetchListPage.apply(2L)).thenReturn(List.of());
+
+        var result = paginate.from(10, fetchListPage);
+        assertThat(result).containsExactly("1", "2", "3");
+    }
+
+    @Test
+    @DisplayName("Should concatenate items from multiple pages when there is no total page count")
+    void multiplePagesNoTotalPages() {
+        var paginate = new Paginate();
+        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+        when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+        when(fetchListPage.apply(3L)).thenReturn(List.of());
+
+        var result = paginate.from(10, fetchListPage);
+        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+    }
+
+    @Test
+    @DisplayName("Should return empty stream when there is no data and no total page count")
+    void noDataNoTotalPages() {
+        var paginate = new Paginate();
+        when(fetchListPage.apply(1L)).thenReturn(List.of());
+
+        var result = paginate.from(10, fetchListPage);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should respect max pages limit when there is no total page count")
+    void limitPagesNoTotalPages() {
+        var paginate = new Paginate();
+        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+        when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+
+        var result = paginate.from(2, fetchListPage);
+        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+    }
 }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/ReposApiIntegrationTest.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.github.pulpogato.common.NullableOptional;
+import io.github.pulpogato.common.Paginate;
 import io.github.pulpogato.common.SingularOrPlural;
 import io.github.pulpogato.rest.schemas.ContentFile;
 import io.github.pulpogato.rest.schemas.CustomPropertyValue;
 import io.github.pulpogato.rest.schemas.FullRepository;
 import io.github.pulpogato.rest.schemas.RulesetVersion;
 import io.github.pulpogato.rest.schemas.SecurityAndAnalysis;
+import io.github.pulpogato.rest.schemas.ShortBranch;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -37,6 +39,54 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(tags).hasSize(2);
         assertThat(tags.get(0).getName()).isEqualTo("v0.2.0");
         assertThat(tags.get(1).getName()).isEqualTo("v0.1.0");
+    }
+
+    @Test
+    void testListBranchesPaginated() {
+        var api = new RestClients(webClient).getReposApi();
+        var perPage = 5L;
+
+        var branches = new Paginate()
+                .from(25, page -> api.listBranches("jenkinsci", "gradle-jpi-plugin", null, perPage, page)
+                        .getBody())
+                .toList();
+
+        var allBranches = api.listBranches("jenkinsci", "gradle-jpi-plugin", null, 100L, 1L)
+                .getBody();
+        assertThat(branches).hasSize(24);
+        assertThat(branches)
+                .extracting(ShortBranch::getName)
+                .containsExactlyElementsOf(
+                        allBranches.stream().map(ShortBranch::getName).toList());
+        assertThat(branches)
+                .filteredOn(ShortBranch::getName, "main")
+                .extracting(ShortBranch::getIsProtected)
+                .containsExactly(true);
+    }
+
+    @Test
+    void testListBranchesPaginatedRespectsMaxPages() {
+        var api = new RestClients(webClient).getReposApi();
+        var perPage = 1L;
+
+        var branches = new Paginate()
+                .from(1, page -> api.listBranches("pulpogato", "pulpogato", null, perPage, page)
+                        .getBody())
+                .toList();
+
+        assertThat(branches).extracting(ShortBranch::getName).containsExactly("gh-pages");
+    }
+
+    @Test
+    void testListBranchesPaginatedNoResults() {
+        var api = new RestClients(webClient).getReposApi();
+
+        var branches = new Paginate()
+                .from(10, page -> api.listBranches("pulpogato", "create-demo", true, 100L, page)
+                        .getBody())
+                .toList();
+
+        assertThat(branches).isEmpty();
     }
 
     @Test

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/SearchApiIntegrationTest.java
@@ -2,6 +2,8 @@ package io.github.pulpogato.rest.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.pulpogato.common.Paginate;
+import io.github.pulpogato.rest.schemas.RepoSearchResultItem;
 import org.junit.jupiter.api.Test;
 
 class SearchApiIntegrationTest extends BaseApiIntegrationTest {
@@ -38,6 +40,26 @@ class SearchApiIntegrationTest extends BaseApiIntegrationTest {
         var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void testSearchRepositoriesPaginated() {
+        var api = new RestClients(webClient).getSearchApi();
+        var perPage = 1L;
+
+        var repos = new Paginate()
+                .from(
+                        8,
+                        page -> api.repos("pulpogato", null, null, perPage, page)
+                                .getBody(),
+                        response -> response.getItems().stream(),
+                        response -> (int) Math.ceil(response.getTotalCount() / (double) perPage))
+                .toList();
+
+        // total_count is 20, but the maxPages cap of 8 (with per_page=1) stops us short of that
+        assertThat(repos).hasSize(8);
+        assertThat(repos).extracting(RepoSearchResultItem::getFullName).doesNotHaveDuplicates();
+        assertThat(repos).extracting(RepoSearchResultItem::getFullName).contains("pulpogato/pulpogato");
     }
 
     @Test

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginated.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginated.yml
@@ -1,0 +1,457 @@
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=2>;\
+        \ rel=\"next\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"last\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "accmod-toolchain",
+        "commit" : {
+          "sha" : "714cb1afb32117f84f9445786905c0a4dcf43666",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/714cb1afb32117f84f9445786905c0a4dcf43666"
+        },
+        "protected" : false
+      }, {
+        "name" : "feature/nix",
+        "commit" : {
+          "sha" : "f4f4613bb9be07fd38dfbc82062504e6d3c50bb0",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/f4f4613bb9be07fd38dfbc82062504e6d3c50bb0"
+        },
+        "protected" : false
+      }, {
+        "name" : "feature/remote-exec",
+        "commit" : {
+          "sha" : "e93896a56933692b767d19bc12f702011be21c1a",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e93896a56933692b767d19bc12f702011be21c1a"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/ci",
+        "commit" : {
+          "sha" : "ec7194e8098d6a2322fbc7147f15b97671078230",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/ec7194e8098d6a2322fbc7147f15b97671078230"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/jvm-args",
+        "commit" : {
+          "sha" : "5fcebbb1d125dd4ecb47033c470d1f8e470b2ce0",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/5fcebbb1d125dd4ecb47033c470d1f8e470b2ce0"
+        },
+        "protected" : false
+      } ]
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=2
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"prev\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=3>;\
+        \ rel=\"next\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"last\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "fix/project-ref",
+        "commit" : {
+          "sha" : "e3fd27ff49b738b8a40b8ea4c0bc36a94e932697",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e3fd27ff49b738b8a40b8ea4c0bc36a94e932697"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/test-annotation",
+        "commit" : {
+          "sha" : "feedb8c276b52f28e804b1ad74cf346a5c21c1a8",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/feedb8c276b52f28e804b1ad74cf346a5c21c1a8"
+        },
+        "protected" : false
+      }, {
+        "name" : "gradle-8.5",
+        "commit" : {
+          "sha" : "5deca30757717b33b63a3bd3a035e0ddcf44dd49",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/5deca30757717b33b63a3bd3a035e0ddcf44dd49"
+        },
+        "protected" : false
+      }, {
+        "name" : "jdk-8",
+        "commit" : {
+          "sha" : "c7e31f0d53724d0395ba961bce5023e8fd70bac1",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/c7e31f0d53724d0395ba961bce5023e8fd70bac1"
+        },
+        "protected" : false
+      }, {
+        "name" : "jdk-11",
+        "commit" : {
+          "sha" : "63a6fe9d1f3fcf6697004e2f8075fa2711cdb703",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/63a6fe9d1f3fcf6697004e2f8075fa2711cdb703"
+        },
+        "protected" : false
+      } ]
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=3
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=2>;\
+        \ rel=\"prev\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=4>;\
+        \ rel=\"next\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"last\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "main",
+        "commit" : {
+          "sha" : "d52a19414f56db5b5437ad1c8af4de280e905a3b",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d52a19414f56db5b5437ad1c8af4de280e905a3b"
+        },
+        "protected" : true
+      }, {
+        "name" : "pull/227/head",
+        "commit" : {
+          "sha" : "6b0931bd77ff1d4476615824e290ed6fecb4712f",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/6b0931bd77ff1d4476615824e290ed6fecb4712f"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/actions-checkout-7.x",
+        "commit" : {
+          "sha" : "fc9418b358a555d9dfc1e80c559ebc9e4085820e",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/fc9418b358a555d9dfc1e80c559ebc9e4085820e"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/codenarc-3.x",
+        "commit" : {
+          "sha" : "d8db4bd651cc22d7d2c7e56be6e6cf3cedc26829",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d8db4bd651cc22d7d2c7e56be6e6cf3cedc26829"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/com.gradle.develocity-4.x",
+        "commit" : {
+          "sha" : "dcf742206f665103980f3ff64c98e2c6a4e792ec",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/dcf742206f665103980f3ff64c98e2c6a4e792ec"
+        },
+        "protected" : false
+      } ]
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=4
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=3>;\
+        \ rel=\"prev\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"next\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"last\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "renovate/gradle-9.x",
+        "commit" : {
+          "sha" : "0851e8c4afe13275a8910a6563bad8eedef1d673",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/0851e8c4afe13275a8910a6563bad8eedef1d673"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/jenkins",
+        "commit" : {
+          "sha" : "e568696fffbc0189af607c1534df817e28a1033d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e568696fffbc0189af607c1534df817e28a1033d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/junit-framework-monorepo",
+        "commit" : {
+          "sha" : "2fa6c0c25c5bee46cdcf4fd0b930bbafe902fb1d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/2fa6c0c25c5bee46cdcf4fd0b930bbafe902fb1d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/kotlin-monorepo",
+        "commit" : {
+          "sha" : "c1e088c01ee05c32a1b1b3376d082a98bf85ca51",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/c1e088c01ee05c32a1b1b3376d082a98bf85ca51"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/major-guava-monorepo",
+        "commit" : {
+          "sha" : "d165bca50fed8496383711922dcc58f8a642d8f7",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d165bca50fed8496383711922dcc58f8a642d8f7"
+        },
+        "protected" : false
+      } ]
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=5
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=4>;\
+        \ rel=\"prev\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "renovate/major-okhttp-monorepo",
+        "commit" : {
+          "sha" : "104ad715d9019b5828a386c97f306e8cb684029d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/104ad715d9019b5828a386c97f306e8cb684029d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/spotbugs.gradle",
+        "commit" : {
+          "sha" : "96b425e1a14d3b7515adc54885a3a3210896ca2a",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/96b425e1a14d3b7515adc54885a3a3210896ca2a"
+        },
+        "protected" : false
+      }, {
+        "name" : "sghill-patch-1",
+        "commit" : {
+          "sha" : "2717072fa244abe521377966126b02ea8c4587f8",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/2717072fa244abe521377966126b02ea8c4587f8"
+        },
+        "protected" : false
+      }, {
+        "name" : "simplify-manifest",
+        "commit" : {
+          "sha" : "012fdb9d173f6cfd8cbc59e7916db703a8a1a090",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/012fdb9d173f6cfd8cbc59e7916db703a8a1a090"
+        },
+        "protected" : false
+      } ]
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=5&page=6
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Link: "<https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"prev\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=5>;\
+        \ rel=\"last\", <https://api.github.com/repositories/2976872/branches?per_page=5&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: "[ ]"
+- request:
+    method: GET
+    uri: /repos/jenkinsci/gradle-jpi-plugin/branches?per_page=100&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "accmod-toolchain",
+        "commit" : {
+          "sha" : "714cb1afb32117f84f9445786905c0a4dcf43666",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/714cb1afb32117f84f9445786905c0a4dcf43666"
+        },
+        "protected" : false
+      }, {
+        "name" : "feature/nix",
+        "commit" : {
+          "sha" : "f4f4613bb9be07fd38dfbc82062504e6d3c50bb0",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/f4f4613bb9be07fd38dfbc82062504e6d3c50bb0"
+        },
+        "protected" : false
+      }, {
+        "name" : "feature/remote-exec",
+        "commit" : {
+          "sha" : "e93896a56933692b767d19bc12f702011be21c1a",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e93896a56933692b767d19bc12f702011be21c1a"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/ci",
+        "commit" : {
+          "sha" : "ec7194e8098d6a2322fbc7147f15b97671078230",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/ec7194e8098d6a2322fbc7147f15b97671078230"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/jvm-args",
+        "commit" : {
+          "sha" : "5fcebbb1d125dd4ecb47033c470d1f8e470b2ce0",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/5fcebbb1d125dd4ecb47033c470d1f8e470b2ce0"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/project-ref",
+        "commit" : {
+          "sha" : "e3fd27ff49b738b8a40b8ea4c0bc36a94e932697",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e3fd27ff49b738b8a40b8ea4c0bc36a94e932697"
+        },
+        "protected" : false
+      }, {
+        "name" : "fix/test-annotation",
+        "commit" : {
+          "sha" : "feedb8c276b52f28e804b1ad74cf346a5c21c1a8",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/feedb8c276b52f28e804b1ad74cf346a5c21c1a8"
+        },
+        "protected" : false
+      }, {
+        "name" : "gradle-8.5",
+        "commit" : {
+          "sha" : "5deca30757717b33b63a3bd3a035e0ddcf44dd49",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/5deca30757717b33b63a3bd3a035e0ddcf44dd49"
+        },
+        "protected" : false
+      }, {
+        "name" : "jdk-8",
+        "commit" : {
+          "sha" : "c7e31f0d53724d0395ba961bce5023e8fd70bac1",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/c7e31f0d53724d0395ba961bce5023e8fd70bac1"
+        },
+        "protected" : false
+      }, {
+        "name" : "jdk-11",
+        "commit" : {
+          "sha" : "63a6fe9d1f3fcf6697004e2f8075fa2711cdb703",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/63a6fe9d1f3fcf6697004e2f8075fa2711cdb703"
+        },
+        "protected" : false
+      }, {
+        "name" : "main",
+        "commit" : {
+          "sha" : "d52a19414f56db5b5437ad1c8af4de280e905a3b",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d52a19414f56db5b5437ad1c8af4de280e905a3b"
+        },
+        "protected" : true
+      }, {
+        "name" : "pull/227/head",
+        "commit" : {
+          "sha" : "6b0931bd77ff1d4476615824e290ed6fecb4712f",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/6b0931bd77ff1d4476615824e290ed6fecb4712f"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/actions-checkout-7.x",
+        "commit" : {
+          "sha" : "fc9418b358a555d9dfc1e80c559ebc9e4085820e",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/fc9418b358a555d9dfc1e80c559ebc9e4085820e"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/codenarc-3.x",
+        "commit" : {
+          "sha" : "d8db4bd651cc22d7d2c7e56be6e6cf3cedc26829",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d8db4bd651cc22d7d2c7e56be6e6cf3cedc26829"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/com.gradle.develocity-4.x",
+        "commit" : {
+          "sha" : "dcf742206f665103980f3ff64c98e2c6a4e792ec",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/dcf742206f665103980f3ff64c98e2c6a4e792ec"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/gradle-9.x",
+        "commit" : {
+          "sha" : "0851e8c4afe13275a8910a6563bad8eedef1d673",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/0851e8c4afe13275a8910a6563bad8eedef1d673"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/jenkins",
+        "commit" : {
+          "sha" : "e568696fffbc0189af607c1534df817e28a1033d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/e568696fffbc0189af607c1534df817e28a1033d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/junit-framework-monorepo",
+        "commit" : {
+          "sha" : "2fa6c0c25c5bee46cdcf4fd0b930bbafe902fb1d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/2fa6c0c25c5bee46cdcf4fd0b930bbafe902fb1d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/kotlin-monorepo",
+        "commit" : {
+          "sha" : "c1e088c01ee05c32a1b1b3376d082a98bf85ca51",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/c1e088c01ee05c32a1b1b3376d082a98bf85ca51"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/major-guava-monorepo",
+        "commit" : {
+          "sha" : "d165bca50fed8496383711922dcc58f8a642d8f7",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/d165bca50fed8496383711922dcc58f8a642d8f7"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/major-okhttp-monorepo",
+        "commit" : {
+          "sha" : "104ad715d9019b5828a386c97f306e8cb684029d",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/104ad715d9019b5828a386c97f306e8cb684029d"
+        },
+        "protected" : false
+      }, {
+        "name" : "renovate/spotbugs.gradle",
+        "commit" : {
+          "sha" : "96b425e1a14d3b7515adc54885a3a3210896ca2a",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/96b425e1a14d3b7515adc54885a3a3210896ca2a"
+        },
+        "protected" : false
+      }, {
+        "name" : "sghill-patch-1",
+        "commit" : {
+          "sha" : "2717072fa244abe521377966126b02ea8c4587f8",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/2717072fa244abe521377966126b02ea8c4587f8"
+        },
+        "protected" : false
+      }, {
+        "name" : "simplify-manifest",
+        "commit" : {
+          "sha" : "012fdb9d173f6cfd8cbc59e7916db703a8a1a090",
+          "url" : "https://api.github.com/repos/jenkinsci/gradle-jpi-plugin/commits/012fdb9d173f6cfd8cbc59e7916db703a8a1a090"
+        },
+        "protected" : false
+      } ]

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginatedNoResults.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginatedNoResults.yml
@@ -1,0 +1,30 @@
+- request:
+    method: GET
+    uri: /repos/pulpogato/create-demo/branches?protected=true&per_page=100&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 301
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Location: https://api.github.com/repositories/952818951/branches?protected=true&per_page=100&page=1
+    bodyIsBinary: false
+    body: |-
+      {
+        "message" : "Moved Permanently",
+        "url" : "https://api.github.com/repositories/952818951/branches?protected=true&per_page=100&page=1",
+        "documentation_url" : "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
+      }
+- request:
+    method: GET
+    uri: /repositories/952818951/branches?protected=true&per_page=100&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+    bodyIsBinary: false
+    body: "[ ]"

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginatedRespectsMaxPages.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/ReposApiIntegrationTest/testListBranchesPaginatedRespectsMaxPages.yml
@@ -1,0 +1,33 @@
+- request:
+    method: GET
+    uri: /repos/pulpogato/pulpogato/branches?per_page=1&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/repositories/825463572/branches?per_page=1&page=2>;\
+        \ rel=\"next\", <https://api.github.com/repositories/825463572/branches?per_page=1&page=3>;\
+        \ rel=\"last\""
+    bodyIsBinary: false
+    body: |-
+      [ {
+        "name" : "gh-pages",
+        "commit" : {
+          "sha" : "0d134897c10bf38cb68e0302f9f98f2f2bbe348e",
+          "url" : "https://api.github.com/repos/pulpogato/pulpogato/commits/0d134897c10bf38cb68e0302f9f98f2f2bbe348e"
+        },
+        "protected" : false,
+        "protection" : {
+          "enabled" : false,
+          "required_status_checks" : {
+            "enforcement_level" : "off",
+            "contexts" : [ ],
+            "checks" : [ ]
+          }
+        },
+        "protection_url" : "https://api.github.com/repos/pulpogato/pulpogato/branches/gh-pages/protection"
+      } ]

--- a/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/SearchApiIntegrationTest/testSearchRepositoriesPaginated.yml
+++ b/pulpogato-rest-fpt/src/test/resources/tapes/io/github/pulpogato/rest/api/SearchApiIntegrationTest/testSearchRepositoriesPaginated.yml
@@ -1,0 +1,1068 @@
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=1
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=2>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 67203482,
+          "node_id" : "MDEwOlJlcG9zaXRvcnk2NzIwMzQ4Mg==",
+          "name" : "las-aventuras-de-paco-el-pulpogato",
+          "full_name" : "LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "LuisJoseSanchez",
+            "id" : 840797,
+            "node_id" : "MDQ6VXNlcjg0MDc5Nw==",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/840797?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/LuisJoseSanchez",
+            "html_url" : "https://github.com/LuisJoseSanchez",
+            "followers_url" : "https://api.github.com/users/LuisJoseSanchez/followers",
+            "following_url" : "https://api.github.com/users/LuisJoseSanchez/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/LuisJoseSanchez/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/LuisJoseSanchez/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/LuisJoseSanchez/subscriptions",
+            "organizations_url" : "https://api.github.com/users/LuisJoseSanchez/orgs",
+            "repos_url" : "https://api.github.com/users/LuisJoseSanchez/repos",
+            "events_url" : "https://api.github.com/users/LuisJoseSanchez/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/LuisJoseSanchez/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato",
+          "description" : "Las asombrosas aventuras y desventuras del ser colaborativo festivo",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato",
+          "forks_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato/deployments",
+          "created_at" : "2016-09-02T08:05:05Z",
+          "updated_at" : "2018-10-30T11:02:19Z",
+          "pushed_at" : "2021-03-20T06:28:50Z",
+          "git_url" : "git://github.com/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato.git",
+          "ssh_url" : "git@github.com:LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato.git",
+          "clone_url" : "https://github.com/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato.git",
+          "svn_url" : "https://github.com/LuisJoseSanchez/las-aventuras-de-paco-el-pulpogato",
+          "homepage" : null,
+          "size" : 3,
+          "stargazers_count" : 6,
+          "watchers_count" : 6,
+          "language" : null,
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 16,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 7,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 16,
+          "open_issues" : 7,
+          "watchers" : 6,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=2
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=3>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 296306402,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkyOTYzMDY0MDI=",
+          "name" : "las-aventuras-de-paco-el-pulpogato",
+          "full_name" : "JuanMaCasGod/las-aventuras-de-paco-el-pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "JuanMaCasGod",
+            "id" : 71384524,
+            "node_id" : "MDQ6VXNlcjcxMzg0NTI0",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/71384524?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/JuanMaCasGod",
+            "html_url" : "https://github.com/JuanMaCasGod",
+            "followers_url" : "https://api.github.com/users/JuanMaCasGod/followers",
+            "following_url" : "https://api.github.com/users/JuanMaCasGod/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/JuanMaCasGod/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/JuanMaCasGod/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/JuanMaCasGod/subscriptions",
+            "organizations_url" : "https://api.github.com/users/JuanMaCasGod/orgs",
+            "repos_url" : "https://api.github.com/users/JuanMaCasGod/repos",
+            "events_url" : "https://api.github.com/users/JuanMaCasGod/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/JuanMaCasGod/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato",
+          "description" : null,
+          "fork" : false,
+          "url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato",
+          "forks_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato/deployments",
+          "created_at" : "2020-09-17T11:28:29Z",
+          "updated_at" : "2020-11-03T20:56:24Z",
+          "pushed_at" : "2020-09-17T11:37:54Z",
+          "git_url" : "git://github.com/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato.git",
+          "ssh_url" : "git@github.com:JuanMaCasGod/las-aventuras-de-paco-el-pulpogato.git",
+          "clone_url" : "https://github.com/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato.git",
+          "svn_url" : "https://github.com/JuanMaCasGod/las-aventuras-de-paco-el-pulpogato",
+          "homepage" : null,
+          "size" : 2,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : null,
+          "has_issues" : false,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 4,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 4,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=3
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=2>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=4>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 825463572,
+          "node_id" : "R_kgDOMTOTFA",
+          "name" : "pulpogato",
+          "full_name" : "pulpogato/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "pulpogato",
+            "id" : 183456368,
+            "node_id" : "O_kgDOCu9ScA",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/183456368?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/pulpogato",
+            "html_url" : "https://github.com/pulpogato",
+            "followers_url" : "https://api.github.com/users/pulpogato/followers",
+            "following_url" : "https://api.github.com/users/pulpogato/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/pulpogato/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/pulpogato/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/pulpogato/subscriptions",
+            "organizations_url" : "https://api.github.com/users/pulpogato/orgs",
+            "repos_url" : "https://api.github.com/users/pulpogato/repos",
+            "events_url" : "https://api.github.com/users/pulpogato/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/pulpogato/received_events",
+            "type" : "Organization",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/pulpogato/pulpogato",
+          "description" : "Generated GitHub Java Client",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/pulpogato/pulpogato",
+          "forks_url" : "https://api.github.com/repos/pulpogato/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/pulpogato/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/pulpogato/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/pulpogato/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/pulpogato/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/pulpogato/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/pulpogato/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/pulpogato/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/pulpogato/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/pulpogato/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/pulpogato/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/pulpogato/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/pulpogato/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/pulpogato/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/pulpogato/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/pulpogato/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/pulpogato/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/pulpogato/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/pulpogato/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/pulpogato/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/pulpogato/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/pulpogato/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/pulpogato/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/pulpogato/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/pulpogato/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/pulpogato/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/pulpogato/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/pulpogato/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/pulpogato/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/pulpogato/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/pulpogato/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/pulpogato/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/pulpogato/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/pulpogato/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/pulpogato/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/pulpogato/pulpogato/deployments",
+          "created_at" : "2024-07-07T21:03:05Z",
+          "updated_at" : "2026-07-09T18:16:26Z",
+          "pushed_at" : "2026-07-09T18:16:15Z",
+          "git_url" : "git://github.com/pulpogato/pulpogato.git",
+          "ssh_url" : "git@github.com:pulpogato/pulpogato.git",
+          "clone_url" : "https://github.com/pulpogato/pulpogato.git",
+          "svn_url" : "https://github.com/pulpogato/pulpogato",
+          "homepage" : "https://pulpogato.github.io/pulpogato/",
+          "size" : 11035,
+          "stargazers_count" : 2,
+          "watchers_count" : 2,
+          "language" : "Java",
+          "has_issues" : true,
+          "has_projects" : false,
+          "has_downloads" : true,
+          "has_wiki" : false,
+          "has_pages" : true,
+          "has_discussions" : false,
+          "forks_count" : 2,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 1,
+          "license" : {
+            "key" : "apache-2.0",
+            "name" : "Apache License 2.0",
+            "spdx_id" : "Apache-2.0",
+            "url" : "https://api.github.com/licenses/apache-2.0",
+            "node_id" : "MDc6TGljZW5zZTI="
+          },
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ "api", "github", "hacktoberfest", "java" ],
+          "visibility" : "public",
+          "forks" : 2,
+          "open_issues" : 1,
+          "watchers" : 2,
+          "default_branch" : "main",
+          "permissions" : {
+            "admin" : true,
+            "maintain" : true,
+            "push" : true,
+            "triage" : true,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=4
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=3>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=5>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 158686048,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkxNTg2ODYwNDg=",
+          "name" : "pulpogato",
+          "full_name" : "josecordonescobo91/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "josecordonescobo91",
+            "id" : 45201621,
+            "node_id" : "MDQ6VXNlcjQ1MjAxNjIx",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/45201621?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/josecordonescobo91",
+            "html_url" : "https://github.com/josecordonescobo91",
+            "followers_url" : "https://api.github.com/users/josecordonescobo91/followers",
+            "following_url" : "https://api.github.com/users/josecordonescobo91/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/josecordonescobo91/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/josecordonescobo91/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/josecordonescobo91/subscriptions",
+            "organizations_url" : "https://api.github.com/users/josecordonescobo91/orgs",
+            "repos_url" : "https://api.github.com/users/josecordonescobo91/repos",
+            "events_url" : "https://api.github.com/users/josecordonescobo91/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/josecordonescobo91/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/josecordonescobo91/pulpogato",
+          "description" : "Pulpogato",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/josecordonescobo91/pulpogato",
+          "forks_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/josecordonescobo91/pulpogato/deployments",
+          "created_at" : "2018-11-22T11:00:25Z",
+          "updated_at" : "2018-11-22T11:31:17Z",
+          "pushed_at" : "2018-11-22T11:31:16Z",
+          "git_url" : "git://github.com/josecordonescobo91/pulpogato.git",
+          "ssh_url" : "git@github.com:josecordonescobo91/pulpogato.git",
+          "clone_url" : "https://github.com/josecordonescobo91/pulpogato.git",
+          "svn_url" : "https://github.com/josecordonescobo91/pulpogato",
+          "homepage" : null,
+          "size" : 1,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : null,
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 0,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 0,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=5
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=4>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=6>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 158686039,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkxNTg2ODYwMzk=",
+          "name" : "pulpogato",
+          "full_name" : "AlbertoLomas/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "AlbertoLomas",
+            "id" : 45201577,
+            "node_id" : "MDQ6VXNlcjQ1MjAxNTc3",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/45201577?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/AlbertoLomas",
+            "html_url" : "https://github.com/AlbertoLomas",
+            "followers_url" : "https://api.github.com/users/AlbertoLomas/followers",
+            "following_url" : "https://api.github.com/users/AlbertoLomas/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/AlbertoLomas/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/AlbertoLomas/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/AlbertoLomas/subscriptions",
+            "organizations_url" : "https://api.github.com/users/AlbertoLomas/orgs",
+            "repos_url" : "https://api.github.com/users/AlbertoLomas/repos",
+            "events_url" : "https://api.github.com/users/AlbertoLomas/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/AlbertoLomas/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/AlbertoLomas/pulpogato",
+          "description" : "Pulpogato",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/AlbertoLomas/pulpogato",
+          "forks_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/AlbertoLomas/pulpogato/deployments",
+          "created_at" : "2018-11-22T11:00:23Z",
+          "updated_at" : "2018-11-22T11:48:21Z",
+          "pushed_at" : "2018-11-22T11:48:20Z",
+          "git_url" : "git://github.com/AlbertoLomas/pulpogato.git",
+          "ssh_url" : "git@github.com:AlbertoLomas/pulpogato.git",
+          "clone_url" : "https://github.com/AlbertoLomas/pulpogato.git",
+          "svn_url" : "https://github.com/AlbertoLomas/pulpogato",
+          "homepage" : null,
+          "size" : 15,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : "Java",
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 0,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 0,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=6
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=5>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=7>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 158686061,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkxNTg2ODYwNjE=",
+          "name" : "pulpogato",
+          "full_name" : "AGarciaDeLucas/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "AGarciaDeLucas",
+            "id" : 45201582,
+            "node_id" : "MDQ6VXNlcjQ1MjAxNTgy",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/45201582?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/AGarciaDeLucas",
+            "html_url" : "https://github.com/AGarciaDeLucas",
+            "followers_url" : "https://api.github.com/users/AGarciaDeLucas/followers",
+            "following_url" : "https://api.github.com/users/AGarciaDeLucas/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/AGarciaDeLucas/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/AGarciaDeLucas/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/AGarciaDeLucas/subscriptions",
+            "organizations_url" : "https://api.github.com/users/AGarciaDeLucas/orgs",
+            "repos_url" : "https://api.github.com/users/AGarciaDeLucas/repos",
+            "events_url" : "https://api.github.com/users/AGarciaDeLucas/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/AGarciaDeLucas/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/AGarciaDeLucas/pulpogato",
+          "description" : "pulpogato",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato",
+          "forks_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/AGarciaDeLucas/pulpogato/deployments",
+          "created_at" : "2018-11-22T11:00:31Z",
+          "updated_at" : "2018-11-22T11:15:45Z",
+          "pushed_at" : "2018-11-22T11:15:43Z",
+          "git_url" : "git://github.com/AGarciaDeLucas/pulpogato.git",
+          "ssh_url" : "git@github.com:AGarciaDeLucas/pulpogato.git",
+          "clone_url" : "https://github.com/AGarciaDeLucas/pulpogato.git",
+          "svn_url" : "https://github.com/AGarciaDeLucas/pulpogato",
+          "homepage" : null,
+          "size" : 0,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : null,
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 0,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 0,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=7
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=6>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=8>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 158686103,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkxNTg2ODYxMDM=",
+          "name" : "pulpogato",
+          "full_name" : "daserpel98/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "daserpel98",
+            "id" : 45201475,
+            "node_id" : "MDQ6VXNlcjQ1MjAxNDc1",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/45201475?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/daserpel98",
+            "html_url" : "https://github.com/daserpel98",
+            "followers_url" : "https://api.github.com/users/daserpel98/followers",
+            "following_url" : "https://api.github.com/users/daserpel98/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/daserpel98/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/daserpel98/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/daserpel98/subscriptions",
+            "organizations_url" : "https://api.github.com/users/daserpel98/orgs",
+            "repos_url" : "https://api.github.com/users/daserpel98/repos",
+            "events_url" : "https://api.github.com/users/daserpel98/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/daserpel98/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/daserpel98/pulpogato",
+          "description" : null,
+          "fork" : false,
+          "url" : "https://api.github.com/repos/daserpel98/pulpogato",
+          "forks_url" : "https://api.github.com/repos/daserpel98/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/daserpel98/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/daserpel98/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/daserpel98/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/daserpel98/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/daserpel98/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/daserpel98/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/daserpel98/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/daserpel98/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/daserpel98/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/daserpel98/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/daserpel98/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/daserpel98/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/daserpel98/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/daserpel98/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/daserpel98/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/daserpel98/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/daserpel98/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/daserpel98/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/daserpel98/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/daserpel98/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/daserpel98/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/daserpel98/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/daserpel98/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/daserpel98/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/daserpel98/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/daserpel98/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/daserpel98/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/daserpel98/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/daserpel98/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/daserpel98/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/daserpel98/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/daserpel98/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/daserpel98/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/daserpel98/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/daserpel98/pulpogato/deployments",
+          "created_at" : "2018-11-22T11:00:53Z",
+          "updated_at" : "2018-11-22T11:00:53Z",
+          "pushed_at" : "2018-11-22T11:00:54Z",
+          "git_url" : "git://github.com/daserpel98/pulpogato.git",
+          "ssh_url" : "git@github.com:daserpel98/pulpogato.git",
+          "clone_url" : "https://github.com/daserpel98/pulpogato.git",
+          "svn_url" : "https://github.com/daserpel98/pulpogato",
+          "homepage" : null,
+          "size" : 0,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : null,
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 0,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 0,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }
+- request:
+    method: GET
+    uri: /search/repositories?q=pulpogato&per_page=1&page=8
+    protocol: HTTP/1.1
+    headers:
+      Accept: application/json
+  response:
+    statusCode: 200
+    headers:
+      Content-Type: application/json; charset=utf-8
+      Transfer-Encoding: chunked
+      Link: "<https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=7>;\
+        \ rel=\"prev\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=9>;\
+        \ rel=\"next\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=20>;\
+        \ rel=\"last\", <https://api.github.com/search/repositories?q=pulpogato&per_page=1&page=1>;\
+        \ rel=\"first\""
+    bodyIsBinary: false
+    body: |-
+      {
+        "total_count" : 20,
+        "incomplete_results" : false,
+        "items" : [ {
+          "id" : 158686041,
+          "node_id" : "MDEwOlJlcG9zaXRvcnkxNTg2ODYwNDE=",
+          "name" : "pulpogato",
+          "full_name" : "albertolunadelmoral/pulpogato",
+          "private" : false,
+          "owner" : {
+            "login" : "albertolunadelmoral",
+            "id" : 45201509,
+            "node_id" : "MDQ6VXNlcjQ1MjAxNTA5",
+            "avatar_url" : "https://avatars.githubusercontent.com/u/45201509?v=4",
+            "gravatar_id" : "",
+            "url" : "https://api.github.com/users/albertolunadelmoral",
+            "html_url" : "https://github.com/albertolunadelmoral",
+            "followers_url" : "https://api.github.com/users/albertolunadelmoral/followers",
+            "following_url" : "https://api.github.com/users/albertolunadelmoral/following{/other_user}",
+            "gists_url" : "https://api.github.com/users/albertolunadelmoral/gists{/gist_id}",
+            "starred_url" : "https://api.github.com/users/albertolunadelmoral/starred{/owner}{/repo}",
+            "subscriptions_url" : "https://api.github.com/users/albertolunadelmoral/subscriptions",
+            "organizations_url" : "https://api.github.com/users/albertolunadelmoral/orgs",
+            "repos_url" : "https://api.github.com/users/albertolunadelmoral/repos",
+            "events_url" : "https://api.github.com/users/albertolunadelmoral/events{/privacy}",
+            "received_events_url" : "https://api.github.com/users/albertolunadelmoral/received_events",
+            "type" : "User",
+            "user_view_type" : "public",
+            "site_admin" : false
+          },
+          "html_url" : "https://github.com/albertolunadelmoral/pulpogato",
+          "description" : "Las asombrosas aventuras y desventuras del ser colaborativo festivo",
+          "fork" : false,
+          "url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato",
+          "forks_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/forks",
+          "keys_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/keys{/key_id}",
+          "collaborators_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/collaborators{/collaborator}",
+          "teams_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/teams",
+          "hooks_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/hooks",
+          "issue_events_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/issues/events{/number}",
+          "events_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/events",
+          "assignees_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/assignees{/user}",
+          "branches_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/branches{/branch}",
+          "tags_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/tags",
+          "blobs_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/git/blobs{/sha}",
+          "git_tags_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/git/tags{/sha}",
+          "git_refs_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/git/refs{/sha}",
+          "trees_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/git/trees{/sha}",
+          "statuses_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/statuses/{sha}",
+          "languages_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/languages",
+          "stargazers_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/stargazers",
+          "contributors_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/contributors",
+          "subscribers_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/subscribers",
+          "subscription_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/subscription",
+          "commits_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/commits{/sha}",
+          "git_commits_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/git/commits{/sha}",
+          "comments_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/comments{/number}",
+          "issue_comment_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/issues/comments{/number}",
+          "contents_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/contents/{+path}",
+          "compare_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/compare/{base}...{head}",
+          "merges_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/merges",
+          "archive_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/{archive_format}{/ref}",
+          "downloads_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/downloads",
+          "issues_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/issues{/number}",
+          "pulls_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/pulls{/number}",
+          "milestones_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/milestones{/number}",
+          "notifications_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/notifications{?since,all,participating}",
+          "labels_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/labels{/name}",
+          "releases_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/releases{/id}",
+          "deployments_url" : "https://api.github.com/repos/albertolunadelmoral/pulpogato/deployments",
+          "created_at" : "2018-11-22T11:00:23Z",
+          "updated_at" : "2018-11-22T11:20:12Z",
+          "pushed_at" : "2018-11-22T11:20:11Z",
+          "git_url" : "git://github.com/albertolunadelmoral/pulpogato.git",
+          "ssh_url" : "git@github.com:albertolunadelmoral/pulpogato.git",
+          "clone_url" : "https://github.com/albertolunadelmoral/pulpogato.git",
+          "svn_url" : "https://github.com/albertolunadelmoral/pulpogato",
+          "homepage" : null,
+          "size" : 1,
+          "stargazers_count" : 0,
+          "watchers_count" : 0,
+          "language" : null,
+          "has_issues" : true,
+          "has_projects" : true,
+          "has_downloads" : true,
+          "has_wiki" : true,
+          "has_pages" : false,
+          "has_discussions" : false,
+          "forks_count" : 0,
+          "mirror_url" : null,
+          "archived" : false,
+          "disabled" : false,
+          "open_issues_count" : 0,
+          "license" : null,
+          "allow_forking" : true,
+          "is_template" : false,
+          "web_commit_signoff_required" : false,
+          "has_pull_requests" : true,
+          "pull_request_creation_policy" : "all",
+          "topics" : [ ],
+          "visibility" : "public",
+          "forks" : 0,
+          "open_issues" : 0,
+          "watchers" : 0,
+          "default_branch" : "master",
+          "permissions" : {
+            "admin" : false,
+            "maintain" : false,
+            "push" : false,
+            "triage" : false,
+            "pull" : true
+          },
+          "score" : 1.0
+        } ]
+      }


### PR DESCRIPTION
## Summary
- Some GitHub endpoints (e.g. `ReposApi#listBranches`, `SearchApi#repos`) don't report a total page count, so the existing `totalPages`-based `Paginate#from` doesn't fit.
- Adds a `Paginate#from` overload that fetches pages lazily starting at page 1 and stops as soon as a page comes back short/empty (or `maxPages` is hit).
- Adds unit tests for the new overload and integration tests exercising both `Paginate#from` overloads against `ReposApi#listBranches` and `SearchApi#repos`.