### PR TITLE
refactor(paginate): share pagination core across overloads, add Link header support

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/Paginate.java
@@ -1,14 +1,22 @@
 package io.github.pulpogato.common;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.function.ToIntFunction;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -42,23 +50,7 @@ public class Paginate {
             final LongFunction<@Nullable R> fetchPage,
             final Function<@NonNull R, @NonNull Stream<T>> extractItems,
             final ToIntFunction<@NonNull R> totalPages) {
-        var response = fetchPage.apply(1L);
-        if (response == null) {
-            return Stream.empty();
-        }
-        var pages = Math.min(maxPages, totalPages.applyAsInt(response));
-        var firstPage = extractItems.apply(response);
-        if (pages <= 1) {
-            return firstPage;
-        }
-        return Stream.concat(
-                firstPage, Stream.iterate(2L, page -> page + 1).limit(pages - 1).flatMap(page -> {
-                    var pageResponse = fetchPage.apply(page);
-                    if (pageResponse == null) {
-                        return Stream.empty();
-                    }
-                    return extractItems.apply(pageResponse);
-                }));
+        return from(maxPages, fetchPage, extractItems, (page, response) -> page < totalPages.applyAsInt(response));
     }
 
     /**
@@ -67,6 +59,12 @@ public class Paginate {
      * starting from page 1, and fetching stops as soon as a page comes back empty (or {@code maxPages}
      * is reached), since these APIs signal the end of pagination by returning a short or empty page.
      *
+     * <p>Because there's no other signal available here, a non-empty page can't be distinguished
+     * from the last page happening to end exactly on a page boundary, so this method always fetches
+     * one extra page after any non-empty page to confirm there's no more data. Prefer
+     * {@link #from(long, LongFunction, BiPredicate)} when a cheaper signal is available, such as
+     * the requested page size or a response header, to avoid that extra request.
+     *
      * @param <T>       the type of items to be extracted from each page
      * @param maxPages  the maximum number of pages to fetch (prevents infinite pagination)
      * @param fetchPage function that takes a page number (1-based) and returns the list of items for that page
@@ -74,11 +72,94 @@ public class Paginate {
      */
     @NonNull
     public <T> Stream<T> from(final long maxPages, final LongFunction<@Nullable List<T>> fetchPage) {
-        return Stream.iterate(1L, page -> page + 1)
-                .limit(maxPages)
-                .map(fetchPage::apply)
-                .takeWhile(items -> items != null && !items.isEmpty())
-                .flatMap(Collection::stream);
+        return from(maxPages, fetchPage, (page, items) -> !items.isEmpty());
+    }
+
+    /**
+     * Creates a stream of items from paginated API responses whose need for a next page is decided
+     * by {@code hasNextPage}, rather than a total page count or an empty trailing page. This lets a
+     * caller stop after the last page without an extra request, using whatever signal is available
+     * for a given response type {@code R} — for example, comparing the item count against the
+     * requested page size, or reading a {@code Link} header off the response.
+     *
+     * @param <T>         the type of items to be extracted from each page
+     * @param <R>         the type of the API response containing the paginated data
+     * @param maxPages    the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage   function that takes a page number (1-based) and returns the API response for that page
+     * @param extractItems function that takes an API response and returns a stream of items from that page
+     * @param hasNextPage predicate given the page number just fetched and its response, returning
+     *                    whether another page should be fetched
+     * @return a stream containing all items from the fetched pages
+     */
+    @NonNull
+    public <T, R> Stream<T> from(
+            final long maxPages,
+            final LongFunction<@Nullable R> fetchPage,
+            final Function<@NonNull R, @NonNull Stream<T>> extractItems,
+            final BiPredicate<Long, @NonNull R> hasNextPage) {
+        Iterator<R> iterator = new PageStreamIterator<>(maxPages, fetchPage, hasNextPage);
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+                .filter(Objects::nonNull)
+                .flatMap(extractItems);
+    }
+
+    /**
+     * Convenience form of {@link #from(long, LongFunction, Function, BiPredicate)} for APIs that
+     * return a plain list of items per page, with no separate response wrapper to extract from.
+     *
+     * @param <T>         the type of items to be extracted from each page
+     * @param maxPages    the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage   function that takes a page number (1-based) and returns the list of items for that page
+     * @param hasNextPage predicate given the page number just fetched and its items, returning
+     *                    whether another page should be fetched — for example, {@code (page, items)
+     *                    -> items.size() == perPage} to stop as soon as a short page is seen
+     * @return a stream containing all items from the fetched pages
+     */
+    @NonNull
+    public <T> Stream<T> from(
+            final long maxPages,
+            final LongFunction<@Nullable List<T>> fetchPage,
+            final BiPredicate<Long, @NonNull List<T>> hasNextPage) {
+        return from(maxPages, fetchPage, List::stream, hasNextPage);
+    }
+
+    /**
+     * Convenience form of {@link #from(long, LongFunction, Function, BiPredicate)} for GitHub-style
+     * list endpoints that report pagination via a {@code Link} response header (RFC 8288) instead of
+     * a total page count or an empty trailing page, such as
+     * {@code io.github.pulpogato.rest.api.ReposApi#listBranches}. Stops as soon as a page's
+     * {@code Link} header stops reporting {@code rel="next"}. A {@code null} response body is treated
+     * as an empty page rather than an error, since callers with stricter needs (such as
+     * distinguishing a not-found first page) can check the body themselves before returning.
+     *
+     * @param <T>       the type of items to be extracted from each page
+     * @param maxPages  the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage function that takes a page number (1-based) and returns the response for that page
+     * @return a stream containing all items from the fetched pages
+     */
+    @NonNull
+    public <T> Stream<T> fromLinkHeader(
+            final long maxPages, final LongFunction<@Nullable ResponseEntity<List<T>>> fetchPage) {
+        return from(
+                maxPages,
+                fetchPage,
+                response -> {
+                    List<T> body = response.getBody();
+                    return body == null ? Stream.empty() : body.stream();
+                },
+                (page, response) -> hasNextPage(response));
+    }
+
+    /**
+     * Matches a {@code rel} link-param naming {@code next}, per RFC 8288: either the quoted form
+     * ({@code rel="next"}, optionally alongside other space-separated relation types) or the
+     * unquoted extension-token form ({@code rel=next}). Relation types are case-insensitive.
+     */
+    private static final Pattern REL_NEXT = Pattern.compile("(?i)rel\\s*=\\s*(\"[^\"]*\\bnext\\b[^\"]*\"|next\\b)");
+
+    private static boolean hasNextPage(final ResponseEntity<?> response) {
+        String link = response.getHeaders().getFirst("Link");
+        return link != null && REL_NEXT.matcher(link).find();
     }
 
     /**
@@ -102,7 +183,7 @@ public class Paginate {
             final Function<@NonNull R, @NonNull Flux<T>> extractItems,
             final ToIntFunction<@NonNull R> totalPages) {
         return fetchReactive(
-                1L, maxPages, fetchPage, extractItems, (page, response) -> page < totalPages.applyAsInt(response));
+                maxPages, fetchPage, extractItems, (page, response) -> page < totalPages.applyAsInt(response));
     }
 
     /**
@@ -118,19 +199,91 @@ public class Paginate {
      */
     @NonNull
     public <T> Flux<T> fromReactive(final long maxPages, final LongFunction<@Nullable Mono<List<T>>> fetchPage) {
-        return fetchReactive(1L, maxPages, fetchPage, Flux::fromIterable, (ignore, items) -> !items.isEmpty());
+        return fromReactive(maxPages, fetchPage, (page, items) -> !items.isEmpty());
     }
 
     /**
-     * Shared recursive implementation for reactive pagination. Fetches pages sequentially starting at
-     * {@code page}, emitting items from each page before requesting the next. Fetching stops when
-     * {@code page} reaches {@code maxPages}, when {@code hasMorePages} returns {@code false} for the
-     * current page, or when {@code fetchPage} returns {@code null}. The next page is requested lazily
-     * via {@link Flux#defer}, so later pages are not fetched until the current page's items are consumed.
+     * Reactive counterpart to {@link #from(long, LongFunction, Function, BiPredicate)}, for use with
+     * reactive API clients (such as {@code io.github.pulpogato.rest.api.reactive.ReposApi}) whose
+     * methods return a {@link Mono} instead of a value. Pages are fetched lazily and sequentially,
+     * and {@code hasNextPage} decides — from whatever signal is available for response type
+     * {@code R}, such as item count or a response header — whether another page should be fetched.
      *
      * @param <T>          the type of items to be extracted from each page
      * @param <R>          the type of the API response containing the paginated data
-     * @param page         the page number to fetch (1-based)
+     * @param maxPages     the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage    function that takes a page number (1-based) and returns the API response for that page
+     * @param extractItems function that takes an API response and returns a flux of items from that page
+     * @param hasNextPage  predicate given the page number just fetched and its response, returning
+     *                     whether another page should be fetched
+     * @return a flux containing all items from the fetched pages
+     */
+    @NonNull
+    public <T, R> Flux<T> fromReactive(
+            final long maxPages,
+            final LongFunction<@Nullable Mono<R>> fetchPage,
+            final Function<@NonNull R, @NonNull Flux<T>> extractItems,
+            final BiPredicate<Long, @NonNull R> hasNextPage) {
+        return fetchReactive(maxPages, fetchPage, extractItems, hasNextPage);
+    }
+
+    /**
+     * Convenience form of {@link #fromReactive(long, LongFunction, Function, BiPredicate)} for APIs
+     * that return a plain list of items per page, with no separate response wrapper to extract from.
+     *
+     * @param <T>         the type of items to be extracted from each page
+     * @param maxPages    the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage   function that takes a page number (1-based) and returns the list of items for that page
+     * @param hasNextPage predicate given the page number just fetched and its items, returning
+     *                    whether another page should be fetched — for example, {@code (page, items)
+     *                    -> items.size() == perPage} to stop as soon as a short page is seen
+     * @return a flux containing all items from the fetched pages
+     */
+    @NonNull
+    public <T> Flux<T> fromReactive(
+            final long maxPages,
+            final LongFunction<@Nullable Mono<List<T>>> fetchPage,
+            final BiPredicate<Long, @NonNull List<T>> hasNextPage) {
+        return fetchReactive(maxPages, fetchPage, Flux::fromIterable, hasNextPage);
+    }
+
+    /**
+     * Reactive counterpart to {@link #fromLinkHeader(long, LongFunction)}, for use with reactive API
+     * clients (such as {@code io.github.pulpogato.rest.api.reactive.ReposApi}) whose methods return a
+     * {@link Mono} instead of a value. Stops as soon as a page's {@code Link} header stops reporting
+     * {@code rel="next"}. A {@code null} response body is treated as an empty page rather than an
+     * error, since callers with stricter needs (such as distinguishing a not-found first page) can
+     * check the body themselves before returning.
+     *
+     * @param <T>       the type of items to be extracted from each page
+     * @param maxPages  the maximum number of pages to fetch (prevents infinite pagination)
+     * @param fetchPage function that takes a page number (1-based) and returns the response for that page
+     * @return a flux containing all items from the fetched pages
+     */
+    @NonNull
+    public <T> Flux<T> fromLinkHeaderReactive(
+            final long maxPages, final LongFunction<@Nullable Mono<ResponseEntity<List<T>>>> fetchPage) {
+        return fetchReactive(
+                maxPages,
+                fetchPage,
+                response -> {
+                    List<T> body = response.getBody();
+                    return body == null ? Flux.empty() : Flux.fromIterable(body);
+                },
+                (page, response) -> hasNextPage(response));
+    }
+
+    /**
+     * Shared implementation for reactive pagination. Fetches pages sequentially starting at page 1,
+     * emitting items from each page before requesting the next. Fetching stops when {@code maxPages}
+     * is reached, when {@code hasMorePages} returns {@code false} for the current page, or when
+     * {@code fetchPage} returns {@code null}. Pages are unfolded via {@link Mono#expand}, which
+     * fetches at most one page ahead of what has been emitted — without growing the call stack per
+     * page the way a self-recursive method call would, so an unbounded {@code maxPages} can't
+     * overflow the stack even if every page resolves synchronously.
+     *
+     * @param <T>          the type of items to be extracted from each page
+     * @param <R>          the type of the API response containing the paginated data
      * @param maxPages     the maximum number of pages to fetch (prevents infinite pagination)
      * @param fetchPage    function that takes a page number and returns the API response for that page
      * @param extractItems function that takes an API response and returns a flux of items from that page
@@ -140,22 +293,53 @@ public class Paginate {
      * @return a flux containing all items from the fetched pages
      */
     private <T, R> Flux<T> fetchReactive(
-            final long page,
             final long maxPages,
             final LongFunction<@Nullable Mono<R>> fetchPage,
             final Function<@NonNull R, @NonNull Flux<T>> extractItems,
             final BiPredicate<Long, @NonNull R> hasMorePages) {
+        return fetchPageOrEmpty(fetchPage, 1L)
+                .map(response -> new PageResult<>(1L, response))
+                .expand(current -> {
+                    if (current.page() >= maxPages || !hasMorePages.test(current.page(), current.response())) {
+                        return Mono.empty();
+                    }
+                    var nextPage = current.page() + 1;
+                    return fetchPageOrEmpty(fetchPage, nextPage).map(response -> new PageResult<>(nextPage, response));
+                })
+                .concatMap(result -> extractItems.apply(result.response()));
+    }
+
+    private static <R> Mono<R> fetchPageOrEmpty(final LongFunction<@Nullable Mono<R>> fetchPage, final long page) {
         Mono<R> pageContent = fetchPage.apply(page);
-        if (pageContent == null) {
-            return Flux.empty();
+        return pageContent == null ? Mono.empty() : pageContent;
+    }
+
+    private record PageResult<R>(long page, R response) {}
+
+    @RequiredArgsConstructor
+    private static class PageStreamIterator<R> implements Iterator<R> {
+        private final long maxPages;
+        private final LongFunction<@Nullable R> fetchPage;
+        private final BiPredicate<Long, @NonNull R> hasNextPage;
+        private long page = 1;
+        private boolean done = false;
+
+        @Override
+        public boolean hasNext() {
+            return !done && page <= maxPages;
         }
-        return pageContent.flatMapMany(response -> {
-            var items = extractItems.apply(response);
-            if (page >= maxPages || !hasMorePages.test(page, response)) {
-                return items;
+
+        @Override
+        public R next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
             }
-            return Flux.concat(
-                    items, Flux.defer(() -> fetchReactive(page + 1, maxPages, fetchPage, extractItems, hasMorePages)));
-        });
+            var currentPage = page++;
+            var response = fetchPage.apply(currentPage);
+            if (response == null || !hasNextPage.test(currentPage, response)) {
+                done = true;
+            }
+            return response;
+        }
     }
 }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/PaginateTest.java
@@ -2,9 +2,12 @@ package io.github.pulpogato.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.function.BiPredicate;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -28,6 +34,14 @@ class PaginateTest {
 
     private static Flux<String> getFlux(Response response) {
         return Flux.fromIterable(response.items());
+    }
+
+    private static ResponseEntity<List<String>> withLink(List<String> items, String link) {
+        var headers = new HttpHeaders();
+        if (link != null) {
+            headers.add("Link", link);
+        }
+        return new ResponseEntity<>(items, headers, HttpStatus.OK);
     }
 
     @Nested
@@ -174,6 +188,230 @@ class PaginateTest {
     }
 
     @Nested
+    @DisplayName("from(maxPages, fetchPage, hasNextPage)")
+    class ListOnlyBasedWithHasNextPage {
+
+        @Mock
+        private LongFunction<List<String>> fetchListPage;
+
+        private static final BiPredicate<Long, List<String>> PAGE_SIZE_IS_THREE = (page, items) -> items.size() == 3;
+
+        @Test
+        @DisplayName("Should stop after a short page without an extra request")
+        void shortPageStopsWithoutExtraRequest() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2"));
+
+            var result = paginate.from(10, fetchListPage, PAGE_SIZE_IS_THREE);
+            assertThat(result).containsExactly("1", "2");
+            verify(fetchListPage, never()).apply(2L);
+        }
+
+        @Test
+        @DisplayName("Should concatenate items from multiple full pages until a short page is seen")
+        void multipleFullPagesThenShortPage() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+            when(fetchListPage.apply(3L)).thenReturn(List.of("7"));
+
+            var result = paginate.from(10, fetchListPage, PAGE_SIZE_IS_THREE);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6", "7");
+        }
+
+        @Test
+        @DisplayName("Should fetch an extra page after a page for which hasNextPage returns true")
+        void exactlyFullLastPageStillProbesOnce() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of());
+
+            var result = paginate.from(10, fetchListPage, PAGE_SIZE_IS_THREE);
+            assertThat(result).containsExactly("1", "2", "3");
+            verify(fetchListPage).apply(2L);
+        }
+
+        @Test
+        @DisplayName("Should return empty stream when there is no data")
+        void noData() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of());
+
+            var result = paginate.from(10, fetchListPage, PAGE_SIZE_IS_THREE);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit even when hasNextPage keeps returning true")
+        void limitPages() {
+            var paginate = new Paginate();
+            when(fetchListPage.apply(1L)).thenReturn(List.of("1", "2", "3"));
+            when(fetchListPage.apply(2L)).thenReturn(List.of("4", "5", "6"));
+
+            var result = paginate.from(2, fetchListPage, PAGE_SIZE_IS_THREE);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+        }
+    }
+
+    @Nested
+    @DisplayName("from(maxPages, fetchPage, extractItems, hasNextPage)")
+    class GenericBasedWithHasNextPage {
+
+        @Mock
+        private LongFunction<Response> fetchPage;
+
+        private static final BiPredicate<Long, Response> MORE_PAGES_REPORTED =
+                (page, response) -> page < response.totalPages();
+
+        @Test
+        @DisplayName("Should stop as soon as hasNextPage reports no more pages")
+        void stopsWhenHasNextPageIsFalse() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 2));
+            when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5"), 2));
+
+            var result = paginate.from(10, fetchPage, PaginateTest::getStream, MORE_PAGES_REPORTED);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5");
+        }
+
+        @Test
+        @DisplayName("Should not fetch a next page when hasNextPage is false on the first page")
+        void singlePageWhenHasNextPageIsFalseImmediately() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 1));
+
+            var result = paginate.from(10, fetchPage, PaginateTest::getStream, MORE_PAGES_REPORTED);
+            assertThat(result).containsExactly("1", "2", "3");
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit even when hasNextPage keeps returning true")
+        void limitPages() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(new Response(List.of("1", "2", "3"), 5));
+            when(fetchPage.apply(2L)).thenReturn(new Response(List.of("4", "5", "6"), 5));
+
+            var result = paginate.from(2, fetchPage, PaginateTest::getStream, MORE_PAGES_REPORTED);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+        }
+    }
+
+    @Nested
+    @DisplayName("fromLinkHeader(maxPages, fetchPage)")
+    class LinkHeaderBased {
+
+        @Mock
+        private LongFunction<ResponseEntity<List<String>>> fetchPage;
+
+        @Test
+        @DisplayName("Should stop as soon as the Link header stops reporting rel=\"next\"")
+        void stopsWhenLinkHeaderHasNoNextPage() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(withLink(List.of("1", "2", "3"), "<url>; rel=\"next\""));
+            when(fetchPage.apply(2L)).thenReturn(withLink(List.of("4", "5"), "<url>; rel=\"last\""));
+
+            var result = paginate.fromLinkHeader(10, fetchPage);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5");
+            verify(fetchPage, never()).apply(3L);
+        }
+
+        @Test
+        @DisplayName("Should recognize an unquoted rel=next link-param per RFC 8288")
+        void unquotedRelNextIsRecognized() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(withLink(List.of("1", "2", "3"), "<url>; rel=next"));
+            when(fetchPage.apply(2L)).thenReturn(withLink(List.of("4", "5"), "<url>; rel=last"));
+
+            var result = paginate.fromLinkHeader(10, fetchPage);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5");
+        }
+
+        @Test
+        @DisplayName("Should not fetch a next page when the first page has no Link header")
+        void singlePageWithNoLinkHeader() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(withLink(List.of("1", "2", "3"), null));
+
+            var result = paginate.fromLinkHeader(10, fetchPage);
+            assertThat(result).containsExactly("1", "2", "3");
+            verify(fetchPage, never()).apply(2L);
+        }
+
+        @Test
+        @DisplayName("Should treat a null response body as an empty page")
+        void nullBodyIsTreatedAsEmpty() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(withLink(null, null));
+
+            var result = paginate.fromLinkHeader(10, fetchPage);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit even when the Link header keeps reporting rel=\"next\"")
+        void limitPages() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(withLink(List.of("1", "2", "3"), "<url>; rel=\"next\""));
+            when(fetchPage.apply(2L)).thenReturn(withLink(List.of("4", "5", "6"), "<url>; rel=\"next\""));
+
+            var result = paginate.fromLinkHeader(2, fetchPage);
+            assertThat(result).containsExactly("1", "2", "3", "4", "5", "6");
+        }
+    }
+
+    @Nested
+    @DisplayName("fromLinkHeaderReactive(maxPages, fetchPage)")
+    class LinkHeaderBasedReactive {
+
+        @Mock
+        private LongFunction<Mono<ResponseEntity<List<String>>>> fetchPage;
+
+        @Test
+        @DisplayName("Should stop reactively as soon as the Link header stops reporting rel=\"next\"")
+        void stopsWhenLinkHeaderHasNoNextPageReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(withLink(List.of("1", "2", "3"), "<url>; rel=\"next\"")));
+            when(fetchPage.apply(2L)).thenReturn(Mono.just(withLink(List.of("4", "5"), "<url>; rel=\"last\"")));
+
+            var result = paginate.fromLinkHeaderReactive(10, fetchPage);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5").verifyComplete();
+            verify(fetchPage, never()).apply(3L);
+        }
+
+        @Test
+        @DisplayName("Should not fetch a next page reactively when the first page has no Link header")
+        void singlePageWithNoLinkHeaderReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(withLink(List.of("1", "2", "3"), null)));
+
+            var result = paginate.fromLinkHeaderReactive(10, fetchPage);
+            StepVerifier.create(result).expectNext("1", "2", "3").verifyComplete();
+            verify(fetchPage, never()).apply(2L);
+        }
+
+        @Test
+        @DisplayName("Should treat a null response body as an empty page reactively")
+        void nullBodyIsTreatedAsEmptyReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(withLink(null, null)));
+
+            var result = paginate.fromLinkHeaderReactive(10, fetchPage);
+            StepVerifier.create(result).verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit reactively even when the Link header keeps reporting rel=\"next\"")
+        void limitPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(withLink(List.of("1", "2", "3"), "<url>; rel=\"next\"")));
+            when(fetchPage.apply(2L)).thenReturn(Mono.just(withLink(List.of("4", "5", "6"), "<url>; rel=\"next\"")));
+
+            var result = paginate.fromLinkHeaderReactive(2, fetchPage);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
+        }
+    }
+
+    @Nested
     @DisplayName("fromReactive(maxPages, fetchPage, extractItems, totalPages)")
     class TotalPagesBasedReactive {
 
@@ -298,6 +536,105 @@ class PaginateTest {
             when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of("4", "5", "6")));
 
             var result = paginate.fromReactive(2, fetchListReactivePage);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
+        }
+    }
+
+    @Nested
+    @DisplayName("fromReactive(maxPages, fetchPage, hasNextPage)")
+    class ListOnlyBasedWithHasNextPageReactive {
+
+        @Mock
+        private LongFunction<Mono<List<String>>> fetchListReactivePage;
+
+        private static final BiPredicate<Long, List<String>> PAGE_SIZE_IS_THREE = (page, items) -> items.size() == 3;
+
+        @Test
+        @DisplayName("Should stop after a short page reactively without an extra request")
+        void shortPageStopsWithoutExtraRequestReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2")));
+
+            var result = paginate.fromReactive(10, fetchListReactivePage, PAGE_SIZE_IS_THREE);
+            StepVerifier.create(result).expectNext("1", "2").verifyComplete();
+            verify(fetchListReactivePage, never()).apply(2L);
+        }
+
+        @Test
+        @DisplayName("Should concatenate items from multiple full pages reactively until a short page is seen")
+        void multipleFullPagesThenShortPageReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2", "3")));
+            when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of("4", "5", "6")));
+            when(fetchListReactivePage.apply(3L)).thenReturn(Mono.just(List.of("7")));
+
+            var result = paginate.fromReactive(10, fetchListReactivePage, PAGE_SIZE_IS_THREE);
+            StepVerifier.create(result)
+                    .expectNext("1", "2", "3", "4", "5", "6", "7")
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should return empty flux when there is no data")
+        void noDataReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of()));
+
+            var result = paginate.fromReactive(10, fetchListReactivePage, PAGE_SIZE_IS_THREE);
+            StepVerifier.create(result).verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit reactively even when hasNextPage keeps returning true")
+        void limitPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchListReactivePage.apply(1L)).thenReturn(Mono.just(List.of("1", "2", "3")));
+            when(fetchListReactivePage.apply(2L)).thenReturn(Mono.just(List.of("4", "5", "6")));
+
+            var result = paginate.fromReactive(2, fetchListReactivePage, PAGE_SIZE_IS_THREE);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
+        }
+    }
+
+    @Nested
+    @DisplayName("fromReactive(maxPages, fetchPage, extractItems, hasNextPage)")
+    class GenericBasedWithHasNextPageReactive {
+
+        @Mock
+        private LongFunction<Mono<Response>> fetchPage;
+
+        private static final BiPredicate<Long, Response> MORE_PAGES_REPORTED =
+                (page, response) -> page < response.totalPages();
+
+        @Test
+        @DisplayName("Should stop reactively as soon as hasNextPage reports no more pages")
+        void stopsWhenHasNextPageIsFalseReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 2)));
+            when(fetchPage.apply(2L)).thenReturn(Mono.just(new Response(List.of("4", "5"), 2)));
+
+            var result = paginate.fromReactive(10, fetchPage, PaginateTest::getFlux, MORE_PAGES_REPORTED);
+            StepVerifier.create(result).expectNext("1", "2", "3", "4", "5").verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should not fetch a next page reactively when hasNextPage is false on the first page")
+        void singlePageWhenHasNextPageIsFalseImmediatelyReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 1)));
+
+            var result = paginate.fromReactive(10, fetchPage, PaginateTest::getFlux, MORE_PAGES_REPORTED);
+            StepVerifier.create(result).expectNext("1", "2", "3").verifyComplete();
+        }
+
+        @Test
+        @DisplayName("Should respect max pages limit reactively even when hasNextPage keeps returning true")
+        void limitPagesReactive() {
+            var paginate = new Paginate();
+            when(fetchPage.apply(1L)).thenReturn(Mono.just(new Response(List.of("1", "2", "3"), 5)));
+            when(fetchPage.apply(2L)).thenReturn(Mono.just(new Response(List.of("4", "5", "6"), 5)));
+
+            var result = paginate.fromReactive(2, fetchPage, PaginateTest::getFlux, MORE_PAGES_REPORTED);
             StepVerifier.create(result).expectNext("1", "2", "3", "4", "5", "6").verifyComplete();
         }
     }


### PR DESCRIPTION
## Summary
- The `totalPages`, empty-trailing-page, and `hasNextPage` overloads each re-implemented the same fetch/stop logic, so a fix to one could silently miss the others. They now all route through the shared iterator (sync) / recursive (reactive) cores, so there's one place to get pagination-stopping right.
- Adds `fromLinkHeader`/`fromLinkHeaderReactive`: GitHub endpoints like `listBranches` don't report a total page count, and the existing empty-page heuristic always costs one extra request to confirm the end. The `Link` response header (RFC 8288, `rel="next"`) gives a cheaper signal to stop on.