### PR TITLE
chore: Remove `asciidoctorDocs` task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build Main Project
         if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
-        run: ./gradlew build asciidoctorDocs --max-workers=$MAX_WORKERS --continue
+        run: ./gradlew build :pulpogato-docs:asciidoctor --max-workers=$MAX_WORKERS --continue
 
       - name: Run Pitest (Renovate PRs Only)
         if: github.event_name == 'pull_request' && github.actor == 'renovate[bot]'
@@ -73,7 +73,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pcodegen.format=true build asciidoctorDocs snapshot --max-workers=$MAX_WORKERS
+        run: ./gradlew -Pcodegen.format=true build :pulpogato-docs:asciidoctor snapshot --max-workers=$MAX_WORKERS
 
       - name: Deploy docs to ghpages
         uses: peaceiris/actions-gh-pages@v4

--- a/README.adoc
+++ b/README.adoc
@@ -320,7 +320,7 @@ To run asciidoctor locally, run this command.
 
 [source, bash]
 ----
-./gradlew asciidoctorDocs
+./gradlew :pulpogato-docs:asciidoctor
 ----
 
 This task uses the Gradle Asciidoctor plugin and writes output to `pulpogato-docs/build/index.html`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,10 +179,3 @@ tasks.register("pitest") {
     notCompatibleWithConfigurationCache("Delegates to a task that invokes a separate Gradle build.")
     dependsOn(pitestPlugin)
 }
-
-tasks.register<Exec>("asciidoctorDocs") {
-    description = "Generate Asciidoctor HTML docs"
-    group = "documentation"
-    notCompatibleWithConfigurationCache("Invokes a separate Gradle build to avoid configuration cache issues.")
-    commandLine("./gradlew", "--no-configuration-cache", ":pulpogato-docs:asciidoctor")
-}

--- a/pulpogato-docs/build.gradle.kts
+++ b/pulpogato-docs/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.asciidoctor)
 }
 
-tasks.asciidoctor {
+tasks.asciidoctor.configure {
     notCompatibleWithConfigurationCache("Asciidoctor Gradle Plugin is not compatible with the configuration cache.")
     sourceDir(file("src"))
     sources {


### PR DESCRIPTION
It merely made a nested call to gradle to run the `:pulpogato-docs:asciidoctor` task.
