### PR TITLE
fix(codegen): suppress Sonar S1452 on generated builder()/toBuilder()

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -26,6 +26,15 @@ object Annotations {
             .addMember("value", $$"$S", property)
             .build()
 
+    // SuperBuilder's builder()/toBuilder() must return the wildcarded builder type since the
+    // caller's concrete self-type isn't known at that point; this is a known Sonar false positive
+    // for the Lombok @SuperBuilder pattern, which this codegen replicates by hand.
+    fun suppressWarnings(rule: String): AnnotationSpec =
+        AnnotationSpec
+            .builder(ClassName.get(SuppressWarnings::class.java))
+            .addMember("value", $$"$S", rule)
+            .build()
+
     fun jsonSetterNullsAsEmpty(): AnnotationSpec =
         AnnotationSpec
             .builder(ClassName.get(JsonSetter::class.java))

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -24,6 +24,7 @@ import io.github.pulpogato.restcodegen.Annotations.nullableOptionalSerializer
 import io.github.pulpogato.restcodegen.Annotations.serializerAnnotationForJackson2
 import io.github.pulpogato.restcodegen.Annotations.serializerAnnotationForJackson3
 import io.github.pulpogato.restcodegen.Annotations.singleValueAsArray
+import io.github.pulpogato.restcodegen.Annotations.suppressWarnings
 import io.github.pulpogato.restcodegen.Annotations.typeGenerated
 import io.github.pulpogato.restcodegen.Context
 import io.github.pulpogato.restcodegen.MarkdownHelper
@@ -1530,6 +1531,7 @@ private fun generateBuilderFactoryMethod(
         .methodBuilder("builder")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
         .addAnnotation(generated(0, context))
+        .addAnnotation(suppressWarnings("java:S1452"))
         .returns(createBuilder(className))
         .addStatement($$"return new $T()", className.nestedClass("${className.simpleName()}BuilderImpl"))
         .build()
@@ -1560,6 +1562,7 @@ private fun generateToBuilderMethod(
         .methodBuilder("toBuilder")
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(generated(0, context))
+        .addAnnotation(suppressWarnings("java:S1452"))
         .returns(wildcardBuilder)
         .addStatement($$$"return (new $T()).$$fillValuesFrom(this)", implClassName)
         .build()


### PR DESCRIPTION
## Summary
- The hand-rolled `@SuperBuilder` pattern in the codegen must return the wildcarded builder type (`FooBuilder<?, ?>`) from `builder()` and `toBuilder()`, since the caller's concrete self-type isn't known at that point — this mirrors Lombok's real `@SuperBuilder` output.
- Sonar flags this as `java:S1452` ("Remove usage of generic wildcard type"), a known false positive for this pattern that can't be structurally avoided without breaking builder inheritance.
- Adds a `suppressWarnings` helper in `Annotations.kt` and applies `@SuppressWarnings("java:S1452")` to the generated `builder()`/`toBuilder()` methods in `SchemaExtensions.kt`.

Verified by regenerating `pulpogato-rest-fpt` sources and confirming the annotation appears on `builder()`/`toBuilder()` in generated output, and that `compileJava` still succeeds.