### PR TITLE
feat(cache): distinguish invalidated entries from cold misses

### DIFF
--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingClientHttpRequestInterceptor.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingClientHttpRequestInterceptor.java
@@ -40,7 +40,8 @@ import org.springframework.http.client.ClientHttpResponse;
  * is returned. Per <a href="https://www.rfc-editor.org/rfc/rfc9111#section-4.3.4">RFC 9111
  * section 4.3.4</a>, a 304 also refreshes the stored entry: the header fields from the 304 replace
  * the corresponding stored fields and the freshness lifetime restarts, so a validated entry can
- * serve fresh hits again instead of revalidating on every subsequent request.
+ * serve fresh hits again instead of revalidating on every subsequent request. If the server instead
+ * returns a fresh 200 for a stale entry, the stored value is invalidated and replaced.
  *
  * <p>Responses larger than {@link #maxCacheableSize} are not cached but are still returned
  * successfully. This prevents memory issues with very large responses.
@@ -163,14 +164,15 @@ public class CachingClientHttpRequestInterceptor implements ClientHttpRequestInt
 
         // Cache the response if it has caching headers
         if (response.getStatusCode().is2xxSuccessful()) {
-            return cacheResponse(cacheKey, uri, response, parent);
+            return cacheResponse(cacheKey, uri, response, cached != null, parent);
         }
 
         return response;
     }
 
     private ClientHttpResponse cacheResponse(
-            String cacheKey, String uri, ClientHttpResponse response, @Nullable Observation parent) throws IOException {
+            String cacheKey, String uri, ClientHttpResponse response, boolean wasCached, @Nullable Observation parent)
+            throws IOException {
         var headers = response.getHeaders();
         var etag = headers.getETag();
         var lastModified = headers.getFirst("Last-Modified");
@@ -203,16 +205,15 @@ public class CachingClientHttpRequestInterceptor implements ClientHttpRequestInt
                     responseBody);
         }
 
-        // Cache and return
+        // Cache and return. A prior cached entry that reached here (rather than the 304 branch) means
+        // the live API returned a fresh 200 for a stale lookup, i.e. it invalidated the stored value.
         var cachedResponse = new CachedResponse(responseBody, headerMap, etag, lastModified, maxAge, clock.millis());
-        getEngine()
-                .recordPut(
-                        cacheKey, uri, HttpCacheEngine.CACHE_STORED, () -> cache.put(cacheKey, cachedResponse), parent);
+        var putStatus = wasCached ? HttpCacheEngine.CACHE_INVALIDATED : HttpCacheEngine.CACHE_STORED;
+        var headerStatus = wasCached ? HttpCacheEngine.CACHE_INVALIDATED : HttpCacheEngine.CACHE_MISS;
+        getEngine().recordPut(cacheKey, uri, putStatus, () -> cache.put(cacheKey, cachedResponse), parent);
 
         return new BufferedClientHttpResponse(
-                statusCode,
-                headersWith(headerMap, HttpCacheEngine.CACHE_HEADER_NAME, HttpCacheEngine.CACHE_MISS),
-                responseBody);
+                statusCode, headersWith(headerMap, HttpCacheEngine.CACHE_HEADER_NAME, headerStatus), responseBody);
     }
 
     private static Map<String, List<String>> toMap(HttpHeaders headers) {

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunction.java
@@ -42,7 +42,8 @@ import reactor.core.publisher.Mono;
  * is returned. Per <a href="https://www.rfc-editor.org/rfc/rfc9111#section-4.3.4">RFC 9111
  * section 4.3.4</a>, a 304 also refreshes the stored entry: the header fields from the 304 replace
  * the corresponding stored fields and the freshness lifetime restarts, so a validated entry can
- * serve fresh hits again instead of revalidating on every subsequent request.
+ * serve fresh hits again instead of revalidating on every subsequent request. If the server instead
+ * returns a fresh 200 for a stale entry, the stored value is invalidated and replaced.
  *
  * <p>Responses larger than {@link #maxCacheableSize} are not cached but are still returned
  * successfully. This prevents memory issues with very large responses.
@@ -182,7 +183,7 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
 
             // Cache the response if it has caching headers
             if (response.statusCode().is2xxSuccessful()) {
-                return cacheResponse(cacheKey, request, response, parent);
+                return cacheResponse(cacheKey, request, response, cached != null, parent);
             }
 
             return Mono.just(response);
@@ -190,7 +191,11 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
     }
 
     private Mono<ClientResponse> cacheResponse(
-            String cacheKey, ClientRequest request, ClientResponse response, @Nullable Observation parent) {
+            String cacheKey,
+            ClientRequest request,
+            ClientResponse response,
+            boolean wasCached,
+            @Nullable Observation parent) {
         var headers = response.headers().asHttpHeaders();
         var etag = headers.getETag();
         var lastModified = headers.getFirst("Last-Modified");
@@ -230,20 +235,18 @@ public class CachingExchangeFilterFunction implements ExchangeFilterFunction {
                                 .build();
                     }
 
-                    // Cache and return
+                    // Cache and return. A prior cached entry that reached here (rather than the 304 branch)
+                    // means the live API returned a fresh 200 for a stale lookup, i.e. it invalidated the
+                    // stored value.
                     var cachedResponse =
                             new CachedResponse(body, headerMap, etag, lastModified, maxAge, clock.millis());
-                    getEngine()
-                            .recordPut(
-                                    cacheKey,
-                                    uri,
-                                    HttpCacheEngine.CACHE_STORED,
-                                    () -> cache.put(cacheKey, cachedResponse),
-                                    parent);
+                    var putStatus = wasCached ? HttpCacheEngine.CACHE_INVALIDATED : HttpCacheEngine.CACHE_STORED;
+                    var headerStatus = wasCached ? HttpCacheEngine.CACHE_INVALIDATED : HttpCacheEngine.CACHE_MISS;
+                    getEngine().recordPut(cacheKey, uri, putStatus, () -> cache.put(cacheKey, cachedResponse), parent);
 
                     return ClientResponse.create(response.statusCode(), LARGE_BUFFER_STRATEGIES)
                             .headers(h -> h.putAll(headerMap))
-                            .header(HttpCacheEngine.CACHE_HEADER_NAME, HttpCacheEngine.CACHE_MISS)
+                            .header(HttpCacheEngine.CACHE_HEADER_NAME, headerStatus)
                             .body(Flux.just(bufferFactory.wrap(body)))
                             .build();
                 });

--- a/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/HttpCacheEngine.java
+++ b/pulpogato-common/src/main/java/io/github/pulpogato/common/cache/HttpCacheEngine.java
@@ -32,6 +32,7 @@ class HttpCacheEngine {
     static final String CACHE_STALE = "STALE";
     static final String CACHE_MISS = "MISS";
     static final String CACHE_STORED = "STORED";
+    static final String CACHE_INVALIDATED = "INVALIDATED";
     static final String CACHE_SKIP = "SKIP";
 
     private static final Pattern MAX_AGE_PATTERN = Pattern.compile("max-age=(\\d+)");
@@ -100,14 +101,16 @@ class HttpCacheEngine {
         var maxAge = parsedMaxAge >= 0 ? parsedMaxAge : cached.getMaxAgeSeconds();
 
         var refreshed = new CachedResponse(cached.getBody(), merged, etag, lastModified, maxAge, clock.millis());
-        recordPut(cacheKey, uri, CACHE_STORED, () -> cache.put(cacheKey, refreshed), parent);
+        recordPut(cacheKey, uri, CACHE_REVALIDATED, () -> cache.put(cacheKey, refreshed), parent);
         return refreshed;
     }
 
     /**
      * Records a {@code pulpogato.cache.put} span for the store phase, tagging it with the outcome
-     * (e.g. {@link #CACHE_STORED} or {@link #CACHE_SKIP}). When {@code store} is non-null it runs
-     * inside the span so the span captures the write latency of the cache backend; a null
+     * ({@link #CACHE_STORED} for a cold miss, {@link #CACHE_REVALIDATED} when a stale entry's 304
+     * confirmed it was still valid, {@link #CACHE_INVALIDATED} when a stale entry's revalidation
+     * request instead got back a fresh 200, or {@link #CACHE_SKIP}). When {@code store} is non-null
+     * it runs inside the span so the span captures the write latency of the cache backend; a null
      * {@code store} records a zero-work span documenting that the response was not cached.
      */
     void recordPut(String cacheKey, String uri, String status, @Nullable Runnable store, @Nullable Observation parent) {

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingClientHttpRequestInterceptorTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingClientHttpRequestInterceptorTest.java
@@ -356,7 +356,7 @@ class CachingClientHttpRequestInterceptorTest {
         }
 
         @Test
-        @DisplayName("200 response after revalidation updates cache")
+        @DisplayName("200 response after revalidation invalidates and updates cache")
         void okResponseAfterRevalidationUpdatesCache() throws Exception {
             when(clock.millis()).thenReturn(CURRENT_TIME);
             when(cacheKeyMapper.apply(any(HttpRequest.class))).thenReturn(CACHE_KEY);
@@ -376,7 +376,7 @@ class CachingClientHttpRequestInterceptorTest {
 
             assertThat(result).isNotNull();
             assertThat(result.getHeaders().get(HttpCacheEngine.CACHE_HEADER_NAME))
-                    .containsExactly("MISS");
+                    .containsExactly("INVALIDATED");
 
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
@@ -779,7 +779,7 @@ class CachingClientHttpRequestInterceptorTest {
         }
 
         @Test
-        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and a cache.put STORED span")
+        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and a cache.put REVALIDATED span")
         void revalidationRecordsStaleLookupAndRefresh() throws Exception {
             when(clock.millis()).thenReturn(CURRENT_TIME);
             when(cacheKeyMapper.apply(any(HttpRequest.class))).thenReturn(CACHE_KEY);
@@ -798,7 +798,32 @@ class CachingClientHttpRequestInterceptorTest {
                     .backToTestObservationRegistry()
                     .hasObservationWithNameEqualTo(CACHE_PUT)
                     .that()
-                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_STORED)
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_REVALIDATED)
+                    .hasHighCardinalityKeyValue("uri", TEST_URL)
+                    .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
+        }
+
+        @Test
+        @DisplayName("Stale entry that gets a fresh 200 records a cache.put INVALIDATED span")
+        void invalidationRecordsStaleLookupAndReplace() throws Exception {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(HttpRequest.class))).thenReturn(CACHE_KEY);
+            when(cache.get(CACHE_KEY, CachedResponse.class))
+                    .thenReturn(new CachedResponse(
+                            RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME - 100_000));
+            when(execution.execute(any(), any())).thenReturn(createResponse("\"new-etag\"", null, null));
+
+            observedInterceptor(CachingClientHttpRequestInterceptor.DEFAULT_MAX_CACHEABLE_SIZE)
+                    .intercept(createGetRequest(), new byte[0], execution);
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_GET)
+                    .that()
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_STALE)
+                    .backToTestObservationRegistry()
+                    .hasObservationWithNameEqualTo(CACHE_PUT)
+                    .that()
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_INVALIDATED)
                     .hasHighCardinalityKeyValue("uri", TEST_URL)
                     .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
         }

--- a/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
+++ b/pulpogato-common/src/test/java/io/github/pulpogato/common/cache/CachingExchangeFilterFunctionTest.java
@@ -314,7 +314,7 @@ class CachingExchangeFilterFunctionTest {
         }
 
         @Test
-        @DisplayName("200 response after revalidation updates cache")
+        @DisplayName("200 response after revalidation invalidates and updates cache")
         void okResponseAfterRevalidationUpdatesCache() {
             when(clock.millis()).thenReturn(CURRENT_TIME);
             when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
@@ -329,7 +329,7 @@ class CachingExchangeFilterFunctionTest {
 
             assertThat(result).isNotNull();
             assertThat(result.headers().header(HttpCacheEngine.CACHE_HEADER_NAME))
-                    .containsExactly("MISS");
+                    .containsExactly("INVALIDATED");
 
             var captor = ArgumentCaptor.forClass(CachedResponse.class);
             verify(cache).put(eq(CACHE_KEY), captor.capture());
@@ -767,7 +767,7 @@ class CachingExchangeFilterFunctionTest {
         }
 
         @Test
-        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and a cache.put STORED span")
+        @DisplayName("Stale entry revalidated with 304 records a cache.get STALE span and a cache.put REVALIDATED span")
         void revalidationRecordsStaleLookupAndRefresh() {
             when(clock.millis()).thenReturn(CURRENT_TIME);
             when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
@@ -788,7 +788,35 @@ class CachingExchangeFilterFunctionTest {
                     .backToTestObservationRegistry()
                     .hasObservationWithNameEqualTo(CACHE_PUT)
                     .that()
-                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_STORED)
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_REVALIDATED)
+                    .hasHighCardinalityKeyValue("uri", TEST_URL)
+                    .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
+        }
+
+        @Test
+        @DisplayName("Stale entry that gets a fresh 200 records a cache.put INVALIDATED span")
+        void invalidationRecordsStaleLookupAndReplace() {
+            when(clock.millis()).thenReturn(CURRENT_TIME);
+            when(cacheKeyMapper.apply(any(ClientRequest.class))).thenReturn(CACHE_KEY);
+            // Cached long enough ago to be expired against its 60s max-age.
+            when(cache.get(CACHE_KEY, CachedResponse.class))
+                    .thenReturn(new CachedResponse(
+                            RESPONSE_BODY, DEFAULT_HEADERS, "\"abc123\"", null, 60, CURRENT_TIME - 100_000));
+            when(exchangeFunction.exchange(any(ClientRequest.class)))
+                    .thenReturn(Mono.just(createResponse("\"new-etag\"", null, null)));
+
+            observedFilter(CachingExchangeFilterFunction.DEFAULT_MAX_CACHEABLE_SIZE)
+                    .filter(createGetRequest(), exchangeFunction)
+                    .block();
+
+            TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo(CACHE_GET)
+                    .that()
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_STALE)
+                    .backToTestObservationRegistry()
+                    .hasObservationWithNameEqualTo(CACHE_PUT)
+                    .that()
+                    .hasLowCardinalityKeyValue(HttpCacheEngine.CACHE_STATUS, HttpCacheEngine.CACHE_INVALIDATED)
                     .hasHighCardinalityKeyValue("uri", TEST_URL)
                     .hasHighCardinalityKeyValue("cache.key", CACHE_KEY);
         }

--- a/pulpogato-docs/src/index.adoc
+++ b/pulpogato-docs/src/index.adoc
@@ -374,9 +374,12 @@ The filter handles:
 The response includes an `X-Pulpogato-Cache` header indicating the cache status:
 
 * `HIT` - Response served from cache without server request
-* `MISS` - Response fetched from server and cached
-* `REVALIDATED` - Server returned 304, cached response body returned
+* `MISS` - No prior cache entry; response fetched from server and cached
+* `REVALIDATED` - Cache entry was stale; server returned 304, confirming it was still valid, and the cached response body is returned
+* `INVALIDATED` - Cache entry was stale; server returned a fresh 200, invalidating the stored value, which is replaced with the new response
 * `SKIP` - Response too large to cache (still returned to caller)
+
+When an `ObservationRegistry` is configured, each lookup and store is also recorded as a Micrometer observation (`pulpogato.cache.get` / `pulpogato.cache.put`) tagged with a matching `cache.status` (`HIT`/`STALE`/`MISS` on the get, `STORED`/`REVALIDATED`/`INVALIDATED`/`SKIP` on the put), so the same HIT/MISS/REVALIDATED/INVALIDATED outcomes shown in the header are also visible in metrics and tracing.
 
 === Advanced Caching Options
 


### PR DESCRIPTION
## Summary
- A stale cache entry that gets a fresh 200 (rather than a 304 confirming it was still valid) was previously reported the same as a genuine cold miss, in both the `X-Pulpogato-Cache` header and the `pulpogato.cache.put` observation.
- Adds a new `INVALIDATED` status to `HttpCacheEngine`, `CachingClientHttpRequestInterceptor`, and `CachingExchangeFilterFunction` so this outcome is distinguishable from both a cold `MISS` and a confirmed-valid `REVALIDATED`.
- Updates the header docs in `pulpogato-docs/src/index.adoc` and adds a note that the Micrometer observation tags mirror the header semantics.
- Adds/updates tests covering the header and observation for the new status in both the blocking interceptor and reactive filter function.