### PR TITLE
fix: correct codeRef stack frame lookup for default-arg call sites

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -181,7 +181,8 @@ object Annotations {
     private fun codeRef(offset: Int): String {
         val walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
         val frames = walker.walk { frames: Stream<StackWalker.StackFrame> -> frames.toList() }
-        val frame = frames[2 + offset]
+        val callerFrames = frames.dropWhile { it.declaringClass == Annotations::class.java }
+        val frame = callerFrames[offset]
         return "${frame.fileName}:${frame.lineNumber}"
     }
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/TestBuilder.kt
@@ -71,7 +71,7 @@ object TestBuilder {
                     MethodSpec
                         .methodBuilder("test${key.pascalCase()}")
                         .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
-                        .addAnnotation(Annotations.generated(1, context))
+                        .addAnnotation(Annotations.generated(0, context))
                         .addException(ClassName.get("java.io", "IOException"))
                         .addStatement($$"var stream = getClass().getClassLoader().getResourceAsStream($S)", fileName)
                         .addStatement($$"$T.assertThat(stream).as(\"Could not read stream for file $L\").isNotNull()", assertionsClass, fileName)
@@ -99,7 +99,7 @@ object TestBuilder {
                     MethodSpec
                         .methodBuilder("test${key.pascalCase()}")
                         .addAnnotation(ClassName.get("org.junit.jupiter.api", "Test"))
-                        .addAnnotation(Annotations.generated(1, context))
+                        .addAnnotation(Annotations.generated(0, context))
                         .addStatement($$"@$T(\"json\") $T input = $L", Language::class.java, String::class.java, formatted.blockQuote())
                         .addStatement($$"var softly = new $T()", ClassName.get(PACKAGE_ASSERTJ, "SoftAssertions"))
                         .addStatement(

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
@@ -2,6 +2,7 @@ package io.github.pulpogato.restcodegen
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.palantir.javapoet.TypeSpec
+import io.swagger.v3.oas.models.OpenAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -104,5 +105,43 @@ class AnnotationsTest {
         val result = Annotations.testExtension()
 
         assertThat(result.type().toString()).contains("CompositeTestExtension")
+    }
+
+    private fun testContext(): Context = Context(OpenAPI(), "test", listOf("#", "tags", "0"))
+
+    @Test
+    fun `generated with omitted sourceFile points codeRef at the real call site, not Annotations kt`() {
+        val result = Annotations.generated(0, testContext())
+
+        val codeRef = result.members()["codeRef"].toString()
+        assertThat(codeRef).contains("AnnotationsTest.kt:")
+        assertThat(codeRef).doesNotContain("Annotations.kt")
+    }
+
+    @Test
+    fun `generated with explicit sourceFile points codeRef at the real call site`() {
+        val result = Annotations.generated(0, testContext(), "other.json")
+
+        val codeRef = result.members()["codeRef"].toString()
+        assertThat(codeRef).contains("AnnotationsTest.kt:")
+        assertThat(codeRef).doesNotContain("Annotations.kt")
+        assertThat(result.members()["sourceFile"].toString()).contains("\"other.json\"")
+    }
+
+    // Mimics call sites (e.g. TestBuilder) that generate the annotation from inside a helper
+    // and use offset=1 to attribute codeRef to the helper's caller instead of the helper itself.
+    private fun generateThroughHelper(): String {
+        val result = Annotations.generated(1, testContext())
+        return result.members()["codeRef"].toString()
+    }
+
+    @Test
+    fun `generated with offset skips the immediate caller frame`() {
+        val codeRefFromHelper = generateThroughHelper()
+        val expectedLine = Throwable().stackTrace[0].lineNumber - 1
+
+        assertThat(codeRefFromHelper).contains("AnnotationsTest.kt:")
+        assertThat(codeRefFromHelper).doesNotContain("Annotations.kt")
+        assertThat(codeRefFromHelper).contains("AnnotationsTest.kt:$expectedLine\"")
     }
 }


### PR DESCRIPTION
## Summary
- `Annotations.generated(offset, context, sourceFile = "schema.json")` has a default parameter, so Kotlin generates a synthetic `generated$default` bridge for call sites that omit `sourceFile`. That bridge added an extra stack frame that `codeRef()`'s hardcoded `frames[2 + offset]` indexing didn't account for, so the emitted `codeRef` sometimes pointed into `Annotations.kt` itself instead of the real call site — e.g. `UsersApi.java` showed `codeRef = "Annotations.kt:142"` instead of `PathsBuilder.kt:393`.
- `codeRef()` now drops every stack frame declared in `Annotations` (including synthetic default-arg bridges) before applying the offset, so it resolves correctly regardless of whether the default parameter was used.
- Removed the `TestBuilder`-only `offset = 1` workaround, which was a per-call-site hack for this same bug and is no longer needed.
- Added unit tests in `AnnotationsTest.kt` covering `generated()` with the default `sourceFile` omitted, with it explicit, and through one level of helper-method indirection.

Verified by regenerating `pulpogato-rest-ghes-3.18`: `UsersApi.java` now emits `codeRef = "PathsBuilder.kt:393"` instead of `Annotations.kt:142`.