### PR TITLE
feat(common): add NullableFunction and update Jackson serializers

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2FancySerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson2FancySerializer.java
@@ -16,7 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A serializer that can handle <code>anyOf</code>, <code>allOf</code>, and <code>oneOf</code>.
@@ -32,7 +32,7 @@ public class Jackson2FancySerializer<T> extends StdSerializer<T> {
      * @param <T>    The type of the object
      * @param <X>    The type of the field
      */
-    public record GettableField<T, X>(Class<X> type, Function<T, X> getter) {}
+    public record GettableField<T, X>(Class<X> type, NullableFunction<T, X> getter) {}
 
     private static final ObjectMapper om = new ObjectMapper().registerModule(new JavaTimeModule());
 
@@ -43,7 +43,7 @@ public class Jackson2FancySerializer<T> extends StdSerializer<T> {
      * @param mode   The mode of serialization
      * @param fields The fields that can be read from the class
      */
-    public Jackson2FancySerializer(Class<T> vc, Mode mode, List<GettableField<T, ?>> fields) {
+    public Jackson2FancySerializer(Class<T> vc, Mode mode, List<GettableField<T, @Nullable ?>> fields) {
         super(vc);
         this.mode = mode;
         this.fields = fields;
@@ -57,7 +57,7 @@ public class Jackson2FancySerializer<T> extends StdSerializer<T> {
     /**
      * The fields that can be read from the class
      */
-    private final transient List<GettableField<T, ?>> fields;
+    private final transient List<GettableField<T, @Nullable ?>> fields;
 
     /**
      * Serializes the value when used as a polymorphic subtype (e.g. a sealed webhook supertype).

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3FancySerializer.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/Jackson3FancySerializer.java
@@ -7,7 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
@@ -29,7 +29,7 @@ public class Jackson3FancySerializer<T> extends StdSerializer<T> {
      * @param <T>    The type of the object
      * @param <X>    The type of the field
      */
-    public record GettableField<T, X>(Class<X> type, Function<T, X> getter) {}
+    public record GettableField<T, X>(Class<X> type, NullableFunction<T, X> getter) {}
 
     private static final ObjectMapper om = new ObjectMapper();
 
@@ -40,7 +40,7 @@ public class Jackson3FancySerializer<T> extends StdSerializer<T> {
      * @param mode   The mode of serialization
      * @param fields The fields that can be read from the class
      */
-    public Jackson3FancySerializer(Class<T> vc, Mode mode, List<GettableField<T, ?>> fields) {
+    public Jackson3FancySerializer(Class<T> vc, Mode mode, List<GettableField<T, @Nullable ?>> fields) {
         super(vc);
         this.mode = mode;
         this.fields = fields;

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/NullableFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/jackson/NullableFunction.java
@@ -1,0 +1,23 @@
+package io.github.pulpogato.common.jackson;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a function that accepts one argument and produces a nullable result.
+ *
+ * <p>This is a functional interface whose functional method is {@link #apply(Object)}.
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
+@FunctionalInterface
+public interface NullableFunction<T, R> {
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument
+     * @return the function result, which may be {@code null}
+     */
+    @Nullable
+    R apply(T t);
+}


### PR DESCRIPTION
## Summary
- Added `NullableFunction` functional interface with Javadoc documentation to support nullable return values in functional mapping.
- Updated `Jackson2FancySerializer` and `Jackson3FancySerializer` to use `NullableFunction` within `GettableField` and annotated wildcard type parameters with `@Nullable`.

## Verification
- Ran `./gradlew :pulpogato-common:check` and `./gradlew spotlessApply` successfully.