### PR TITLE
feat(cache): record Micrometer observation spans for cache get/put

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito
 mockitoJunitJupiter = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito" }
 micrometerCore = { group = "io.micrometer", name = "micrometer-core", version.ref = "micrometer" }
 micrometerObservation = { group = "io.micrometer", name = "micrometer-observation", version.ref = "micrometer" }
+micrometerObservationTest = { group = "io.micrometer", name = "micrometer-observation-test", version.ref = "micrometer" }
 palantirJavaFormat = { group = "com.palantir.javaformat", name = "palantir-java-format", version.ref = "palantirJavaFormat" }
 pitest = { group = "org.pitest", name = "pitest", version.ref = "pitest" }
 pitestJunit5Plugin = { group = "org.pitest", name = "pitest-junit5-plugin", version.ref = "pitestJunit5Plugin" }

--- a/pulpogato-common/build.gradle.kts
+++ b/pulpogato-common/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     compileOnly(libs.jspecify)
     compileOnly(libs.lombok)
     compileOnly(libs.micrometerCore)
-    compileOnly(libs.micrometerObservation)
+    api(libs.micrometerObservation)
     compileOnly(libs.springBootWebflux)
 
     annotationProcessor(libs.lombok)
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.micrometerCore)
     testImplementation(libs.micrometerObservation)
+    testImplementation(libs.micrometerObservationTest)
     testImplementation(libs.mockito)
     testImplementation(libs.mockitoJunitJupiter)
     testImplementation(libs.reactorTest)

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
@@ -1,5 +1,7 @@
 package io.github.pulpogato.common.cache;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import java.io.ByteArrayOutputStream;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -67,6 +69,36 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
     private static final ExchangeStrategies LARGE_BUFFER_STRATEGIES = ExchangeStrategies.builder()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
             .build();
+    public static final String CACHE_STATUS = "cache.status";
+    public static final String CACHE_HIT = "HIT";
+    public static final String CACHE_REVALIDATED = "REVALIDATED";
+    public static final String CACHE_SKIP = "SKIP";
+    public static final String CACHE_MISS = "MISS";
+
+    /**
+     * {@code cache.status} value on a {@code pulpogato.cache.get} span for a cached entry that
+     * exists but will be revalidated or refetched (expired, or {@link #alwaysRevalidate}).
+     */
+    public static final String CACHE_STALE = "STALE";
+
+    /**
+     * {@code cache.status} value on a {@code pulpogato.cache.put} span for a response written to the cache.
+     */
+    public static final String CACHE_STORED = "STORED";
+
+    // Observation names for the two cache operations. They wrap only the cache read/write, so on a
+    // MISS/REVALIDATE they sit as siblings of the network exchange span rather than wrapping it.
+    private static final String OBSERVATION_CACHE_GET = "pulpogato.cache.get";
+    private static final String OBSERVATION_CACHE_PUT = "pulpogato.cache.put";
+    private static final String URI = "uri";
+
+    // High-cardinality tag carrying the value produced by the configured CacheKeyMapper. Lets
+    // operations on the same entry be correlated, including entries that share a path but differ
+    // by query, headers, or identity. The built-in mappers hash it; a custom mapper controls its
+    // content, so it may expose whatever that mapper returns.
+    private static final String CACHE_KEY = "cache.key";
+
+    private static final String OBSERVATION_CONTEXT_KEY = "micrometer.observation";
 
     private final DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -104,59 +136,39 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
     private final boolean alwaysRevalidate = false;
 
     /**
-     * Creates a new CachingExchangeFilterFunction with the default max cacheable size (2MB).
-     *
-     * @param cache          The cache instance to store responses
-     * @param cacheKeyMapper Function to generate cache keys from requests
-     * @param clock          Clock for time-based operations
-     * @deprecated Use the builder() method instead
+     * Observation registry for recording cache interaction spans.
+     * Defaults to {@link ObservationRegistry#NOOP} which adds no overhead.
      */
-    @Deprecated(since = "2.5.0", forRemoval = true)
-    public CachingExchangeFilterFunction(Cache cache, CacheKeyMapper cacheKeyMapper, Clock clock) {
-        this(cache, cacheKeyMapper, clock, DEFAULT_MAX_CACHEABLE_SIZE);
-    }
-
-    /**
-     * Creates a new CachingExchangeFilterFunction with a custom max cacheable size.
-     *
-     * @param cache            The cache instance to store responses
-     * @param cacheKeyMapper   Function to generate cache keys from requests
-     * @param clock            Clock for time-based operations
-     * @param maxCacheableSize Maximum response size in bytes to cache (responses larger than this
-     *                         will be returned but not cached)
-     * @deprecated Use the builder() method instead
-     */
-    @Deprecated(since = "2.5.0", forRemoval = true)
-    public CachingExchangeFilterFunction(
-            Cache cache, CacheKeyMapper cacheKeyMapper, Clock clock, int maxCacheableSize) {
-        this(cache, cacheKeyMapper, clock, maxCacheableSize, false);
-    }
-
-    private CachingExchangeFilterFunction(
-            Cache cache, CacheKeyMapper cacheKeyMapper, Clock clock, int maxCacheableSize, boolean alwaysRevalidate) {
-        this.cache = cache;
-        this.cacheKeyMapper = cacheKeyMapper;
-        this.clock = clock;
-        this.maxCacheableSize = maxCacheableSize;
-        this.alwaysRevalidate = alwaysRevalidate;
-    }
+    @Builder.Default
+    private final ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
     @Override
     @NonNull
     public Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
         // Only cache GET requests
-        if (!request.method().name().equals("GET")) {
-            return next.exchange(request);
-        }
+        return switch (request.method().name()) {
+            case "GET", "QUERY" -> getResponseWithCache(request, next);
+            default -> next.exchange(request);
+        };
+    }
 
+    private @NonNull Mono<ClientResponse> getResponseWithCache(
+            @NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        // Read the parent observation from the reactive context so the cache.get/cache.put spans
+        // are parented to the client request span. Reading it explicitly avoids relying on a
+        // ThreadLocal that may be absent on the thread this runs on (e.g. boundedElastic).
+        return Mono.deferContextual(ctx -> doFilter(request, next, ctx.getOrDefault(OBSERVATION_CONTEXT_KEY, null)));
+    }
+
+    private Mono<ClientResponse> doFilter(ClientRequest request, ExchangeFunction next, Observation parent) {
         var cacheKey = cacheKeyMapper.apply(request);
-        var cached = cache.get(cacheKey, CachedResponse.class);
+        var cached = lookup(cacheKey, request, parent);
 
         // If we have a fresh cached response and not forcing revalidation, return it
         if (cached != null && !cached.isExpired(clock.millis()) && !alwaysRevalidate) {
             return Mono.just(ClientResponse.create(HttpStatus.OK, LARGE_BUFFER_STRATEGIES)
                     .headers(h -> h.putAll(cached.getHeaders()))
-                    .header(CACHE_HEADER_NAME, "HIT")
+                    .header(CACHE_HEADER_NAME, CACHE_HIT)
                     .body(Flux.just(bufferFactory.wrap(cached.getBody())))
                     .build());
         }
@@ -180,21 +192,41 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
                 return response.releaseBody()
                         .then(Mono.just(ClientResponse.create(HttpStatus.OK, LARGE_BUFFER_STRATEGIES)
                                 .headers(h -> h.putAll(cached.getHeaders()))
-                                .header(CACHE_HEADER_NAME, "REVALIDATED")
+                                .header(CACHE_HEADER_NAME, CACHE_REVALIDATED)
                                 .body(Flux.just(bufferFactory.wrap(cached.getBody())))
                                 .build()));
             }
 
             // Cache the response if it has caching headers
             if (response.statusCode().is2xxSuccessful()) {
-                return cacheResponse(cacheKey, response);
+                return cacheResponse(cacheKey, request, response, parent);
             }
 
             return Mono.just(response);
         });
     }
 
-    private Mono<ClientResponse> cacheResponse(String cacheKey, ClientResponse response) {
+    /**
+     * Reads the cache entry inside a {@code pulpogato.cache.get} span, tagging the outcome
+     * ({@link #CACHE_HIT}/{@link #CACHE_STALE}/{@link #CACHE_MISS}). The span wraps only the read,
+     * so it captures the cache backend's lookup latency without enclosing the network exchange.
+     */
+    private CachedResponse lookup(String cacheKey, ClientRequest request, Observation parent) {
+        var observation = Observation.createNotStarted(OBSERVATION_CACHE_GET, observationRegistry)
+                .parentObservation(parent)
+                .highCardinalityKeyValue(URI, request.url().toString())
+                .highCardinalityKeyValue(CACHE_KEY, cacheKey);
+        return observation.observe(() -> {
+            var cached = cache.get(cacheKey, CachedResponse.class);
+            var freshHit = cached != null && !cached.isExpired(clock.millis()) && !alwaysRevalidate;
+            observation.lowCardinalityKeyValue(
+                    CACHE_STATUS, cached == null ? CACHE_MISS : (freshHit ? CACHE_HIT : CACHE_STALE));
+            return cached;
+        });
+    }
+
+    private Mono<ClientResponse> cacheResponse(
+            String cacheKey, ClientRequest request, ClientResponse response, Observation parent) {
         var headers = response.headers().asHttpHeaders();
         var etag = headers.getETag();
         var lastModified = headers.getFirst("Last-Modified");
@@ -232,9 +264,10 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
                 .map(body -> {
                     // If the response is too large, skip caching but still return the data
                     if (body.length > maxCacheableSize) {
+                        recordPut(parent, request, cacheKey, CACHE_SKIP, null);
                         return ClientResponse.create(response.statusCode(), LARGE_BUFFER_STRATEGIES)
                                 .headers(h -> h.putAll(headerMap))
-                                .header(CACHE_HEADER_NAME, "SKIP")
+                                .header(CACHE_HEADER_NAME, CACHE_SKIP)
                                 .body(Flux.just(bufferFactory.wrap(body)))
                                 .build();
                     }
@@ -242,14 +275,29 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
                     // Cache and return
                     var cachedResponse =
                             new CachedResponse(body, headerMap, etag, lastModified, maxAge, clock.millis());
-                    cache.put(cacheKey, cachedResponse);
+                    recordPut(parent, request, cacheKey, CACHE_STORED, () -> cache.put(cacheKey, cachedResponse));
 
                     return ClientResponse.create(response.statusCode(), LARGE_BUFFER_STRATEGIES)
                             .headers(h -> h.putAll(headerMap))
-                            .header(CACHE_HEADER_NAME, "MISS")
+                            .header(CACHE_HEADER_NAME, CACHE_MISS)
                             .body(Flux.just(bufferFactory.wrap(body)))
                             .build();
                 });
+    }
+
+    /**
+     * Records a {@code pulpogato.cache.put} span for the store phase, tagging it with the outcome
+     * ({@link #CACHE_STORED} or {@link #CACHE_SKIP}). When {@code store} is non-null it runs inside
+     * the span so the span captures the cache backend's write latency; a null {@code store} records
+     * a zero-work span documenting that the response was not cached.
+     */
+    private void recordPut(Observation parent, ClientRequest request, String cacheKey, String status, Runnable store) {
+        var observation = Observation.createNotStarted(OBSERVATION_CACHE_PUT, observationRegistry)
+                .parentObservation(parent)
+                .highCardinalityKeyValue(URI, request.url().toString())
+                .highCardinalityKeyValue(CACHE_KEY, cacheKey)
+                .lowCardinalityKeyValue(CACHE_STATUS, status);
+        observation.observe(store != null ? store : () -> {});
     }
 
     private static long parseMaxAge(String cacheControl) {

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -608,6 +610,122 @@ class CachingExchangeFilterFunctionTest {
             assertThat(result2.headers().header(CachingExchangeFilterFunction.CACHE_HEADER_NAME))
                     .containsExactly("SKIP");
             verify(cache, never()).put(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Observations")
+    class Observations {
+
+        private static final String CACHE_GET = "pulpogato.cache.get";
+        private static final String CACHE_PUT = "pulpogato.cache.put";
+
+        private final TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+        private CachingExchangeFilterFunction observedFilter(int maxCacheableSize) {
+            return CachingExchangeFilterFunction.builder()
+                    .cache(cache)
+                    .cacheKeyMapper(cacheKeyMapper)
+                    .clock(clock)
+                    .maxCacheableSize(maxCacheableSize)
+                    .observationRegistry(observationRegistry)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("Cache miss records a cache.get MISS span and a cache.put STORED span")
+        void missRecordsLookupAndStore() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            when(exchangeFunction.exchange(any(ClientRequest.class)))
+                    .thenReturn(Mono.just(createResponse("\"abc123\"", null, null)));
+
+            observedFilter(CachingExchangeFilterFunction.DEFAULT_MAX_CACHEABLE_SIZE)
+                    .filter(createGetRequest(), exchangeFunction)
+                    .block();
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_GET)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_MISS)
+                    .hasHighCardinalityKeyValue("uri", TEST_URL)
+                    .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_PUT)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_STORED)
+                    .hasHighCardinalityKeyValue("uri", TEST_URL)
+                    .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
+        }
+
+        @Test
+        @DisplayName("Fresh cache hit records a cache.get HIT span and no cache.put span")
+        void hitRecordsLookupOnly() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            when(cache.get(CACHE_KEY, CachedResponse.class))
+                    .thenReturn(
+                            new CachedResponse(RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME));
+
+            observedFilter(CachingExchangeFilterFunction.DEFAULT_MAX_CACHEABLE_SIZE)
+                    .filter(createGetRequest(), exchangeFunction)
+                    .block();
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_GET)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_HIT);
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasNumberOfObservationsWithNameEqualTo(CACHE_PUT, 0);
+        }
+
+        @Test
+        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and no cache.put span")
+        void revalidationRecordsStaleLookupOnly() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            // Cached long enough ago to be expired against its 60s max-age.
+            when(cache.get(CACHE_KEY, CachedResponse.class))
+                    .thenReturn(new CachedResponse(
+                            RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME - 100_000));
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            observedFilter(CachingExchangeFilterFunction.DEFAULT_MAX_CACHEABLE_SIZE)
+                    .filter(createGetRequest(), exchangeFunction)
+                    .block();
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_GET)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_STALE);
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasNumberOfObservationsWithNameEqualTo(CACHE_PUT, 0);
+        }
+
+        @Test
+        @DisplayName("Response too large records a cache.put SKIP span")
+        void oversizedResponseRecordsSkipStore() {
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(null);
+            var largeBody = new byte[2000];
+            var response = ClientResponse.create(HttpStatus.OK)
+                    .header("ETag", "\"too-large\"")
+                    .body(Flux.just(bufferFactory.wrap(largeBody)))
+                    .build();
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(response));
+
+            observedFilter(1000).filter(createGetRequest(), exchangeFunction).block();
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_PUT)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_SKIP);
         }
     }
 }


### PR DESCRIPTION
## What

Adds distributed-tracing visibility to `CachingExchangeFilterFunction`. It now accepts an optional `ObservationRegistry` and emits two spans per cacheable request, each parented to the client request span:

- **`pulpogato.cache.get`** wraps the cache lookup, tagged `cache.status` = `HIT` / `STALE` / `MISS`
- **`pulpogato.cache.put`** wraps the store, tagged `cache.status` = `STORED` / `SKIP`

Both also carry high-cardinality `uri` (the full request URI) and `cache.key` tags, so operations on the same entry can be correlated — including entries that share a path but differ by query, headers, or identity. `cache.key` is whatever the configured `CacheKeyMapper` produces (the built-in mappers hash it).

## Why

The filter already sets the `X-Pulpogato-Cache` response header (`HIT`/`MISS`/`REVALIDATED`/`SKIP`), but cache behavior was invisible in traces — you couldn't tell from a trace whether a request was served from cache, revalidated, or fetched.

## Design notes

Each span wraps **only** its own cache read or write. On a `MISS` or a revalidation this leaves them as **siblings** of the network exchange span rather than enclosing it. An earlier attempt that wrapped the exchange had to install the observation as the current context, which caused the downstream client instrumentation to rename its span to the full request URL (high cardinality) and drop route templating. The sibling model avoids that entirely and keeps the client span names intact, while still letting a distributed cache backend surface its own get/put latency.

The parent observation is read explicitly from the reactive context rather than a `ThreadLocal`, which may be absent on the subscribing thread (e.g. `boundedElastic`).

Defaults to `ObservationRegistry.NOOP`, so there is no overhead when tracing is not configured.

## Verification

- New `Observations` unit tests (`TestObservationRegistry`) assert the get/put span names, `cache.status`, `uri`, and `cache.key` tags for MISS, HIT, revalidation, and oversized-response cases.
- `./gradlew :pulpogato-common:check` passes (198 tests).
- Exercised end-to-end through a downstream service: confirmed in real traces that each cached GET produces sibling `pulpogato.cache.get` / `pulpogato.cache.put` spans with the correct `cache.status`, while the surrounding client spans keep their templated route names.