### PR TITLE
feat(common): add reactive Paginate.fromReactive overloads

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
@@ -6,6 +6,8 @@ import java.util.function.LongFunction;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Utility class for paginating through API responses and collecting all items into a single stream.
@@ -65,5 +67,70 @@ public class Paginate {
                 .map(fetchPage::apply)
                 .takeWhile(items -> !items.isEmpty())
                 .flatMap(List::stream);
+    }
+
+    /**
+     * Reactive counterpart to {@link #from(long, LongFunction, Function, ToIntFunction)}, for use with
+     * reactive API clients (such as {@code io.github.pulpogato.rest.api.reactive.SearchApi}) whose methods
+     * return a {@link Mono} instead of a value. Pages are fetched lazily and sequentially, one at a time,
+     * up to {@code maxPages} or the total page count reported by the first response, whichever is lower.
+     *
+     * @param <T>          the type of items to be extracted from each page
+     * @param <R>          the type of the API response containing the paginated data
+     * @param maxPages     the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage    function that takes a page number (1-based) and returns the API response for that page
+     * @param extractItems function that takes an API response and returns a flux of items from that page
+     * @param totalPages   function that takes an API response and returns the total number of pages available
+     * @return a flux containing all items from the fetched pages
+     */
+    public <T, R> Flux<T> fromReactive(
+            final long maxPages,
+            final LongFunction<@NonNull Mono<R>> fetchPage,
+            final Function<R, @NonNull Flux<T>> extractItems,
+            final ToIntFunction<R> totalPages) {
+        return fetchReactive(1L, maxPages, fetchPage, extractItems, totalPages);
+    }
+
+    private <T, R> Flux<T> fetchReactive(
+            final long page,
+            final long maxPages,
+            final LongFunction<@NonNull Mono<R>> fetchPage,
+            final Function<R, @NonNull Flux<T>> extractItems,
+            final ToIntFunction<R> totalPages) {
+        return fetchPage.apply(page).flatMapMany(response -> {
+            var items = extractItems.apply(response);
+            if (page >= maxPages || page >= totalPages.applyAsInt(response)) {
+                return items;
+            }
+            return Flux.concat(items, fetchReactive(page + 1, maxPages, fetchPage, extractItems, totalPages));
+        });
+    }
+
+    /**
+     * Reactive counterpart to {@link #from(long, LongFunction)}, for use with reactive API clients (such as
+     * {@code io.github.pulpogato.rest.api.reactive.ReposApi}) whose methods return a {@link Mono} instead of
+     * a value. Pages are fetched lazily and sequentially, starting from page 1, and fetching stops as soon
+     * as a page comes back empty (or {@code maxPages} is reached).
+     *
+     * @param <T>       the type of items to be extracted from each page
+     * @param maxPages  the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage function that takes a page number (1-based) and returns the list of items for that page
+     * @return a flux containing all items from the fetched pages
+     */
+    public <T> Flux<T> fromReactive(final long maxPages, final LongFunction<@NonNull Mono<List<T>>> fetchPage) {
+        return fetchListReactive(1L, maxPages, fetchPage);
+    }
+
+    private <T> Flux<T> fetchListReactive(
+            final long page, final long maxPages, final LongFunction<@NonNull Mono<List<T>>> fetchPage) {
+        if (page > maxPages) {
+            return Flux.empty();
+        }
+        return fetchPage.apply(page).flatMapMany(items -> {
+            if (items.isEmpty()) {
+                return Flux.empty();
+            }
+            return Flux.concat(Flux.fromIterable(items), fetchListReactive(page + 1, maxPages, fetchPage));
+        });
     }
 }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
@@ -8,148 +8,297 @@ import java.util.List;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
 class PaginateTest {
 
     record Response(List<String> items, int totalPages) {}
 
-    @Mock
-    private LongFunction<Response> fetchPage;
-
-    @Test
-    @DisplayName("Should return all items from a single page")
-    void singlePage() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 1));
-
-        var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
-        assertThat(result).containsExactly("1", "2", "3");
-    }
-
     private static Stream<String> getStream(Response response) {
         return response.items().stream();
     }
 
-    @Test
-    @DisplayName("Should concatenate items from multiple pages")
-    void multiplePages() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 3));
-        when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 3));
-        when(fetchPage.apply(3L)).thenReturn(new Response(List.of("7", "8", "9"), 3));
-
-        var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
-        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+    private static Flux<String> getFlux(Response response) {
+        return Flux.fromIterable(response.items());
     }
 
-    @Test
-    @DisplayName("Should return empty stream when there is no data")
-    void noData() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of(), 0));
+    @Nested
+    @DisplayName("from(maxPages, fetchPage, extractItems, totalPages)")
+    class TotalPagesBased {
 
-        var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
-        assertThat(result).isEmpty();
+        @Mock
+        private LongFunction<Response> fetchPage;
+
+        @Test
+        @DisplayName("Should return all items from a single page")
+        void singlePage() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 1));
+
+            var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
+            assertThat(result).containsExactly("1", "2", "3");
+        }
+
+        @Test
+        @DisplayName("Should concatenate items from multiple pages")
+        void multiplePages() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 3));
+            when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 3));
+            when(fetchPage.apply(3L)).thenReturn(new Response(List.of("7", "8", "9"), 3));
+
+            var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+        }
+
+        @Test
+        @DisplayName("Should return empty stream when there is no data")
+        void noData() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of(), 0));
+
+            var result = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit when total pages exceed it")
+        void limitPages() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 5));
+            when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 5));
+            when(fetchPage.apply(3L)).thenReturn(new Response(List.of("7", "8", "9"), 5));
+
+            var result = paginate.from(3, fetchPage, PaginateTest::getStream, Response::totalPages);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+        }
+
+        @Test
+        @DisplayName("Should propagate exception thrown during first page fetch")
+        void throwExceptionOnFirstPage() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenThrow(new RuntimeException("Failed to fetch page"));
+
+            assertThatThrownBy(() -> paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages)
+                            .toList())
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Failed to fetch page");
+        }
+
+        @Test
+        @DisplayName("Should propagate exception thrown during subsequent page fetch")
+        void throwExceptionOnSubsequentPage() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 3));
+            when(fetchPage.apply(2L)).thenThrow(new RuntimeException("Failed to fetch page"));
+
+            var stream = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
+            assertThatThrownBy(stream::toList)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Failed to fetch page");
+        }
+
+        @Test
+        @DisplayName("Should stop fetching pages when stream consumer terminates early")
+        void stopsReadingIfConsumerStops() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 5));
+            when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 5));
+
+            var result = paginate.from(3, fetchPage, PaginateTest::getStream, Response::totalPages);
+
+            final var first = result.filter("5"::equals).findFirst();
+
+            assertThat(first).isPresent();
+        }
     }
 
-    @Test
-    @DisplayName("Should respect max pages limit when total pages exceed it")
-    void limitPages() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 5));
-        when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 5));
-        when(fetchPage.apply(3L)).thenReturn(new Response(List.of("7", "8", "9"), 5));
+    @Nested
+    @DisplayName("from(maxPages, fetchPage)")
+    class ListOnlyBased {
 
-        var result = paginate.from(3, fetchPage, PaginateTest::getStream, Response::totalPages);
-        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+        @Mock
+        private LongFunction<List<String>> fetchListPage;
+
+        @Test
+        @DisplayName("Should return all items from a single page when there is no total page count")
+        void singlePageNoTotalPages() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of());
+
+            var result = paginate.from(10, fetchListPage);
+            assertThat(result).containsExactly("1", "2", "3");
+        }
+
+        @Test
+        @DisplayName("Should concatenate items from multiple pages when there is no total page count")
+        void multiplePagesNoTotalPages() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+            when(fetchListPage.apply(3L)).thenReturn(List.of());
+
+            var result = paginate.from(10, fetchListPage);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+        }
+
+        @Test
+        @DisplayName("Should return empty stream when there is no data and no total page count")
+        void noDataNoTotalPages() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of());
+
+            var result = paginate.from(10, fetchListPage);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit when there is no total page count")
+        void limitPagesNoTotalPages() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+
+            var result = paginate.from(2, fetchListPage);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+        }
     }
 
-    @Test
-    @DisplayName("Should propagate exception thrown during first page fetch")
-    void throwExceptionOnFirstPage() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenThrow(new RuntimeException("Failed to fetch page"));
+    @Nested
+    @DisplayName("fromReactive(maxPages, fetchPage, extractItems, totalPages)")
+    class TotalPagesBasedReactive {
 
-        assertThatThrownBy(() -> paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages)
-                        .toList())
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Failed to fetch page");
+        @Mock
+        private LongFunction<Mono<Response>> fetchReactivePage;
+
+        @Test
+        @DisplayName("Should return all items from a single page reactively")
+        void singlePageReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 1)));
+
+            var result = paginate.fromReactive(10, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result).expectNext("1", "2", "3").verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should concatenate items from multiple pages reactively")
+        void multiplePagesReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 3)));
+            when(fetchReactivePage.apply(2L)).thenReturn(Mono.just(new Response(List.of("4", "5", "6"), 3)));
+            when(fetchReactivePage.apply(3L)).thenReturn(Mono.just(new Response(List.of("7", "8", "9"), 3)));
+
+            var result = paginate.fromReactive(10, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result)
+                    .expectNext("1", "2", "3", "4", "5", "6", "7", "8", "9")
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should return empty flux when there is no data")
+        void noDataReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.just(new Response(List.of(), 0)));
+
+            var result = paginate.fromReactive(10, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result).verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit when total pages exceed it reactively")
+        void limitPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 5)));
+            when(fetchReactivePage.apply(2L)).thenReturn(Mono.just(new Response(List.of("4", "5", "6"), 5)));
+            when(fetchReactivePage.apply(3L)).thenReturn(Mono.just(new Response(List.of("7", "8", "9"), 5)));
+
+            var result = paginate.fromReactive(3, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result)
+                    .expectNext("1", "2", "3", "4", "5", "6", "7", "8", "9")
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should propagate error thrown during first page fetch reactively")
+        void errorOnFirstPageReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.error(new RuntimeException("Failed to fetch page")));
+
+            var result = paginate.fromReactive(10, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result).verifyErrorMessage("Failed to fetch page");
+        }
+
+        @Test
+        @DisplayName("Should propagate error thrown during subsequent page fetch reactively")
+        void errorOnSubsequentPageReactive() {
+            var paginate = new Paginate();
+            when(fetchReactivePage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 3)));
+            when(fetchReactivePage.apply(2L)).thenReturn(Mono.error(new RuntimeException("Failed to fetch page")));
+
+            var result = paginate.fromReactive(10, fetchReactivePage, PaginateTest::getFlux, Response::totalPages);
+            StepVerifier.create(result).expectNext("1", "2", "3").verifyErrorMessage("Failed to fetch page");
+        }
     }
 
-    @Test
-    @DisplayName("Should propagate exception thrown during subsequent page fetch")
-    void throwExceptionOnSubsequentPage() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 3));
-        when(fetchPage.apply(2L)).thenThrow(new RuntimeException("Failed to fetch page"));
+    @Nested
+    @DisplayName("fromReactive(maxPages, fetchPage)")
+    class ListOnlyBasedReactive {
 
-        var stream = paginate.from(10, fetchPage, PaginateTest::getStream, Response::totalPages);
-        assertThatThrownBy(stream::toList).isInstanceOf(RuntimeException.class).hasMessage("Failed to fetch page");
-    }
+        @Mock
+        private LongFunction<Mono<List<String>>> fetchListReactivePage;
 
-    @Test
-    @DisplayName("Should stop fetching pages when stream consumer terminates early")
-    void stopsReadingIfConsumerStops() {
-        var paginate = new Paginate();
-        when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 5));
-        when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 5));
+        @Test
+        @DisplayName("Should return all items from a single page reactively when there is no total page count")
+        void singlePageNoTotalPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2", "3")));
+            when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of()));
 
-        var result = paginate.from(3, fetchPage, PaginateTest::getStream, Response::totalPages);
+            var result = paginate.fromReactive(10, fetchListReactivePage);
+            StepVerifier.create(result).expectNext("1", "2", "3").verifyComplete();
+        }
 
-        final var first = result.filter("5"::equals).findFirst();
+        @Test
+        @DisplayName("Should concatenate items from multiple pages reactively when there is no total page count")
+        void multiplePagesNoTotalPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2", "3")));
+            when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of("4", "5", "6")));
+            when(fetchListReactivePage.apply(3L)).thenReturn(Mono.just(List.of()));
 
-        assertThat(first).isPresent();
-    }
+            var result = paginate.fromReactive(10, fetchListReactivePage);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
+        }
 
-    @Mock
-    private LongFunction<List<String>> fetchListPage;
+        @Test
+        @DisplayName("Should return empty flux when there is no data and no total page count")
+        void noDataNoTotalPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of()));
 
-    @Test
-    @DisplayName("Should return all items from a single page when there is no total page count")
-    void singlePageNoTotalPages() {
-        var paginate = new Paginate();
-        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
-        when(fetchListPage.apply(2L)).thenReturn(List.of());
+            var result = paginate.fromReactive(10, fetchListReactivePage);
+            StepVerifier.create(result).verifyComplete();
+        }
 
-        var result = paginate.from(10, fetchListPage);
-        assertThat(result).containsExactly("1", "2", "3");
-    }
+        @Test
+        @DisplayName("Should respect max pages limit reactively when there is no total page count")
+        void limitPagesNoTotalPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2", "3")));
+            when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of("4", "5", "6")));
 
-    @Test
-    @DisplayName("Should concatenate items from multiple pages when there is no total page count")
-    void multiplePagesNoTotalPages() {
-        var paginate = new Paginate();
-        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
-        when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
-        when(fetchListPage.apply(3L)).thenReturn(List.of());
-
-        var result = paginate.from(10, fetchListPage);
-        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
-    }
-
-    @Test
-    @DisplayName("Should return empty stream when there is no data and no total page count")
-    void noDataNoTotalPages() {
-        var paginate = new Paginate();
-        when(fetchListPage.apply(1L)).thenReturn(List.of());
-
-        var result = paginate.from(10, fetchListPage);
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Should respect max pages limit when there is no total page count")
-    void limitPagesNoTotalPages() {
-        var paginate = new Paginate();
-        when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
-        when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
-
-        var result = paginate.from(2, fetchListPage);
-        assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+            var result = paginate.fromReactive(2, fetchListReactivePage);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
+        }
     }
 }

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/ReposApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/ReposApiIntegrationTest.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.github.pulpogato.common.NullableOptional;
+import io.github.pulpogato.common.Paginate;
 import io.github.pulpogato.common.SingularOrPlural;
 import io.github.pulpogato.rest.api.BaseApiIntegrationTest;
 import io.github.pulpogato.rest.schemas.ContentFile;
 import io.github.pulpogato.rest.schemas.CustomPropertyValue;
 import io.github.pulpogato.rest.schemas.FullRepository;
 import io.github.pulpogato.rest.schemas.SecurityAndAnalysis;
+import io.github.pulpogato.rest.schemas.ShortBranch;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -20,6 +22,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 import tools.jackson.databind.ObjectMapper;
 
 class ReposApiIntegrationTest extends BaseApiIntegrationTest {
@@ -190,6 +193,58 @@ class ReposApiIntegrationTest extends BaseApiIntegrationTest {
         assertThat(response.getBody()).isNotNull();
         var body = response.getBody();
         assertThat(body.getRequiredStatusChecks().getContexts()).containsExactly("jenkins/pulpogato");
+    }
+
+    @Test
+    void testListBranchesPaginated() {
+        var api = new RestClients(webClient).getReposApi();
+        var perPage = 5L;
+
+        var branches = new Paginate()
+                .fromReactive(25, page -> api.listBranches("jenkinsci", "gradle-jpi-plugin", null, perPage, page)
+                        .map(ResponseEntity::getBody))
+                .collectList()
+                .block();
+
+        var allBranches = api.listBranches("jenkinsci", "gradle-jpi-plugin", null, 100L, 1L)
+                .block()
+                .getBody();
+        assertThat(branches).hasSize(24);
+        assertThat(branches)
+                .extracting(ShortBranch::getName)
+                .containsExactlyElementsOf(
+                        allBranches.stream().map(ShortBranch::getName).toList());
+        assertThat(branches)
+                .filteredOn(ShortBranch::getName, "main")
+                .extracting(ShortBranch::getIsProtected)
+                .containsExactly(true);
+    }
+
+    @Test
+    void testListBranchesPaginatedRespectsMaxPages() {
+        var api = new RestClients(webClient).getReposApi();
+        var perPage = 1L;
+
+        var branches = new Paginate()
+                .fromReactive(1, page -> api.listBranches("pulpogato", "pulpogato", null, perPage, page)
+                        .map(ResponseEntity::getBody))
+                .collectList()
+                .block();
+
+        assertThat(branches).extracting(ShortBranch::getName).containsExactly("gh-pages");
+    }
+
+    @Test
+    void testListBranchesPaginatedNoResults() {
+        var api = new RestClients(webClient).getReposApi();
+
+        var branches = new Paginate()
+                .fromReactive(10, page -> api.listBranches("pulpogato", "create-demo", true, 100L, page)
+                        .map(ResponseEntity::getBody))
+                .collectList()
+                .block();
+
+        assertThat(branches).isEmpty();
     }
 
     @Test

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/SearchApiIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/api/reactive/SearchApiIntegrationTest.java
@@ -2,8 +2,12 @@ package io.github.pulpogato.rest.api.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.pulpogato.common.Paginate;
 import io.github.pulpogato.rest.api.BaseApiIntegrationTest;
+import io.github.pulpogato.rest.schemas.RepoSearchResultItem;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
 
 class SearchApiIntegrationTest extends BaseApiIntegrationTest {
 
@@ -39,6 +43,27 @@ class SearchApiIntegrationTest extends BaseApiIntegrationTest {
         var searchResult = response.getBody();
         assertThat(searchResult.getTotalCount()).isNotNull();
         assertThat(searchResult.getItems()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void testSearchRepositoriesPaginated() {
+        var api = new RestClients(webClient).getSearchApi();
+        var perPage = 1L;
+
+        var repos = new Paginate()
+                .fromReactive(
+                        8,
+                        page -> api.repos("pulpogato", null, null, perPage, page)
+                                .map(ResponseEntity::getBody),
+                        response -> Flux.fromIterable(response.getItems()),
+                        response -> (int) Math.ceil(response.getTotalCount() / (double) perPage))
+                .collectList()
+                .block();
+
+        // total_count is 20, but the maxPages cap of 8 (with per_page=1) stops us short of that
+        assertThat(repos).hasSize(8);
+        assertThat(repos).extracting(RepoSearchResultItem::getFullName).doesNotHaveDuplicates();
+        assertThat(repos).extracting(RepoSearchResultItem::getFullName).contains("pulpogato/pulpogato");
     }
 
     @Test


### PR DESCRIPTION
Stacked on #1274.

Adds reactive counterparts to `Paginate.from`, for use with reactive API clients (`Mono`/`Flux`-returning methods):

- `fromReactive(maxPages, fetchPage, extractItems, totalPages)` — total-pages-based pagination
- `fromReactive(maxPages, fetchPage)` — list-only pagination, stopping on the first empty page

Also splits `PaginateTest` into `@Nested` classes grouping the blocking and reactive variants, and adds reactive integration tests against `reactive.ReposApi#listBranches` and `reactive.SearchApi#repos`, reusing the existing recorded tapes.