### PR TITLE
refactor(codegen): drop redundant isAnyOf/isOneOfOnlyForValidation wrappers

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -83,17 +83,7 @@ fun typesAre(
     vararg types: String,
 ) = types.toSet() == oneOf.flatMap { it.types ?: listOf() }.toSet()
 
-fun isAnyOfOnlyForValidation(
-    anyOf: List<Schema<Any>>,
-    parentSchema: Schema<*>,
-): Boolean = isOnlyForValidation(anyOf, parentSchema)
-
-fun isOneOfOnlyForValidation(
-    oneOf: List<Schema<Any>>,
-    parentSchema: Schema<*>,
-): Boolean = isOnlyForValidation(oneOf, parentSchema)
-
-private fun isOnlyForValidation(
+fun isOnlyForValidation(
     subSchemas: List<Schema<Any>>,
     parentSchema: Schema<*>,
 ): Boolean {
@@ -198,7 +188,7 @@ fun referenceAndDefinition(
             Pair(Types.STRING_OR_INTEGER.annotated(typeGenerated()), null)
         }
 
-        anyOf != null && isAnyOfOnlyForValidation(anyOf, entry.value) -> {
+        anyOf != null && isOnlyForValidation(anyOf, entry.value) -> {
             buildType("${prefix}${entry.className()}", parentClass) { buildSimpleObject(context, entry, it) }
         }
 
@@ -208,7 +198,7 @@ fun referenceAndDefinition(
             }
         }
 
-        oneOf != null && isOneOfOnlyForValidation(oneOf, entry.value) -> {
+        oneOf != null && isOnlyForValidation(oneOf, entry.value) -> {
             buildType("${prefix}${entry.className()}", parentClass) { buildSimpleObject(context, entry, it) }
         }
 

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensionsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensionsTest.kt
@@ -103,7 +103,7 @@ class SchemaExtensionsTest {
     }
 
     @Test
-    fun `isOneOfOnlyForValidation returns true for oneOf with only required constraints`() {
+    fun `isOnlyForValidation returns true for oneOf with only required constraints`() {
         val oneOfSchema1 =
             Schema<Any>().apply {
                 required = listOf("code_scanning_alerts")
@@ -124,11 +124,11 @@ class SchemaExtensionsTest {
                     )
             }
 
-        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isTrue()
+        assertThat(isOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isTrue()
     }
 
     @Test
-    fun `isOneOfOnlyForValidation returns false for oneOf with type definitions`() {
+    fun `isOnlyForValidation returns false for oneOf with type definitions`() {
         val oneOfSchema1 =
             Schema<Any>().apply {
                 type = "object"
@@ -148,11 +148,11 @@ class SchemaExtensionsTest {
                 properties = mapOf("name" to Schema<Any>().apply { type = "string" })
             }
 
-        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isFalse()
+        assertThat(isOnlyForValidation(listOf(oneOfSchema1, oneOfSchema2), parentSchema)).isFalse()
     }
 
     @Test
-    fun `isOneOfOnlyForValidation returns false when parent has no properties`() {
+    fun `isOnlyForValidation returns false when parent has no properties`() {
         val oneOfSchema =
             Schema<Any>().apply {
                 required = listOf("code_scanning_alerts")
@@ -160,6 +160,6 @@ class SchemaExtensionsTest {
 
         val parentSchema = Schema<Any>()
 
-        assertThat(isOneOfOnlyForValidation(listOf(oneOfSchema), parentSchema)).isFalse()
+        assertThat(isOnlyForValidation(listOf(oneOfSchema), parentSchema)).isFalse()
     }
 }


### PR DESCRIPTION
## Summary
- \`isAnyOfOnlyForValidation\` and \`isOneOfOnlyForValidation\` were byte-identical pass-throughs to the private \`isOnlyForValidation\`, differing only in parameter name.
- Made \`isOnlyForValidation\` internal-visible (dropped \`private\`) and updated both call sites in \`buildFancyObject\` to call it directly, removing the two wrappers.
- Updated \`SchemaExtensionsTest.kt\` to call \`isOnlyForValidation\` directly.