### PR TITLE
fix(codegen): suppress Sonar S100 on $-prefixed builder methods

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -1244,6 +1244,7 @@ private fun generateFillValuesFromMethod(
         .methodBuilder($$"$fillValuesFrom")
         .addModifiers(Modifier.PROTECTED)
         .addAnnotation(generated(0, context))
+        .addAnnotation(suppressWarnings("java:S100"))
         .returns(bTypeVar)
         .addParameter(cTypeVar, "instance")
         .apply {
@@ -1276,6 +1277,7 @@ private fun generateFillValuesFromInstanceIntoBuilderMethod(
             .methodBuilder($$"$fillValuesFromInstanceIntoBuilder")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
             .addAnnotation(generated(0, context))
+            .addAnnotation(suppressWarnings("java:S100"))
             .returns(TypeName.VOID)
             .addParameter(className, "instance")
             .addParameter(wildcardBuilder, "b")


### PR DESCRIPTION
## Summary
- \`\$fillValuesFrom\` and \`\$fillValuesFromInstanceIntoBuilder\` deliberately use Lombok's own \$-prefixed naming convention for the hand-rolled \`@SuperBuilder\` pattern, to avoid colliding with user-defined field/method names on subclasses of the generated builder.
- Sonar flags these against \`java:S100\` ("Rename this method name to match the regular expression `^[a-z][a-zA-Z0-9]*\$`"), which doesn't account for this intentional convention.
- Applies the existing \`suppressWarnings\` codegen helper (added in #1390) to \`generateFillValuesFromMethod\` and \`generateFillValuesFromInstanceIntoBuilderMethod\` in \`SchemaExtensions.kt\`.

Verified by regenerating \`pulpogato-rest-fpt\` sources and confirming \`@SuppressWarnings("java:S100")\` appears on both methods in generated output, and that \`compileJava\` still succeeds.