### PR TITLE
chore: Suppress warning for `@Autowired` in a test class

### DIFF
--- a/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
+++ b/pulpogato-rest-tests/src/main/java/io/github/pulpogato/test/BaseIntegrationTest.java
@@ -27,7 +27,7 @@ import org.springframework.web.reactive.function.client.WebClient;
         })
 @Slf4j
 public class BaseIntegrationTest {
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "SpringJavaInjectionPointsAutowiringInspection"})
     @Autowired
     private WebApplicationContext webApplicationContext;
 


### PR DESCRIPTION
Though it is a test class, it is in `src/main/java` because it is shared by multiple modules.

This causes IDE warnings that are confusing.
