### PR TITLE
Annotate reactive Mono<ResponseEntity<T>> return types with @NonNull

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -202,6 +202,11 @@ object Annotations {
             .builder(ClassName.get("org.jspecify.annotations", "Nullable"))
             .build()
 
+    fun nonNull(): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get("org.jspecify.annotations", "NonNull"))
+            .build()
+
     fun deprecated(since: String): AnnotationSpec =
         AnnotationSpec
             .builder(ClassName.get("java.lang", "Deprecated"))

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -11,6 +11,7 @@ import com.palantir.javapoet.TypeName
 import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
 import io.github.pulpogato.restcodegen.Annotations.generated
+import io.github.pulpogato.restcodegen.Annotations.nonNull
 import io.github.pulpogato.restcodegen.Annotations.nullable
 import io.github.pulpogato.restcodegen.Annotations.testExtension
 import io.github.pulpogato.restcodegen.ext.camelCase
@@ -728,10 +729,11 @@ class PathsBuilder {
                 if (reactiveReturnTypes) {
                     ParameterizedTypeName.get(
                         ClassName.get("reactor.core.publisher", "Mono"),
-                        ParameterizedTypeName.get(
-                            ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"),
-                            nullableBodyType,
-                        ),
+                        ParameterizedTypeName
+                            .get(
+                                ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"),
+                                nullableBodyType,
+                            ).annotated(nonNull()),
                     )
                 } else {
                     ParameterizedTypeName.get(
@@ -784,10 +786,11 @@ class PathsBuilder {
                 if (reactiveReturnTypes) {
                     ParameterizedTypeName.get(
                         ClassName.get("reactor.core.publisher", "Mono"),
-                        ParameterizedTypeName.get(
-                            ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"),
-                            ClassName.get("java.lang", "Void"),
-                        ),
+                        ParameterizedTypeName
+                            .get(
+                                ClassName.get(PACKAGE_SPRING_HTTP, "ResponseEntity"),
+                                ClassName.get("java.lang", "Void"),
+                            ).annotated(nonNull()),
                     )
                 } else {
                     ParameterizedTypeName.get(


### PR DESCRIPTION
## Summary
- Generated reactive API methods return `Mono<ResponseEntity<T>>`, backed by Spring's `HttpServiceProxyFactory`/`WebClientAdapter`, which always emits a non-null `ResponseEntity` (body may be null, but the entity itself never is).
- Adds an `Annotations.nonNull()` helper and applies `@NonNull` (jspecify) to the `ResponseEntity<T>` type argument of `Mono<...>` in both the non-void and void reactive method builders in `PathsBuilder.kt`, e.g. `Mono<@NonNull ResponseEntity<ActionsCacheUsageByRepository>>`.
- Non-reactive `ResponseEntity<T>` return types are unaffected.