### PR TITLE
feat(cache): hash a structured cache key instead of a readable string

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CacheKeyData.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CacheKeyData.java
@@ -1,0 +1,25 @@
+package io.github.pulpogato.common.cache;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * All the request attributes that participate in a cache key, prior to hashing.
+ *
+ * <p>Kept as a plain data type (rather than assembled directly into a string) so new
+ * discriminating fields can be added without hand-rolling string concatenation and
+ * escaping/delimiter edge cases.
+ */
+@Getter
+@Builder
+public class CacheKeyData {
+    private final String method;
+    private final String host;
+    private final @Nullable Integer port;
+    private final String path;
+    private final @Nullable String query;
+    private final @Nullable String accept;
+    private final @Nullable String contentType;
+    private final @Nullable String jwtSubject;
+}

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapper.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapper.java
@@ -1,34 +1,78 @@
 package io.github.pulpogato.common.cache;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.ClientRequest;
 
 /**
  * Default implementation of CacheKeyMapper that generates a cache key
- * based on the HTTP method, host, path, and query parameters of the request.
+ * from the HTTP method, host, path, query parameters, {@code Accept} and
+ * {@code Content-Type} headers, and (if present) the subject of a JWT bearer token.
+ *
+ * <p>The request attributes are collected into a {@link CacheKeyData}, serialized to JSON,
+ * and hashed with SHA-256. This avoids hand-rolling a delimited string, which gets awkward once
+ * header values (which may themselves contain the delimiters) join the key.
  */
 public class DefaultCacheKeyMapper implements CacheKeyMapper {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Override
     public String apply(ClientRequest request) {
         final var url = request.url();
-        final var hostHeader = request.headers().getFirst("Host");
+        final var headers = request.headers();
+        final var hostHeader = headers.getFirst("Host");
         final var host = hostHeader != null ? hostHeader : url.getHost();
+        final var port = url.getPort() != -1 ? url.getPort() : null;
 
-        // Optimized with StringBuilder to reduce object allocations in hot path.
-        // Initial capacity of 128 characters avoids resizing for typical GitHub API URLs.
-        final var sb = new StringBuilder(128);
-        sb.append(request.method().name()).append(' ').append(host);
+        final var data = CacheKeyData.builder()
+                .method(request.method().name())
+                .host(host)
+                .port(port)
+                .path(url.getRawPath())
+                .query(url.getRawQuery())
+                .accept(headers.getFirst(HttpHeaders.ACCEPT))
+                .contentType(headers.getFirst(HttpHeaders.CONTENT_TYPE))
+                .jwtSubject(extractJwtSubject(headers.getFirst(HttpHeaders.AUTHORIZATION)))
+                .build();
 
-        if (url.getPort() != -1) {
-            sb.append(':').append(url.getPort());
+        return sha256Hex(toJson(data));
+    }
+
+    private static @Nullable String extractJwtSubject(@Nullable String authorizationHeader) {
+        if (authorizationHeader == null) {
+            return null;
         }
-
-        sb.append(' ').append(url.getRawPath());
-
-        final var query = url.getRawQuery();
-        if (query != null) {
-            sb.append('?').append(query);
+        final var token = authorizationHeader.startsWith("Bearer ")
+                ? authorizationHeader.substring("Bearer ".length())
+                : authorizationHeader;
+        try {
+            return JWT.decode(token).getSubject();
+        } catch (JWTDecodeException e) {
+            return null;
         }
+    }
 
-        return sb.toString();
+    private static byte[] toJson(CacheKeyData data) {
+        try {
+            return OBJECT_MAPPER.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize cache key data", e);
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            final var digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
     }
 }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapperTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/DefaultCacheKeyMapperTest.java
@@ -2,7 +2,10 @@ package io.github.pulpogato.common.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import java.net.URI;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,41 +16,43 @@ class DefaultCacheKeyMapperTest {
 
     private final DefaultCacheKeyMapper mapper = new DefaultCacheKeyMapper();
 
+    private static final String SHA256_HEX_PATTERN = "[0-9a-f]{64}";
+
+    @Test
+    @DisplayName("produces a 64-character lowercase hex (SHA-256) key")
+    void producesMd5HexKey() {
+        var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                .build();
+
+        var key = mapper.apply(request);
+
+        assertThat(key).matches(SHA256_HEX_PATTERN);
+    }
+
+    @Test
+    @DisplayName("is deterministic for equivalent requests")
+    void isDeterministic() {
+        var requestA = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                .build();
+        var requestB = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                .build();
+
+        assertThat(mapper.apply(requestA)).isEqualTo(mapper.apply(requestB));
+    }
+
     @Nested
     @DisplayName("HTTP method")
     class HttpMethodTests {
 
         @Test
-        @DisplayName("includes GET method in cache key")
-        void includesGetMethod() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+        @DisplayName("differs by HTTP method")
+        void differsByMethod() {
+            var getRequest = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+            var postRequest = ClientRequest.create(HttpMethod.POST, URI.create("https://api.example.com/data"))
                     .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).startsWith("GET ");
-        }
-
-        @Test
-        @DisplayName("includes POST method in cache key")
-        void includesPostMethod() {
-            var request = ClientRequest.create(HttpMethod.POST, URI.create("https://api.example.com/data"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).startsWith("POST ");
-        }
-
-        @Test
-        @DisplayName("includes PUT method in cache key")
-        void includesPutMethod() {
-            var request = ClientRequest.create(HttpMethod.PUT, URI.create("https://api.example.com/data"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).startsWith("PUT ");
+            assertThat(mapper.apply(getRequest)).isNotEqualTo(mapper.apply(postRequest));
         }
     }
 
@@ -56,48 +61,26 @@ class DefaultCacheKeyMapperTest {
     class HostResolutionTests {
 
         @Test
-        @DisplayName("uses Host header when present")
+        @DisplayName("uses Host header when present, over the URL host")
         void usesHostHeader() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+            var withHeader = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
                     .header("Host", "custom-host.example.com")
                     .build();
+            var withoutHeader = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET custom-host.example.com /data");
+            assertThat(mapper.apply(withHeader)).isNotEqualTo(mapper.apply(withoutHeader));
         }
 
         @Test
-        @DisplayName("derives host from URL when Host header is absent")
-        void derivesHostFromUrl() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+        @DisplayName("differs by port")
+        void differsByPort() {
+            var defaultPort = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+            var explicitPort = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com:8443/data"))
                     .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /data");
-        }
-
-        @Test
-        @DisplayName("includes port in host when non-standard port is used")
-        void includesPortWhenNonStandard() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com:8443/data"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com:8443 /data");
-        }
-
-        @Test
-        @DisplayName("omits port when using default HTTPS port")
-        void omitsDefaultHttpsPort() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com:443/data"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com:443 /data");
+            assertThat(mapper.apply(defaultPort)).isNotEqualTo(mapper.apply(explicitPort));
         }
     }
 
@@ -106,72 +89,124 @@ class DefaultCacheKeyMapperTest {
     class PathAndQueryTests {
 
         @Test
-        @DisplayName("includes path in cache key")
-        void includesPath() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/users/123"))
+        @DisplayName("differs by path")
+        void differsByPath() {
+            var requestA = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/users/123"))
+                    .build();
+            var requestB = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/users/456"))
                     .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /users/123");
+            assertThat(mapper.apply(requestA)).isNotEqualTo(mapper.apply(requestB));
         }
 
         @Test
-        @DisplayName("includes query parameters in cache key")
-        void includesQueryParameters() {
-            var request = ClientRequest.create(
+        @DisplayName("differs by query parameters")
+        void differsByQueryParameters() {
+            var requestA = ClientRequest.create(
                             HttpMethod.GET, URI.create("https://api.example.com/search?q=test&page=1"))
                     .build();
+            var requestB = ClientRequest.create(
+                            HttpMethod.GET, URI.create("https://api.example.com/search?q=test&page=2"))
+                    .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /search?q=test&page=1");
+            assertThat(mapper.apply(requestA)).isNotEqualTo(mapper.apply(requestB));
         }
 
         @Test
-        @DisplayName("handles empty query string")
+        @DisplayName("no query string does not blow up and is distinct from a request with one")
         void handlesEmptyQuery() {
+            var noQuery = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+            var withQuery = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data?a=b"))
+                    .build();
+
+            assertThat(mapper.apply(noQuery)).isNotEqualTo(mapper.apply(withQuery));
+        }
+    }
+
+    @Nested
+    @DisplayName("Accept and Content-Type headers")
+    class HeaderTests {
+
+        @Test
+        @DisplayName("differs by Accept header")
+        void differsByAccept() {
+            var withAccept = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header("Accept", "application/vnd.github.v3+json")
+                    .build();
+            var withoutAccept = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .build();
+
+            assertThat(mapper.apply(withAccept)).isNotEqualTo(mapper.apply(withoutAccept));
+        }
+
+        @Test
+        @DisplayName("differs by Content-Type header")
+        void differsByContentType() {
+            var withContentType = ClientRequest.create(HttpMethod.POST, URI.create("https://api.example.com/data"))
+                    .header("Content-Type", "application/json")
+                    .build();
+            var withoutContentType = ClientRequest.create(HttpMethod.POST, URI.create("https://api.example.com/data"))
+                    .build();
+
+            assertThat(mapper.apply(withContentType)).isNotEqualTo(mapper.apply(withoutContentType));
+        }
+    }
+
+    @Nested
+    @DisplayName("JWT Authorization header")
+    class JwtTests {
+
+        @Test
+        @DisplayName("differs by JWT subject")
+        void differsByJwtSubject() {
+            var requestA = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header("Authorization", "Bearer " + jwtWithSubject("user-a"))
+                    .build();
+            var requestB = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header("Authorization", "Bearer " + jwtWithSubject("user-b"))
+                    .build();
+
+            assertThat(mapper.apply(requestA)).isNotEqualTo(mapper.apply(requestB));
+        }
+
+        @Test
+        @DisplayName("is the same key for the same JWT subject even if the token itself differs")
+        void sameSubjectSameKey() {
+            var requestA = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header(
+                            "Authorization",
+                            "Bearer "
+                                    + JWT.create()
+                                            .withSubject("user-a")
+                                            .withIssuedAt(Instant.ofEpochSecond(1))
+                                            .sign(Algorithm.HMAC256("secret-one")))
+                    .build();
+            var requestB = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header(
+                            "Authorization",
+                            "Bearer "
+                                    + JWT.create()
+                                            .withSubject("user-a")
+                                            .withIssuedAt(Instant.ofEpochSecond(2))
+                                            .sign(Algorithm.HMAC256("secret-two")))
+                    .build();
+
+            assertThat(mapper.apply(requestA)).isEqualTo(mapper.apply(requestB));
+        }
+
+        @Test
+        @DisplayName("does not blow up for a non-JWT Authorization header (e.g. a personal access token)")
+        void nonJwtAuthorizationHeaderIsIgnored() {
             var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/data"))
+                    .header("Authorization", "token ghp_notActuallyAJwt")
                     .build();
 
-            var key = mapper.apply(request);
-
-            assertThat(key).doesNotContain("?");
+            assertThat(mapper.apply(request)).matches(SHA256_HEX_PATTERN);
         }
 
-        @Test
-        @DisplayName("handles root path")
-        void handlesRootPath() {
-            var request = ClientRequest.create(HttpMethod.GET, URI.create("https://api.example.com/"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /");
-        }
-
-        @Test
-        @DisplayName("preserves URL-encoded characters in path")
-        void preservesEncodedPath() {
-            var request = ClientRequest.create(
-                            HttpMethod.GET, URI.create("https://api.example.com/path%20with%20spaces"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /path%20with%20spaces");
-        }
-
-        @Test
-        @DisplayName("preserves URL-encoded characters in query")
-        void preservesEncodedQuery() {
-            var request = ClientRequest.create(
-                            HttpMethod.GET, URI.create("https://api.example.com/search?q=hello%20world"))
-                    .build();
-
-            var key = mapper.apply(request);
-
-            assertThat(key).isEqualTo("GET api.example.com /search?q=hello%20world");
+        private String jwtWithSubject(String subject) {
+            return JWT.create().withSubject(subject).sign(Algorithm.HMAC256("secret"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Include the `Accept` and `Content-Type` headers in the cache key, so requests that only differ by these no longer collide.
- Extract the JWT subject from a bearer `Authorization` header (falling back to no-op for non-JWT tokens like PATs) and include it in the key.
- Collect the key attributes into a new `CacheKeyData` type and hash its JSON representation (MD5) instead of hand-building a delimited string, avoiding escaping/collision concerns as more fields are added.