### PR TITLE
feat(webhooks): add WebhookEvent marker interface for BY_EVENT_NAME map

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SchemasBuilder.kt
@@ -34,6 +34,7 @@ class SchemasBuilder {
         // sealed supertype so callers can pattern match. Work out which body schemas belong to a
         // group before generating, so each member class can be tagged as a permitted subtype.
         val supertypeGroups = WebhookSupertypes.compute(openAPI, packageName)
+        val singleEventWebhookBodyKeys = WebhookSupertypes.singleEventBodyKeys(openAPI)
         val discriminatedGroups = context.discriminatedOneOfGroups
         val nonDiscriminatedGroups = context.nonDiscriminatedOneOfGroups
         // A body schema can belong to more than one subcategory (e.g. the `exemption-request-*` bodies
@@ -67,8 +68,16 @@ class SchemasBuilder {
                     } else {
                         it
                     }
+                // Single-event webhook bodies aren't a permitted subtype of any generated sealed
+                // interface, so they need tagging here directly rather than via enrichMember.
+                val taggedTypeSpec =
+                    if (entry.key in singleEventWebhookBodyKeys) {
+                        typeSpec.toBuilder().addSuperinterface(ClassName.get(Types.COMMON_PACKAGE, "WebhookEvent")).build()
+                    } else {
+                        typeSpec
+                    }
 
-                JavaFile.builder(packageName, typeSpec).build().writeTo(mainDir)
+                JavaFile.builder(packageName, taggedTypeSpec).build().writeTo(mainDir)
 
                 // If this is an enum, add its converter to the set
                 if (it.enumConstants().isNotEmpty() && typeName is ClassName) {
@@ -108,6 +117,7 @@ class SchemasBuilder {
                     "<br/>Use pattern matching over the permitted subtypes to handle individual variants.",
                 annotations,
                 memberFieldsByKey,
+                markerInterface = ClassName.get(Types.COMMON_PACKAGE, "WebhookEvent"),
             )
         }
     }
@@ -151,6 +161,7 @@ class SchemasBuilder {
         annotations: List<AnnotationSpec>,
         memberFieldsByKey: Map<String, Map<String, TypeName>>,
         nestedTypes: List<TypeSpec> = emptyList(),
+        markerInterface: ClassName = ClassName.get(Types.COMMON_PACKAGE, "PulpogatoType"),
     ) {
         val memberFields = memberSchemaKeys.map { memberFieldsByKey[it] }
         // Skip if any member did not generate as a class; otherwise `permits` would dangle.
@@ -162,7 +173,7 @@ class SchemasBuilder {
             TypeSpec
                 .interfaceBuilder(supertype)
                 .addModifiers(Modifier.PUBLIC, Modifier.SEALED)
-                .addSuperinterface(ClassName.get(Types.COMMON_PACKAGE, "PulpogatoType"))
+                .addSuperinterface(markerInterface)
                 .addAnnotation(generated(0, context.withSchemaStack("#", "synthetic")))
                 .addJavadoc($$"$L", javadoc)
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhookSupertypes.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhookSupertypes.kt
@@ -63,6 +63,27 @@ object WebhookSupertypes {
     }
 
     /**
+     * The body schema keys for subcategories with exactly one event, i.e. the schemas that are used
+     * directly as a `@RequestBody` rather than as a permitted subtype of a generated sealed supertype.
+     * Mirrors the `springEndpoint = v.size == 1` grouping in [WebhooksBuilder].
+     */
+    fun singleEventBodyKeys(openAPI: OpenAPI): Set<String> {
+        val webhooks = openAPI.webhooks ?: return emptySet()
+        return webhooks.entries
+            .groupBy {
+                subcategoryOf(
+                    it.value
+                        .readOperationsMap()
+                        .values
+                        .first(),
+                )
+            }.values
+            .filter { it.size == 1 }
+            .mapNotNull { requestBodySchemaKey(it.first().value) }
+            .toSet()
+    }
+
+    /**
      * The distinct values of a schema's `action` discriminator, or null when it can't be determined.
      *
      * Plain object bodies declare `action` directly. Composite (`oneOf`/`anyOf`) bodies — e.g.

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -12,6 +12,7 @@ import com.palantir.javapoet.ParameterizedTypeName
 import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
+import com.palantir.javapoet.WildcardTypeName
 import io.github.pulpogato.restcodegen.Annotations.generated
 import io.github.pulpogato.restcodegen.Annotations.testExtension
 import io.github.pulpogato.restcodegen.ext.camelCase
@@ -81,6 +82,7 @@ class WebhooksBuilder {
         // The same supertypes SchemasBuilder generates; used here to route the synthetic handler
         // straight to the typed supertype when the subcategory can be deserialized polymorphically.
         val supertypesBySubcategory = WebhookSupertypes.compute(openAPI, "$restPackage.schemas").associateBy { it.subcategory }
+        val requestBodyTypeByEventName = linkedMapOf<String, ClassName>()
         openAPI.webhooks
             .entries
             .groupBy {
@@ -109,6 +111,12 @@ class WebhooksBuilder {
                 v.forEach { (name, webhook) ->
                     val requestBody =
                         createWebhookInterface(context, name, webhook, restPackage, builders, testResourcesDir)
+                    // Per-event methods only carry a real @RequestBody/header pairing when they ARE
+                    // the Spring endpoint (single-event subcategory); for multi-event subcategories
+                    // the only annotated endpoint is the synthetic dispatcher added below.
+                    if (builders.springEndpoint) {
+                        requestBodyTypeByEventName[name] = requestBody
+                    }
                     val methodName =
                         "process" +
                             webhook
@@ -129,6 +137,12 @@ class WebhooksBuilder {
                         builders,
                         v.first().value,
                     )
+                    // Only a discriminable supertype implements WebhookEvent; a non-discriminable group's
+                    // synthetic dispatcher reads JsonNode instead, which has no typed body to publish here.
+                    val supertype = builders.supertype
+                    if (supertype != null && supertype.discriminable) {
+                        requestBodyTypeByEventName[subcategory.replace("-", "_")] = supertype.supertype
+                    }
                 }
 
                 val interfaceSpec = interfaceBuilder.build()
@@ -152,6 +166,11 @@ class WebhooksBuilder {
                         .writeTo(testDir)
                 }
             }
+        JavaFile
+            .builder(webhooksPackage, buildWebhookEventTypes(requestBodyTypeByEventName))
+            .build()
+            .writeTo(mainDir)
+
         val testConfig = buildTestConfig(testControllerBuilder.build())
         val integrationTestBuilder = buildIntegrationTest(context, testConfig.build())
         JavaFile
@@ -454,6 +473,36 @@ class WebhooksBuilder {
             .build()
     }
 
+    /**
+     * Generates a lookup from each `X-Github-Event` header value to the request body type Spring
+     * deserializes it into, for callers that need to resolve a payload's type before dispatch.
+     */
+    private fun buildWebhookEventTypes(requestBodyTypeByEventName: Map<String, ClassName>): TypeSpec {
+        val webhookEvent = ClassName.get(Types.COMMON_PACKAGE, "WebhookEvent")
+        val classOfWildcard = ParameterizedTypeName.get(ClassName.get(Class::class.java), WildcardTypeName.subtypeOf(webhookEvent))
+        val mapType = ParameterizedTypeName.get(Types.MAP, Types.STRING, classOfWildcard)
+
+        // Explicit type witness avoids "vararg method call with 50+ poly arguments" javac warning.
+        val initializer = CodeBlock.builder().add($$"$T.<$T, $T>ofEntries(\n", Types.MAP, Types.STRING, classOfWildcard).indent()
+        requestBodyTypeByEventName.entries.forEachIndexed { index, (eventName, type) ->
+            initializer.add($$"$T.entry($S, $T.class)", Types.MAP, eventName, type)
+            initializer.add(if (index == requestBodyTypeByEventName.size - 1) "\n" else ",\n")
+        }
+        initializer.unindent().add(")")
+
+        return TypeSpec
+            .classBuilder("WebhookEventTypes")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addJavadoc("Maps each {@code X-Github-Event} header value to its webhook request body type.\n")
+            .addField(
+                FieldSpec
+                    .builder(mapType, "BY_EVENT_NAME", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                    .initializer(initializer.build())
+                    .build(),
+            ).addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build())
+            .build()
+    }
+
     private fun getUnitTestBuilder(subcategory: String): TypeSpec.Builder =
         TypeSpec
             .classBuilder("${subcategory.pascalCase()}WebhooksTest")
@@ -577,21 +626,6 @@ class WebhooksBuilder {
             .addAnnotation(AnnotationSpec.builder(ClassName.get(PACKAGE_SPRING_WEB_BIND_ANNOTATION, "RequestBody")).build())
             .addAnnotation(generated(0, context))
             .build()
-
-    /**
-     * Routes a polymorphically-deserialized webhook body to its typed handler. The switch over the
-     * sealed supertype is exhaustive, so no default branch is needed.
-     */
-    private fun buildTypedRouter(requestBodyTypes: Map<String, Pair<String, ClassName>>): CodeBlock {
-        val code = CodeBlock.builder()
-        code.add("return switch (requestBody) {\n")
-        requestBodyTypes.forEach { (_, methodNameAndType) ->
-            val (methodName, type) = methodNameAndType
-            code.add($$"    case $T body -> $L(headers, body);\n", type, methodName)
-        }
-        code.add("};\n")
-        return code.build()
-    }
 
     private fun buildRouter(
         requestBodyTypes: Map<String, Pair<String, ClassName>>,

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/SchemasBuilderTest.kt
@@ -28,7 +28,7 @@ class SchemasBuilderTest {
 
         val supertype = readGenerated("WebhookThing")
         assertThat(supertype)
-            .contains("public sealed interface WebhookThing extends PulpogatoType")
+            .contains("public sealed interface WebhookThing extends WebhookEvent")
             .contains("permits")
             .contains("WebhookThingCreated")
             .contains("WebhookThingDeleted")

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/WebhookEvent.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/WebhookEvent.java
@@ -1,0 +1,7 @@
+package io.github.pulpogato.common;
+
+/**
+ * Marker interface implemented by every webhook event payload type: the single-event body classes
+ * and the sealed supertypes generated for multi-event subcategories.
+ */
+public interface WebhookEvent extends PulpogatoType {}


### PR DESCRIPTION
## Summary
- Add a `WebhookEvent` marker interface (`pulpogato-common`) implemented by every generated webhook event payload type: single-event `@RequestBody` classes and the sealed supertypes generated for multi-event subcategories.
- Generate `WebhookEventTypes.BY_EVENT_NAME`, a `Map<String, Class<? extends WebhookEvent>>` lookup from each `X-Github-Event` header value to its request body type.
- Non-discriminable multi-event subcategories (none currently exist in the GitHub schema) are excluded from the map, since there's no single typed body to publish for them.