### PR TITLE
fix(cache): refresh stored entry on 304 per RFC 9111

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
@@ -14,6 +14,7 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -37,7 +38,10 @@ import reactor.core.publisher.Mono;
  *
  * <p>When a cached response exists and is still fresh (within max-age), it is returned directly.
  * When expired, conditional headers are added and on 304 Not Modified the cached response body
- * is returned.
+ * is returned. Per <a href="https://www.rfc-editor.org/rfc/rfc9111#section-4.3.4">RFC 9111
+ * section 4.3.4</a>, a 304 also refreshes the stored entry: the header fields from the 304 replace
+ * the corresponding stored fields and the freshness lifetime restarts, so a validated entry can
+ * serve fresh hits again instead of revalidating on every subsequent request.
  *
  * <p>Responses larger than {@link #maxCacheableSize} are not cached but are still returned
  * successfully. This prevents memory issues with very large responses.
@@ -187,13 +191,15 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
         var conditionalRequest = requestBuilder.build();
 
         return next.exchange(conditionalRequest).flatMap(response -> {
-            // On 304, return cached body
+            // On 304 the stored representation is still valid: refresh its freshness and merge the
+            // updated header fields (RFC 9111 4.3.4), then serve the cached body.
             if (response.statusCode().value() == 304 && cached != null) {
+                var refreshed = refreshFromNotModified(cacheKey, request, cached, response, parent);
                 return response.releaseBody()
                         .then(Mono.just(ClientResponse.create(HttpStatus.OK, LARGE_BUFFER_STRATEGIES)
-                                .headers(h -> h.putAll(cached.getHeaders()))
+                                .headers(h -> h.putAll(refreshed.getHeaders()))
                                 .header(CACHE_HEADER_NAME, CACHE_REVALIDATED)
-                                .body(Flux.just(bufferFactory.wrap(cached.getBody())))
+                                .body(Flux.just(bufferFactory.wrap(refreshed.getBody())))
                                 .build()));
             }
 
@@ -204,6 +210,53 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
 
             return Mono.just(response);
         });
+    }
+
+    /**
+     * Applies a 304 Not Modified to the stored entry per
+     * <a href="https://www.rfc-editor.org/rfc/rfc9111#section-4.3.4">RFC 9111 section 4.3.4</a>:
+     * header fields from the 304 replace the corresponding stored fields, and the freshness lifetime
+     * restarts from now so the entry can serve fresh hits again instead of revalidating on every
+     * subsequent request. The refreshed entry is written back to the cache inside a
+     * {@code pulpogato.cache.put} span.
+     */
+    private CachedResponse refreshFromNotModified(
+            String cacheKey,
+            ClientRequest request,
+            CachedResponse cached,
+            ClientResponse notModified,
+            Observation parent) {
+        var updateHeaders = notModified.headers().asHttpHeaders();
+
+        // Overlay the 304's header fields onto the stored headers (case-insensitively via HttpHeaders).
+        var merged = new HttpHeaders();
+        cached.getHeaders().forEach(merged::addAll);
+        updateHeaders.forEach((name, values) -> {
+            // A 304 carries no body, so a Content-Length it sends (often 0) must not overwrite the
+            // length of the stored representation we are about to serve.
+            if (!HttpHeaders.CONTENT_LENGTH.equalsIgnoreCase(name)) {
+                merged.put(name, new ArrayList<>(values));
+            }
+        });
+
+        var headerMap = HashMap.<String, List<String>>newHashMap(merged.size());
+        merged.forEach((name, values) -> headerMap.put(name, new ArrayList<>(values)));
+
+        // Recompute caching metadata from the merged headers so any refreshed ETag, Last-Modified, or
+        // Cache-Control the server sent on the 304 is reflected. When the 304 omits a header, the
+        // merged headers retain the stored value; if even that is absent, fall back to the entry's
+        // existing metadata so revalidation never discards known freshness information. A header is
+        // absent exactly when getFirst returns null, so a present-but-updated value still wins.
+        var mergedCacheControl = merged.getFirst(HttpHeaders.CACHE_CONTROL);
+        var etag = merged.getETag() != null ? merged.getETag() : cached.getEtag();
+        var lastModified = merged.getFirst(HttpHeaders.LAST_MODIFIED) != null
+                ? merged.getFirst(HttpHeaders.LAST_MODIFIED)
+                : cached.getLastModified();
+        var maxAge = mergedCacheControl != null ? parseMaxAge(mergedCacheControl) : cached.getMaxAgeSeconds();
+
+        var refreshed = new CachedResponse(cached.getBody(), headerMap, etag, lastModified, maxAge, clock.millis());
+        recordPut(parent, request, cacheKey, CACHE_STORED, () -> cache.put(cacheKey, refreshed));
+        return refreshed;
     }
 
     /**

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -335,6 +335,92 @@ class CachingExchangeFilterFunctionTest {
             verify(cache).put(eq(CACHE_KEY), captor.capture());
             assertThat(captor.getValue().getEtag()).isEqualTo("\"new\"");
         }
+
+        @Test
+        @DisplayName("304 restarts the freshness lifetime and writes the entry back")
+        void notModifiedRestartsFreshness() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var staleCache =
+                    new CachedResponse(RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME - 100_000);
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(create304Response()));
+
+            filter.filter(request, exchangeFunction).block();
+
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            var refreshed = captor.getValue();
+            // Freshness is stamped from now, so the entry is fresh again against its max-age.
+            assertThat(refreshed.getCachedAtMillis()).isEqualTo(CURRENT_TIME);
+            assertThat(refreshed.isExpired(CURRENT_TIME)).isFalse();
+            // Freshness metadata absent from the stored headers is carried forward, not discarded.
+            assertThat(refreshed.getEtag()).isEqualTo("\"abc123\"");
+            assertThat(refreshed.getMaxAgeSeconds()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("304 header fields replace the corresponding stored fields")
+        void notModifiedReplacesStoredHeaders() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var storedHeaders = Map.of(
+                    "Content-Type", List.of("application/json"),
+                    "ETag", List.of("\"v1\""),
+                    "Cache-Control", List.of("max-age=30"));
+            var staleCache =
+                    new CachedResponse(RESPONSE_BODY, storedHeaders, "\"v1\"", null, 30, CURRENT_TIME - 100_000);
+            var notModified = ClientResponse.create(HttpStatus.NOT_MODIFIED)
+                    .header("ETag", "\"v2\"")
+                    .header("Cache-Control", "max-age=120")
+                    .build();
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(notModified));
+
+            var result = filter.filter(request, exchangeFunction).block();
+
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            var refreshed = captor.getValue();
+            assertThat(refreshed.getEtag()).isEqualTo("\"v2\"");
+            assertThat(refreshed.getMaxAgeSeconds()).isEqualTo(120);
+            assertThat(refreshed.getHeaders().get("ETag")).containsExactly("\"v2\"");
+            assertThat(refreshed.getHeaders().get("Cache-Control")).containsExactly("max-age=120");
+            // Headers not present in the 304 are retained from the stored entry.
+            assertThat(refreshed.getHeaders().get("Content-Type")).containsExactly("application/json");
+            // The refreshed headers are also what the caller sees.
+            assertThat(result).isNotNull();
+            assertThat(result.headers().header("ETag")).containsExactly("\"v2\"");
+        }
+
+        @Test
+        @DisplayName("304 Content-Length does not overwrite the stored representation's length")
+        void notModifiedContentLengthDoesNotClobberStored() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            var request = createGetRequest();
+            var bodyLength = String.valueOf(RESPONSE_BODY.length);
+            var storedHeaders = Map.of(
+                    "Content-Type", List.of("application/json"),
+                    "Content-Length", List.of(bodyLength),
+                    "ETag", List.of("\"abc123\""));
+            var staleCache =
+                    new CachedResponse(RESPONSE_BODY, storedHeaders, "\"abc123\"", null, 60, CURRENT_TIME - 100_000);
+            // Some servers send Content-Length: 0 on a bodyless 304; it must not corrupt the entry.
+            var notModified = ClientResponse.create(HttpStatus.NOT_MODIFIED)
+                    .header("Content-Length", "0")
+                    .build();
+            when(cache.get(CACHE_KEY, CachedResponse.class)).thenReturn(staleCache);
+            when(exchangeFunction.exchange(any(ClientRequest.class))).thenReturn(Mono.just(notModified));
+
+            filter.filter(request, exchangeFunction).block();
+
+            var captor = ArgumentCaptor.forClass(CachedResponse.class);
+            verify(cache).put(eq(CACHE_KEY), captor.capture());
+            assertThat(captor.getValue().getHeaders().get("Content-Length")).containsExactly(bodyLength);
+        }
     }
 
     @Nested
@@ -684,8 +770,8 @@ class CachingExchangeFilterFunctionTest {
         }
 
         @Test
-        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and no cache.put span")
-        void revalidationRecordsStaleLookupOnly() {
+        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and a cache.put STORED span")
+        void revalidationRecordsStaleLookupAndRefresh() {
             when(clock.millis()).thenReturn(CURRENT_TIME);
             when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
             // Cached long enough ago to be expired against its 60s max-age.
@@ -703,8 +789,14 @@ class CachingExchangeFilterFunctionTest {
                     .that()
                     .hasLowCardinalityKeyValue(
                             CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_STALE);
+            // The refreshed entry is written back per RFC 9111 4.3.4.
             TestObservationRegistryAssert.assertThat(observationRegistry)
-                    .hasNumberOfObservationsWithNameEqualTo(CACHE_PUT, 0);
+                    .hasObservationWithNameEqualTo(CACHE_PUT)
+                    .that()
+                    .hasLowCardinalityKeyValue(
+                            CachingExchangeFilterFunction.CACHE_STATUS, CachingExchangeFilterFunction.CACHE_STORED)
+                    .hasHighCardinalityKeyValue("uri", TEST_URL)
+                    .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
         }
 
         @Test


### PR DESCRIPTION
## Summary

The `CachingExchangeFilterFunction` 304 Not Modified branch returned the cached body and headers verbatim but **never wrote back to the cache**, so the freshness lifetime was never restarted. Once an entry passed its `max-age` it stayed permanently stale, forcing a conditional round-trip on **every** subsequent request instead of going quiet again for another `max-age` window. The 304's own headers were also discarded entirely.

This makes revalidation standards-compliant with [RFC 9111 §4.3.4](https://www.rfc-editor.org/rfc/rfc9111#section-4.3.4). On each 304 the filter now:

- **Merges headers** — the 304's header fields overlay the stored ones (case-insensitively), so an updated `ETag`, `Cache-Control`, `Date`, rate-limit headers, etc. are picked up; headers the 304 omits are retained from the stored entry.
- **Guards `Content-Length`** — a 304 is bodyless and some servers still send `Content-Length: 0`; that field is excluded from the overlay so it cannot corrupt the length of the cached representation being served.
- **Recomputes caching metadata** (`etag`, `lastModified`, `maxAge`) from the merged headers, falling back to the entry's existing metadata so a 304 that omits a directive never discards known freshness info, while a present-but-changed value still wins.
- **Restarts the freshness lifetime** — stamps a new `cachedAtMillis` and writes the refreshed entry back via `cache.put`, inside the existing `pulpogato.cache.put` observation span (tagged `STORED`).

The caller still receives the cached body with `X-Pulpogato-Cache: REVALIDATED`, now with the merged headers.

### Behavior change

- **Before:** revalidation did not restart expiry — every post-expiry request paid a conditional round-trip forever.
- **After:** a 304 restarts the `max-age` window, so a validated entry serves fast `HIT`s again until it next goes stale.

## Tests

- Updated the observation test that asserted "no `cache.put` on 304" → now asserts a `cache.put` `STORED` span.
- Added `CacheRevalidation` tests for: freshness restart, 304 header fields replacing stored fields (and reaching the caller), and the `Content-Length` guard.

`./gradlew :pulpogato-common:check` passes.