### PR TITLE
refactor: rename `codeRef` in Generated annotations to `value`

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -154,7 +154,7 @@ object Annotations {
         } else {
             throw IllegalArgumentException("SchemaRef is empty")
         }
-        builder.addMember("codeRef", $$"$S", codeRef(offset))
+        builder.addMember("value", $$"$S", codeRef(offset))
         if (sourceFile != "schema.json") {
             builder.addMember("sourceFile", $$"$S", sourceFile)
         }
@@ -164,8 +164,18 @@ object Annotations {
     fun typeGenerated(): AnnotationSpec =
         AnnotationSpec
             .builder(ClassName.get("$COMMON_PACKAGE.annotations", "TypeGenerated"))
-            .addMember("codeRef", $$"$S", codeRef(0))
+            .addMember("value", $$"$S", codeRef(0))
             .build()
+
+    // For boilerplate methods (equals/hashCode/toString/toCode) that aren't tied to a
+    // specific schema element, so schemaRef/ghVersion don't apply - only codeRef does.
+    fun methodGenerated(offset: Int = 0): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get("$COMMON_PACKAGE.annotations", "Generated"))
+            .addMember("value", $$"$S", codeRef(offset))
+            .build()
+
+    fun override(): AnnotationSpec = AnnotationSpec.builder(Override::class.java).build()
 
     fun generatedForGithubFiles(
         schemaRef: String,
@@ -174,7 +184,7 @@ object Annotations {
         AnnotationSpec
             .builder(ClassName.get("$COMMON_PACKAGE.annotations", "Generated"))
             .addMember("schemaRef", $$"$S", schemaRef)
-            .addMember("codeRef", $$"$S", codeRef(0))
+            .addMember("value", $$"$S", codeRef(0))
             .addMember("sourceFile", $$"$S", sourceFile)
             .build()
 

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -1068,6 +1068,8 @@ private fun addToCodeMethod(
     builder.addMethod(
         MethodSpec
             .methodBuilder("toCode")
+            .addAnnotation(Annotations.override())
+            .addAnnotation(Annotations.methodGenerated())
             .addModifiers(Modifier.PUBLIC)
             .returns(String::class.java)
             .addStatement(toCodeStatement.build())
@@ -1201,6 +1203,8 @@ private fun generateAllArgsConstructor(
 private fun generateToString(): MethodSpec =
     MethodSpec
         .methodBuilder("toString")
+        .addAnnotation(Annotations.override())
+        .addAnnotation(Annotations.methodGenerated())
         .addModifiers(Modifier.PUBLIC)
         .returns(String::class.java)
         .addStatement($$"return $T.reflectionToString(this)", ClassName.get(PACKAGE_COMMONS_LANG3_BUILDER, "ToStringBuilder"))
@@ -1212,6 +1216,8 @@ private fun generateToString(): MethodSpec =
 private fun generateEquals(): MethodSpec =
     MethodSpec
         .methodBuilder("equals")
+        .addAnnotation(Annotations.override())
+        .addAnnotation(Annotations.methodGenerated())
         .addModifiers(Modifier.PUBLIC)
         .returns(TypeName.BOOLEAN)
         .addParameter(ParameterSpec.builder(Types.OBJECT, "o").build())
@@ -1224,6 +1230,8 @@ private fun generateEquals(): MethodSpec =
 private fun generateHashCode(): MethodSpec =
     MethodSpec
         .methodBuilder("hashCode")
+        .addAnnotation(Annotations.override())
+        .addAnnotation(Annotations.methodGenerated())
         .addModifiers(Modifier.PUBLIC)
         .returns(
             TypeName.INT,

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
@@ -86,7 +86,7 @@ class AnnotationsTest {
         val result = Annotations.typeGenerated()
 
         assertThat(result.type().toString()).contains("TypeGenerated")
-        assertThat(result.members()["codeRef"].toString()).contains("AnnotationsTest.kt:")
+        assertThat(result.members()["value"].toString()).contains("AnnotationsTest.kt:")
     }
 
     @Test
@@ -97,7 +97,24 @@ class AnnotationsTest {
         assertThat(result.members()).doesNotContainKey("ghVersion")
         assertThat(result.members()["schemaRef"].toString()).contains("\"#/definitions/step\"")
         assertThat(result.members()["sourceFile"].toString()).contains("\"github-workflow.json\"")
-        assertThat(result.members()["codeRef"].toString()).contains("AnnotationsTest.kt:")
+        assertThat(result.members()["value"].toString()).contains("AnnotationsTest.kt:")
+    }
+
+    @Test
+    fun `methodGenerated creates Generated annotation with only codeRef`() {
+        val result = Annotations.methodGenerated()
+
+        assertThat(result.type().toString()).contains("Generated")
+        assertThat(result.members()).doesNotContainKey("ghVersion")
+        assertThat(result.members()).doesNotContainKey("schemaRef")
+        assertThat(result.members()["value"].toString()).contains("AnnotationsTest.kt:")
+    }
+
+    @Test
+    fun `override creates Override annotation`() {
+        val result = Annotations.override()
+
+        assertThat(result.type().toString()).contains("Override")
     }
 
     @Test
@@ -113,7 +130,7 @@ class AnnotationsTest {
     fun `generated with omitted sourceFile points codeRef at the real call site, not Annotations kt`() {
         val result = Annotations.generated(0, testContext())
 
-        val codeRef = result.members()["codeRef"].toString()
+        val codeRef = result.members()["value"].toString()
         assertThat(codeRef).contains("AnnotationsTest.kt:")
         assertThat(codeRef).doesNotContain("Annotations.kt")
     }
@@ -122,7 +139,7 @@ class AnnotationsTest {
     fun `generated with explicit sourceFile points codeRef at the real call site`() {
         val result = Annotations.generated(0, testContext(), "other.json")
 
-        val codeRef = result.members()["codeRef"].toString()
+        val codeRef = result.members()["value"].toString()
         assertThat(codeRef).contains("AnnotationsTest.kt:")
         assertThat(codeRef).doesNotContain("Annotations.kt")
         assertThat(result.members()["sourceFile"].toString()).contains("\"other.json\"")
@@ -132,7 +149,7 @@ class AnnotationsTest {
     // and use offset=1 to attribute codeRef to the helper's caller instead of the helper itself.
     private fun generateThroughHelper(): String {
         val result = Annotations.generated(1, testContext())
-        return result.members()["codeRef"].toString()
+        return result.members()["value"].toString()
     }
 
     @Test

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/annotations/Generated.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/annotations/Generated.java
@@ -23,7 +23,7 @@ public @interface Generated {
      * The generator of the class
      * @return The file and line that generated the type
      */
-    String codeRef();
+    String value();
     /**
      * The source file from which this element was generated
      * @return The source file name (e.g., "schema.json" or "additions.schema.json")

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/annotations/TypeGenerated.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/annotations/TypeGenerated.java
@@ -12,5 +12,5 @@ public @interface TypeGenerated {
      * The location of the type in the schema
      * @return The location as a JSON reference
      */
-    String codeRef();
+    String value();
 }

--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/GeneratedTestFailureWatcher.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/GeneratedTestFailureWatcher.java
@@ -35,7 +35,7 @@ public class GeneratedTestFailureWatcher implements TestWatcher {
                         methodName,
                         generated.ghVersion(),
                         generated.schemaRef(),
-                        generated.codeRef(),
+                        generated.value(),
                         cause);
 
                 synchronized (failures) {


### PR DESCRIPTION
This makes single-value annotations more concise.

Also, test that these are in the right place.