### PR TITLE
chore: Remove unused dependencies for pitest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,8 +80,6 @@ micrometerCore = { group = "io.micrometer", name = "micrometer-core", version.re
 micrometerObservation = { group = "io.micrometer", name = "micrometer-observation", version.ref = "micrometer" }
 micrometerObservationTest = { group = "io.micrometer", name = "micrometer-observation-test", version.ref = "micrometer" }
 palantirJavaFormat = { group = "com.palantir.javaformat", name = "palantir-java-format", version.ref = "palantirJavaFormat" }
-pitest = { group = "org.pitest", name = "pitest", version.ref = "pitest" }
-pitestJunit5Plugin = { group = "org.pitest", name = "pitest-junit5-plugin", version.ref = "pitestJunit5Plugin" }
 reactorTest = {group = "io.projectreactor", name = "reactor-test", version.ref = "reactor"}
 reflections = { group = "org.reflections", name = "reflections", version.ref = "reflections" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }


### PR DESCRIPTION
This build is too big and slow to use pitest.
