### PR TITLE
feat(webhooks): bind webhook headers as a single WebhookHeaders parameter

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -9,6 +9,7 @@ import com.palantir.javapoet.JavaFile
 import com.palantir.javapoet.MethodSpec
 import com.palantir.javapoet.ParameterSpec
 import com.palantir.javapoet.ParameterizedTypeName
+import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
 import io.github.pulpogato.restcodegen.Annotations.generated
@@ -30,6 +31,9 @@ import java.io.StringWriter
 import javax.lang.model.element.Modifier
 
 class WebhooksBuilder {
+    private lateinit var webhookHeadersType: ClassName
+    private lateinit var webhookHeadersResolverType: ClassName
+
     data class WebhookBuilderParams(
         val interfaceBuilder: TypeSpec.Builder,
         val unitTestBuilder: TypeSpec.Builder,
@@ -60,6 +64,18 @@ class WebhooksBuilder {
         // Create the test resources directory for large JSON examples
         val testResourcesDir = File(testDir.parentFile, "resources")
         val testControllerBuilder = buildTestController()
+
+        webhookHeadersType = ClassName.get(webhooksPackage, "WebhookHeaders")
+        webhookHeadersResolverType = ClassName.get(webhooksPackage, "WebhookHeadersArgumentResolver")
+        val headerFields = collectHeaderFields(context)
+        JavaFile
+            .builder(webhooksPackage, buildWebhookHeadersType(context, headerFields))
+            .build()
+            .writeTo(mainDir)
+        JavaFile
+            .builder(webhooksPackage, buildWebhookHeadersResolverType(context, headerFields))
+            .build()
+            .writeTo(mainDir)
 
         val openAPI = context.openAPI
         // The same supertypes SchemasBuilder generates; used here to route the synthetic handler
@@ -144,6 +160,300 @@ class WebhooksBuilder {
             .writeTo(testDir)
     }
 
+    data class HeaderField(
+        val headerName: String,
+        val fieldName: String,
+        val universal: Boolean,
+    )
+
+    /**
+     * Derives a Java field name from a header name the same way for every header, so the generated
+     * fields read the same as the ones that used to be hand-written (e.g. `X-GitHub-Delivery` ->
+     * `githubDelivery`, `X-Hub-Signature-256` -> `hubSignature256`).
+     */
+    private fun headerFieldName(headerName: String): String {
+        val withoutPrefix = if (headerName.startsWith("x-", ignoreCase = true)) headerName.substring(2) else headerName
+        return withoutPrefix.lowercase().camelCase()
+    }
+
+    /**
+     * Header sets can differ across, and even within, a schema's webhook operations (GHES sends two
+     * extra enterprise headers on some but not all operations). Headers present on every operation
+     * become required fields; the rest become nullable fields.
+     */
+    private fun collectHeaderFields(context: Context): List<HeaderField> {
+        val operations =
+            context.openAPI.webhooks
+                .orEmpty()
+                .values
+                .flatMap { it.readOperationsMap().values }
+        val headerSets =
+            operations.map { operation ->
+                operation.parameters
+                    .orEmpty()
+                    .filter { it.`in` == "header" }
+                    .map { it.name }
+                    .toSet()
+            }
+        val orderedNames = LinkedHashSet<String>()
+        headerSets.forEach { orderedNames.addAll(it) }
+        val (universalNames, nonUniversalNames) = orderedNames.partition { name -> headerSets.all { name in it } }
+        return (universalNames + nonUniversalNames).map { name -> HeaderField(name, headerFieldName(name), name in universalNames) }
+    }
+
+    private fun buildWebhookHeadersType(
+        context: Context,
+        headerFields: List<HeaderField>,
+    ): TypeSpec {
+        val builderType = webhookHeadersType.nestedClass("Builder")
+        val extraHeadersType = ParameterizedTypeName.get(Types.MAP, Types.STRING, Types.STRING)
+        val allFieldNames = headerFields.map { it.fieldName } + "extraHeaders"
+
+        val classBuilder =
+            TypeSpec
+                .classBuilder(webhookHeadersType)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addAnnotation(generated(0, context.withSchemaStack("#", "webhooks")))
+                .addJavadoc(
+                    """
+                    The set of HTTP headers GitHub sends on webhook deliveries in this schema, bound as a
+                    single parameter instead of one {@code @RequestHeader} argument per header.
+                    <p>
+                    Requires {@link ${'$'}L} to be registered as a {@code HandlerMethodArgumentResolver} on
+                    the {@code WebMvcConfigurer} in use.
+                    """.trimIndent(),
+                    webhookHeadersResolverType.simpleName(),
+                )
+
+        val constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).addParameter(builderType, "builder")
+
+        headerFields.forEach { field ->
+            val nullability =
+                when {
+                    isKnownOptionalDespiteUniversal(field.headerName) -> ", absent when GitHub omits it (e.g. no secret configured)"
+                    field.universal -> ""
+                    else -> ", absent on operations that don't send it"
+                }
+            classBuilder.addField(
+                FieldSpec
+                    .builder(Types.STRING, field.fieldName, Modifier.PRIVATE, Modifier.FINAL)
+                    .addJavadoc($$"'$L' header$L\n", field.headerName, nullability)
+                    .build(),
+            )
+            classBuilder.addMethod(
+                MethodSpec
+                    .methodBuilder("get${field.fieldName.pascalCase()}")
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(Types.STRING)
+                    .addStatement($$"return $L", field.fieldName)
+                    .build(),
+            )
+        }
+        classBuilder.addField(
+            FieldSpec
+                .builder(extraHeadersType, "extraHeaders", Modifier.PRIVATE, Modifier.FINAL)
+                .addJavadoc(
+                    "any other headers on the request, keyed by header name, for headers GitHub adds after " +
+                        "this library was built\n",
+                ).build(),
+        )
+        classBuilder.addMethod(
+            MethodSpec
+                .methodBuilder("getExtraHeaders")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(extraHeadersType)
+                .addStatement("return extraHeaders")
+                .build(),
+        )
+
+        allFieldNames.forEach { fieldName -> constructor.addStatement($$"this.$L = builder.$L", fieldName, fieldName) }
+        classBuilder.addMethod(constructor.build())
+
+        classBuilder.addMethod(
+            MethodSpec
+                .methodBuilder("builder")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(builderType)
+                .addStatement($$"return new $T()", builderType)
+                .build(),
+        )
+        classBuilder.addType(buildWebhookHeadersBuilderType(builderType, headerFields, extraHeadersType))
+
+        return classBuilder.build()
+    }
+
+    private fun buildWebhookHeadersBuilderType(
+        builderType: ClassName,
+        headerFields: List<HeaderField>,
+        extraHeadersType: ParameterizedTypeName,
+    ): TypeSpec {
+        val builderClassBuilder =
+            TypeSpec
+                .classBuilder(builderType)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build())
+
+        headerFields.forEach { field ->
+            builderClassBuilder.addField(FieldSpec.builder(Types.STRING, field.fieldName, Modifier.PRIVATE).build())
+            builderClassBuilder.addMethod(
+                MethodSpec
+                    .methodBuilder(field.fieldName)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(builderType)
+                    .addParameter(Types.STRING, field.fieldName)
+                    .addStatement($$"this.$L = $L", field.fieldName, field.fieldName)
+                    .addStatement("return this")
+                    .build(),
+            )
+        }
+        builderClassBuilder.addField(FieldSpec.builder(extraHeadersType, "extraHeaders", Modifier.PRIVATE).build())
+        builderClassBuilder.addMethod(
+            MethodSpec
+                .methodBuilder("extraHeaders")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(builderType)
+                .addParameter(extraHeadersType, "extraHeaders")
+                .addStatement($$"this.extraHeaders = extraHeaders")
+                .addStatement("return this")
+                .build(),
+        )
+        builderClassBuilder.addMethod(
+            MethodSpec
+                .methodBuilder("build")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(webhookHeadersType)
+                .addStatement($$"return new $T(this)", webhookHeadersType)
+                .build(),
+        )
+        return builderClassBuilder.build()
+    }
+
+    /**
+     * GitHub omits these headers on some deliveries (no secret configured for the signature headers;
+     * non-Enterprise-Server-originated deliveries for the enterprise headers) even when the schema
+     * declares them on every operation without a `required: false` marker (it never marks any header
+     * optional), so this can't be derived from [collectHeaderFields] alone.
+     */
+    private fun isKnownOptionalDespiteUniversal(headerName: String) =
+        headerName.startsWith("X-Hub-Signature", ignoreCase = true) ||
+            headerName.startsWith("X-GitHub-Enterprise", ignoreCase = true)
+
+    private fun buildWebhookHeadersResolverType(
+        context: Context,
+        headerFields: List<HeaderField>,
+    ): TypeSpec {
+        val webRequestType = ClassName.get("org.springframework.web.context.request", "NativeWebRequest")
+        val constructorCall = CodeBlock.builder().add($$"return $T.builder()\n", webhookHeadersType)
+        headerFields.forEach { field ->
+            if (field.universal && !isKnownOptionalDespiteUniversal(field.headerName)) {
+                constructorCall.add($$".$L(requireHeader(parameter, webRequest, $S))\n", field.fieldName, field.headerName)
+            } else {
+                constructorCall.add($$".$L(webRequest.getHeader($S))\n", field.fieldName, field.headerName)
+            }
+        }
+        constructorCall.add($$".extraHeaders(extraHeaders(webRequest))\n")
+        constructorCall.add($$".build();\n")
+
+        val resolveArgument =
+            MethodSpec
+                .methodBuilder("resolveArgument")
+                .addAnnotation(Types.OVERRIDE)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(Types.OBJECT)
+                .addParameter(ClassName.get("org.springframework.core", "MethodParameter"), "parameter")
+                .addParameter(ClassName.get("org.springframework.web.method.support", "ModelAndViewContainer"), "mavContainer")
+                .addParameter(webRequestType, "webRequest")
+                .addParameter(ClassName.get("org.springframework.web.bind.support", "WebDataBinderFactory"), "binderFactory")
+                .addException(Types.EXCEPTION)
+                .addCode(constructorCall.build())
+                .build()
+
+        val supportsParameter =
+            MethodSpec
+                .methodBuilder("supportsParameter")
+                .addAnnotation(Types.OVERRIDE)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeName.BOOLEAN)
+                .addParameter(ClassName.get("org.springframework.core", "MethodParameter"), "parameter")
+                .addStatement($$"return $T.class.equals(parameter.getParameterType())", webhookHeadersType)
+                .build()
+
+        val requireHeader =
+            MethodSpec
+                .methodBuilder("requireHeader")
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .returns(Types.STRING)
+                .addParameter(ClassName.get("org.springframework.core", "MethodParameter"), "parameter")
+                .addParameter(webRequestType, "webRequest")
+                .addParameter(Types.STRING, "name")
+                .addException(ClassName.get("org.springframework.web.bind", "MissingRequestHeaderException"))
+                .addStatement("var value = webRequest.getHeader(name)")
+                .beginControlFlow("if (value == null)")
+                .addStatement($$"throw new $T(name, parameter)", ClassName.get("org.springframework.web.bind", "MissingRequestHeaderException"))
+                .endControlFlow()
+                .addStatement("return value")
+                .build()
+
+        val extraHeadersMethod =
+            MethodSpec
+                .methodBuilder("extraHeaders")
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .returns(ParameterizedTypeName.get(Types.MAP, Types.STRING, Types.STRING))
+                .addParameter(webRequestType, "webRequest")
+                .addStatement($$"var extraHeaders = new $T<$T, $T>()", ClassName.get("java.util", "LinkedHashMap"), Types.STRING, Types.STRING)
+                .addStatement("var headerNames = webRequest.getHeaderNames()")
+                .beginControlFlow("while (headerNames.hasNext())")
+                .addStatement("var name = headerNames.next()")
+                .beginControlFlow(
+                    $$"if (!KNOWN_HEADERS.contains(name.toLowerCase($T.ROOT)))",
+                    ClassName.get("java.util", "Locale"),
+                ).addStatement("extraHeaders.put(name, webRequest.getHeader(name))")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement("return extraHeaders")
+                .build()
+
+        val knownHeadersField =
+            FieldSpec
+                .builder(ParameterizedTypeName.get(ClassName.get("java.util", "Set"), Types.STRING), "KNOWN_HEADERS")
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                .initializer(
+                    CodeBlock
+                        .builder()
+                        .add($$"$T.of(\n", ClassName.get("java.util", "Set"))
+                        .add(headerFields.joinToString(",\n") { "\"${it.headerName.lowercase()}\"" })
+                        .add(")")
+                        .build(),
+                ).build()
+
+        return TypeSpec
+            .classBuilder(webhookHeadersResolverType)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(generated(0, context.withSchemaStack("#", "webhooks")))
+            .addSuperinterface(ClassName.get("org.springframework.web.method.support", "HandlerMethodArgumentResolver"))
+            .addJavadoc(
+                """
+                Binds a {@link ${'$'}L} parameter from the incoming request's headers, in place of
+                Spring's {@code @RequestHeader}, which only supports single-value or {@code Map} binding.
+                <p>
+                Register on the {@code WebMvcConfigurer} in use:
+                <pre>{@code
+                @Override
+                public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+                    resolvers.add(new ${'$'}L());
+                }
+                }</pre>
+                """.trimIndent(),
+                webhookHeadersType.simpleName(),
+                webhookHeadersResolverType.simpleName(),
+            ).addField(knownHeadersField)
+            .addMethod(supportsParameter)
+            .addMethod(resolveArgument)
+            .addMethod(requireHeader)
+            .addMethod(extraHeadersMethod)
+            .build()
+    }
+
     private fun getUnitTestBuilder(subcategory: String): TypeSpec.Builder =
         TypeSpec
             .classBuilder("${subcategory.pascalCase()}WebhooksTest")
@@ -173,25 +483,13 @@ class WebhooksBuilder {
                 .returns(ParameterizedTypeName.get(ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"), TypeVariableName.get("T")))
                 .addException(Types.EXCEPTION)
                 .addModifiers(Modifier.PUBLIC, if (isDiscriminable) Modifier.ABSTRACT else Modifier.DEFAULT)
-        val headerNames =
-            pathItem
-                .readOperationsMap()
-                .entries
-                .first()
-                .value.parameters
-                .filter { it.`in` == "header" }
-                .map { it.name }
-        headerNames
-            .forEach {
-                methodBuilder
-                    .addParameter(
-                        ParameterSpec
-                            .builder(Types.STRING, it.camelCase())
-                            .addAnnotation(getParameterAnnotation(it).build())
-                            .addAnnotation(generated(0, syntheticContext))
-                            .build(),
-                    )
-            }
+        methodBuilder
+            .addParameter(
+                ParameterSpec
+                    .builder(webhookHeadersType, "headers")
+                    .addAnnotation(generated(0, syntheticContext))
+                    .build(),
+            )
 
         if (supertype != null && supertype.discriminable) {
             // Spring deserializes straight to the sealed supertype (via its @JsonSubTypes), so the
@@ -206,7 +504,7 @@ class WebhooksBuilder {
         } else {
             methodBuilder
                 .addParameter(buildRequestBodyParameter(syntheticContext))
-                .addCode(buildRouter(requestBodyTypes, subcategory, headerNames), ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"))
+                .addCode(buildRouter(requestBodyTypes, subcategory), ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"))
             builders.interfaceBuilder
                 .addMethod(methodBuilder.build())
                 .addMethod(getObjectMapperMethod())
@@ -284,16 +582,12 @@ class WebhooksBuilder {
      * Routes a polymorphically-deserialized webhook body to its typed handler. The switch over the
      * sealed supertype is exhaustive, so no default branch is needed.
      */
-    private fun buildTypedRouter(
-        requestBodyTypes: Map<String, Pair<String, ClassName>>,
-        headerNames: List<String>,
-    ): CodeBlock {
+    private fun buildTypedRouter(requestBodyTypes: Map<String, Pair<String, ClassName>>): CodeBlock {
         val code = CodeBlock.builder()
         code.add("return switch (requestBody) {\n")
         requestBodyTypes.forEach { (_, methodNameAndType) ->
             val (methodName, type) = methodNameAndType
-            val args = (headerNames.map { it.camelCase() } + "body").joinToString(", ")
-            code.add($$"    case $T body -> $L($L);\n", type, methodName, args)
+            code.add($$"    case $T body -> $L(headers, body);\n", type, methodName)
         }
         code.add("};\n")
         return code.build()
@@ -302,7 +596,6 @@ class WebhooksBuilder {
     private fun buildRouter(
         requestBodyTypes: Map<String, Pair<String, ClassName>>,
         subcategory: String,
-        headerNames: List<String>,
     ): String {
         val routerBuilder = StringWriter()
         val printWriter = PrintWriter(routerBuilder)
@@ -314,28 +607,13 @@ class WebhooksBuilder {
         requestBodyTypes.forEach { (name, methodNameAndType) ->
             val cleanedAction = name.replace("-", "_").replace(subcategory, "").replace(Regex("^_"), "")
             val (methodName, type) = methodNameAndType
-            printWriter.print("    case \"$cleanedAction\" -> $methodName(${headerNames.joinToString(", ") { it.camelCase() }},")
+            printWriter.print("    case \"$cleanedAction\" -> $methodName(headers,")
             printWriter.println(" getObjectMapper().treeToValue(requestBody, ${type.simpleName()}.class));")
         }
         printWriter.println($$"    default -> $T.badRequest().build();")
         printWriter.println("};")
         val router = routerBuilder.toString()
         return router
-    }
-
-    private fun getParameterAnnotation(string: String): AnnotationSpec.Builder {
-        val required =
-            when {
-                string.startsWith("X-Hub-Signature") -> false
-                string.startsWith("X-GitHub-Enterprise") -> false
-                else -> true
-            }
-        val parameterAnnotation =
-            getRequestHeaderAnnotation(string)
-        if (!required) {
-            parameterAnnotation.addMember("required", $$"$L", false)
-        }
-        return parameterAnnotation
     }
 
     private fun buildIntegrationTest(
@@ -394,7 +672,21 @@ class WebhooksBuilder {
             .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.context.annotation", "Configuration")).build())
             .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.boot", "SpringBootConfiguration")).build())
             .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.web.servlet.config.annotation", "EnableWebMvc")).build())
+            .addSuperinterface(ClassName.get("org.springframework.web.servlet.config.annotation", "WebMvcConfigurer"))
             .addMethod(
+                MethodSpec
+                    .methodBuilder("addArgumentResolvers")
+                    .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_JAVA_LANG, "Override")).build())
+                    .addModifiers(Modifier.PUBLIC)
+                    .addParameter(
+                        ParameterizedTypeName.get(
+                            ClassName.get("java.util", "List"),
+                            ClassName.get("org.springframework.web.method.support", "HandlerMethodArgumentResolver"),
+                        ),
+                        "resolvers",
+                    ).addStatement($$"resolvers.add(new $T())", webhookHeadersResolverType)
+                    .build(),
+            ).addMethod(
                 MethodSpec
                     .methodBuilder("objectMapper")
                     .addAnnotation(AnnotationSpec.builder(ClassName.get("org.springframework.context.annotation", "Bean")).build())
@@ -545,9 +837,7 @@ class WebhooksBuilder {
                 "\n",
             )
 
-        operation.parameters.filter { it.`in` == "header" }.forEach {
-            javadoc.add("@param ${it.name.camelCase()} '${it.name}' header. Example: <code>${it.example}</code>")
-        }
+        javadoc.add("@param headers The webhook headers")
         javadoc.add("@param requestBody The request body")
         javadoc.add("")
         javadoc.add("@return It doesn't really matter. A 200 means success. Anything else means failure.")
@@ -588,7 +878,7 @@ class WebhooksBuilder {
                 .first { it.key == ref }
         val type = schema.className()
 
-        addHeaderParameters(ctx.operation, ctx.methodSpecBuilder, ctx.context, ctx.springEndpoint)
+        addHeaderParameters(ctx.methodSpecBuilder, ctx.context)
 
         val bodyType = ClassName.get("${ctx.restPackage}.schemas", type)
         val bodyParam =
@@ -617,38 +907,16 @@ class WebhooksBuilder {
     }
 
     private fun addHeaderParameters(
-        operation: Operation,
         methodSpecBuilder: MethodSpec.Builder,
         context: Context,
-        springEndpoint: Boolean,
     ) {
-        operation.parameters.filter { it.`in` == "header" }.forEachIndexed { idx, it ->
-            val contextForParameters = context.withSchemaStack("parameters", idx.toString())
-            val parameter =
-                ParameterSpec
-                    .builder(Types.STRING, it.name.camelCase())
-                    .addAnnotation(generated(0, contextForParameters))
-            if (springEndpoint) {
-                val required =
-                    when {
-                        it.name.startsWith("X-Hub-Signature") -> false
-                        it.name.startsWith("X-GitHub-Enterprise") -> false
-                        else -> true
-                    }
-                val parameterAnnotation = getRequestHeaderAnnotation(it.name)
-                if (!required) {
-                    parameterAnnotation.addMember("required", $$"$L", false)
-                }
-                parameter.addAnnotation(parameterAnnotation.build())
-            }
-            methodSpecBuilder.addParameter(parameter.build())
-        }
+        methodSpecBuilder.addParameter(
+            ParameterSpec
+                .builder(webhookHeadersType, "headers")
+                .addAnnotation(generated(0, context.withSchemaStack("parameters")))
+                .build(),
+        )
     }
-
-    private fun getRequestHeaderAnnotation(requestHeaderName: String): AnnotationSpec.Builder =
-        AnnotationSpec
-            .builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestHeader"))
-            .addMember("value", $$"$S", requestHeaderName)
 
     private fun processExamples(
         entry: Map.Entry<String, MediaType>,

--- a/pulpogato-docs/src/index.adoc
+++ b/pulpogato-docs/src/index.adoc
@@ -94,6 +94,18 @@ Jackson deserializes the payload to the right subtype automatically based on the
 The individual per-event methods (e.g. `processPullRequestEdited`) are `@Deprecated` and dispatched
 by the default implementation; you do not need to override them.
 
+Every webhook method takes a generated `WebhookHeaders` type instead of individual
+`@RequestHeader` parameters, one per module/schema variant.
+Binding it requires registering the matching `WebhookHeadersArgumentResolver` as a
+`HandlerMethodArgumentResolver`:
+
+[source,java,indent=0]
+----
+include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java[tags=pre-pull-request-webhook-resolver]
+include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java[tags=pull-request-webhook-resolver]
+include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java[tags=end-pull-request-webhook-resolver]
+----
+
 [source,java,indent=0]
 ----
 include::../../pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java[tags=pull-request-webhook-controller]

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PingWebhooksIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PingWebhooksIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.github.pulpogato.rest.schemas.WebhookPing;
 import io.github.pulpogato.test.TestWebhookResponse;
 import io.github.pulpogato.test.WebhookHelper;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,7 +21,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
@@ -46,7 +49,7 @@ class PingWebhooksIntegrationTest {
     @Configuration
     @SpringBootConfiguration
     @EnableWebMvc
-    static class PingTestConfig {
+    static class PingTestConfig implements WebMvcConfigurer {
         @Bean
         ObjectMapper objectMapper() {
             return JsonMapper.builder()
@@ -54,6 +57,11 @@ class PingWebhooksIntegrationTest {
                     .disable(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
                     .build();
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(new WebhookHeadersArgumentResolver());
         }
 
         @SuppressWarnings("InnerClassMayBeStatic")
@@ -65,15 +73,7 @@ class PingWebhooksIntegrationTest {
             private final ObjectMapper objectMapper;
 
             @Override
-            public ResponseEntity<TestWebhookResponse> processPing(
-                    String userAgent,
-                    String xGithubHookId,
-                    String xGithubEvent,
-                    String xGithubHookInstallationTargetId,
-                    String xGithubHookInstallationTargetType,
-                    String xGitHubDelivery,
-                    String xHubSignature256,
-                    WebhookPing requestBody) {
+            public ResponseEntity<TestWebhookResponse> processPing(WebhookHeaders headers, WebhookPing requestBody) {
                 return ResponseEntity.ok(TestWebhookResponse.builder()
                         .webhookName("ping")
                         .body(objectMapper.writeValueAsString(requestBody))

--- a/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java
+++ b/pulpogato-rest-fpt/src/test/java/io/github/pulpogato/rest/webhooks/PullRequestWebhooksIntegrationTest.java
@@ -6,6 +6,7 @@ import io.github.pulpogato.rest.schemas.WebhookPullRequestEdited;
 import io.github.pulpogato.rest.schemas.WebhookPullRequestReviewRequested;
 import io.github.pulpogato.test.TestWebhookResponse;
 import io.github.pulpogato.test.WebhookHelper;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,7 +23,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
@@ -39,7 +42,7 @@ import tools.jackson.databind.json.JsonMapper;
  */
 @WebMvcTest
 @AutoConfigureMockMvc
-@ContextConfiguration(classes = PullRequestWebhooksIntegrationTest.PullRequestTestConfig.class)
+@ContextConfiguration(classes = PullRequestWebhooksIntegrationTest.WebhookMvcConfigurer.class)
 class PullRequestWebhooksIntegrationTest {
     @Autowired
     MockMvc mvc;
@@ -54,10 +57,20 @@ class PullRequestWebhooksIntegrationTest {
         WebhookHelper.testWebhook(hookname, filename, mvc);
     }
 
-    @Configuration
     @SpringBootConfiguration
     @EnableWebMvc
-    static class PullRequestTestConfig {
+    // tag::pre-pull-request-webhook-resolver[]
+    @Configuration
+    // end::pre-pull-request-webhook-resolver[]
+    public static
+    // tag::pull-request-webhook-resolver[]
+    class WebhookMvcConfigurer implements WebMvcConfigurer {
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(new WebhookHeadersArgumentResolver());
+        }
+        // end::pull-request-webhook-resolver[]
+
         @Bean
         ObjectMapper objectMapper() {
             return JsonMapper.builder()
@@ -77,14 +90,7 @@ class PullRequestWebhooksIntegrationTest {
 
             @Override
             public ResponseEntity<TestWebhookResponse> processPullRequest(
-                    String userAgent,
-                    String xGithubHookId,
-                    String xGithubEvent,
-                    String xGithubHookInstallationTargetId,
-                    String xGithubHookInstallationTargetType,
-                    String xGitHubDelivery,
-                    String xHubSignature256,
-                    WebhookPullRequest requestBody) {
+                    WebhookHeaders headers, WebhookPullRequest requestBody) {
                 var hookname =
                         switch (requestBody) {
                             case WebhookPullRequestEdited ignored -> "pull-request-edited";
@@ -100,5 +106,7 @@ class PullRequestWebhooksIntegrationTest {
             }
         }
         // end::pull-request-webhook-controller[]
+        // tag::end-pull-request-webhook-resolver[]
     }
+    // end::end-pull-request-webhook-resolver[]
 }

--- a/rest.gradle.kts
+++ b/rest.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 
 dependencies {
     compileOnly(libs.jspecify)
+    compileOnly(libs.springBootWeb)
     compileOnly(libs.springBootWebflux)
     compileOnly(libs.springWeb)
 


### PR DESCRIPTION
Replace the per-header `@RequestHeader`-style parameters on generated webhook methods with a single `WebhookHeaders` type, resolved by a custom `HandlerMethodArgumentResolver`. Headers universally present across every operation in the schema are required; others (and known-optional ones like `X-Hub-Signature-256` and the `X-GitHub-Enterprise-*` headers) are nullable.

`WebhookHeaders` is generated directly with JavaPoet as a plain class with a static nested `Builder` and bean-style getters, matching the accessor convention already used elsewhere in the generated code, rather than introducing Lombok as a main-sourceSet dependency.

Verified generated output and ran full test suites across `fpt`, `ghec`, and `ghes-3.17` — all passing (2715, 3026, and 1900 tests respectively).