### PR TITLE
refactor(rest-codegen): support vararg in suppressWarnings and introduce SonarRules

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/Annotations.kt
@@ -26,14 +26,18 @@ object Annotations {
             .addMember("value", $$"$S", property)
             .build()
 
-    // SuperBuilder's builder()/toBuilder() must return the wildcarded builder type since the
-    // caller's concrete self-type isn't known at that point; this is a known Sonar false positive
-    // for the Lombok @SuperBuilder pattern, which this codegen replicates by hand.
-    fun suppressWarnings(rule: String): AnnotationSpec =
-        AnnotationSpec
-            .builder(ClassName.get(SuppressWarnings::class.java))
-            .addMember("value", $$"$S", rule)
-            .build()
+    /**
+     * Creates a [SuppressWarnings] annotation spec for the given rule(s).
+     * @see SonarRules
+     */
+    fun suppressWarnings(vararg rules: String): AnnotationSpec {
+        require(rules.isNotEmpty()) { "At least one suppression rule must be provided." }
+        val builder = AnnotationSpec.builder(ClassName.get(SuppressWarnings::class.java))
+        for (rule in rules) {
+            builder.addMember("value", $$"$S", rule)
+        }
+        return builder.build()
+    }
 
     fun jsonSetterNullsAsEmpty(): AnnotationSpec =
         AnnotationSpec

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SonarRules.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SonarRules.kt
@@ -1,0 +1,20 @@
+package io.github.pulpogato.restcodegen
+
+/**
+ * Constants for Sonar rule identifiers used with [Annotations.suppressWarnings].
+ */
+object SonarRules {
+    /**
+     * Sonar rule `java:S100`: "Method names should comply with a naming convention".
+     * Suppressed on generated internal helper methods whose names intentionally contain '$' (such as `$fillValuesFrom`).
+     */
+    const val METHOD_NAMING = "java:S100"
+
+    /**
+     * Sonar rule `java:S1452`: "Generic wildcard types should not be used in return types".
+     * Suppressed on `builder()`/`toBuilder()` methods since SuperBuilder's builder returns a wildcarded builder type (`Builder<?, ?>`)
+     * because the caller's concrete self-type isn't known at that point; this is a known Sonar false positive for the Lombok `@SuperBuilder` pattern,
+     * which this codegen replicates by hand.
+     */
+    const val GENERIC_WILDCARD_RETURN = "java:S1452"
+}

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/ext/SchemaExtensions.kt
@@ -28,6 +28,7 @@ import io.github.pulpogato.restcodegen.Annotations.suppressWarnings
 import io.github.pulpogato.restcodegen.Annotations.typeGenerated
 import io.github.pulpogato.restcodegen.Context
 import io.github.pulpogato.restcodegen.MarkdownHelper
+import io.github.pulpogato.restcodegen.SonarRules
 import io.github.pulpogato.restcodegen.Types
 import io.swagger.v3.oas.models.media.Schema
 import javax.lang.model.element.Modifier
@@ -1234,7 +1235,7 @@ private fun generateFillValuesFromMethod(
         .methodBuilder($$"$fillValuesFrom")
         .addModifiers(Modifier.PROTECTED)
         .addAnnotation(generated(0, context))
-        .addAnnotation(suppressWarnings("java:S100"))
+        .addAnnotation(suppressWarnings(SonarRules.METHOD_NAMING))
         .returns(bTypeVar)
         .addParameter(cTypeVar, "instance")
         .apply {
@@ -1267,7 +1268,7 @@ private fun generateFillValuesFromInstanceIntoBuilderMethod(
             .methodBuilder($$"$fillValuesFromInstanceIntoBuilder")
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
             .addAnnotation(generated(0, context))
-            .addAnnotation(suppressWarnings("java:S100"))
+            .addAnnotation(suppressWarnings(SonarRules.METHOD_NAMING))
             .returns(TypeName.VOID)
             .addParameter(className, "instance")
             .addParameter(wildcardBuilder, "b")
@@ -1523,7 +1524,7 @@ private fun generateBuilderFactoryMethod(
         .methodBuilder("builder")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
         .addAnnotation(generated(0, context))
-        .addAnnotation(suppressWarnings("java:S1452"))
+        .addAnnotation(suppressWarnings(SonarRules.GENERIC_WILDCARD_RETURN))
         .returns(createBuilder(className))
         .addStatement($$"return new $T()", className.nestedClass("${className.simpleName()}BuilderImpl"))
         .build()
@@ -1554,7 +1555,7 @@ private fun generateToBuilderMethod(
         .methodBuilder("toBuilder")
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(generated(0, context))
-        .addAnnotation(suppressWarnings("java:S1452"))
+        .addAnnotation(suppressWarnings(SonarRules.GENERIC_WILDCARD_RETURN))
         .returns(wildcardBuilder)
         .addStatement($$$"return (new $T()).$$fillValuesFrom(this)", implClassName)
         .build()

--- a/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
+++ b/gradle/pulpogato-rest-codegen/src/test/kotlin/io/github/pulpogato/restcodegen/AnnotationsTest.kt
@@ -33,6 +33,32 @@ class AnnotationsTest {
     }
 
     @Test
+    fun `suppressWarnings creates annotation with single rule`() {
+        val result = Annotations.suppressWarnings("unchecked")
+
+        assertThat(result.type().toString()).contains("SuppressWarnings")
+        assertThat(result.members()["value"].toString()).contains("\"unchecked\"")
+    }
+
+    @Test
+    fun `suppressWarnings creates annotation with multiple rules`() {
+        val result = Annotations.suppressWarnings("unchecked", "rawtypes")
+
+        assertThat(result.type().toString()).contains("SuppressWarnings")
+        assertThat(result.members()["value"].toString()).contains("\"unchecked\"")
+        assertThat(result.members()["value"].toString()).contains("\"rawtypes\"")
+    }
+
+    @Test
+    fun `suppressWarnings creates annotation with SonarRules constants`() {
+        val result = Annotations.suppressWarnings(SonarRules.METHOD_NAMING, SonarRules.GENERIC_WILDCARD_RETURN)
+
+        assertThat(result.type().toString()).contains("SuppressWarnings")
+        assertThat(result.members()["value"].toString()).contains("\"java:S100\"")
+        assertThat(result.members()["value"].toString()).contains("\"java:S1452\"")
+    }
+
+    @Test
     fun `serializerAnnotation creates annotation with correct using member`() {
         val result = Annotations.serializerAnnotationForJackson3("TestClass", mockTypeSpec)
 


### PR DESCRIPTION
## Summary
- Refactored `Annotations.suppressWarnings` to accept `vararg rules: String`.
- Introduced `SonarRules` object with constants and detailed documentation for suppressed Sonar rules (`java:S100`, `java:S1452`).
- Replaced hardcoded Sonar rule strings with `SonarRules` constants in `SchemaExtensions.kt`.
- Added unit test cases for single rule, multiple rules, and `SonarRules` constants in `AnnotationsTest.kt`.