### PR TITLE
build: fail compilation on deprecation warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,11 @@ subprojects {
         isPreserveFileTimestamps = false
         isReproducibleFileOrder = true
     }
+    tasks.withType<JavaCompile>().configureEach {
+        // Codegen emits @Deprecated fields verbatim from GitHub's OpenAPI spec, so a stray
+        // reference to one anywhere in hand-written code is a real signal, not noise.
+        options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))
+    }
     tasks.withType<Test> {
         useJUnitPlatform()
         // Tests are MockMvc-based (no bound ports) and data-driven, so they parallelize safely across forked JVMs.


### PR DESCRIPTION
## Summary
- Enable `-Xlint:deprecation` with `-Werror` scoped to that lint category across all subprojects, so any hand-written code referencing a `@Deprecated` API fails the build instead of just warning.
- Confirmed `compileJava`/`compileTestJava` across all modules currently produce zero deprecation warnings, so this is a no-op today and only guards against future regressions.