### PR TITLE
fix(rest-codegen): suppress java:S5976 on generated test classes

### DIFF
--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/PathsBuilder.kt
@@ -12,6 +12,7 @@ import com.palantir.javapoet.TypeSpec
 import com.palantir.javapoet.TypeVariableName
 import io.github.pulpogato.restcodegen.Annotations.generated
 import io.github.pulpogato.restcodegen.Annotations.nullable
+import io.github.pulpogato.restcodegen.Annotations.suppressWarnings
 import io.github.pulpogato.restcodegen.Annotations.testExtension
 import io.github.pulpogato.restcodegen.ext.camelCase
 import io.github.pulpogato.restcodegen.ext.pascalCase
@@ -489,6 +490,7 @@ class PathsBuilder {
         TypeSpec
             .classBuilder(interfaceName + "Test")
             .addAnnotation(testExtension())
+            .addAnnotation(suppressWarnings(SonarRules.SIMILAR_TESTS))
 
     /**
      * Creates an API interface builder with appropriate annotations and documentation.
@@ -595,6 +597,7 @@ class PathsBuilder {
                                 .classBuilder(methodName.pascalCase() + "Response")
                                 .addAnnotation(generated(0, context))
                                 .addAnnotation(AnnotationSpec.builder(ClassName.get("org.junit.jupiter.api", "Nested")).build())
+                                .addAnnotation(suppressWarnings(SonarRules.SIMILAR_TESTS))
                                 .addMethods(testMethods)
                                 .addJavadoc($$"$L", "Tests {@link $typeRef#$methodName}")
                                 .build(),
@@ -1033,6 +1036,7 @@ class PathsBuilder {
                     .addJavadoc($$"$L", "Tests {@link $typeRef#${atomicMethod.operationName.camelCase()}}")
                     .addAnnotation(generated(0, context))
                     .addAnnotation(AnnotationSpec.builder(ClassName.get("org.junit.jupiter.api", "Nested")).build())
+                    .addAnnotation(suppressWarnings(SonarRules.SIMILAR_TESTS))
                     .addMethods(testMethods)
                     .build(),
             )

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SonarRules.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/SonarRules.kt
@@ -17,4 +17,10 @@ object SonarRules {
      * which this codegen replicates by hand.
      */
     const val GENERIC_WILDCARD_RETURN = "java:S1452"
+
+    /**
+     * Sonar rule `java:S5976`: "Tests with similar assertions should be combined into a parameterized test".
+     * Suppressed on generated OpenAPI example tests because test cases are auto-generated as individual `@Test` methods for each schema example.
+     */
+    const val SIMILAR_TESTS = "java:S5976"
 }

--- a/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
+++ b/gradle/pulpogato-rest-codegen/src/main/kotlin/io/github/pulpogato/restcodegen/WebhooksBuilder.kt
@@ -15,6 +15,7 @@ import com.palantir.javapoet.TypeVariableName
 import com.palantir.javapoet.WildcardTypeName
 import io.github.pulpogato.restcodegen.Annotations.generated
 import io.github.pulpogato.restcodegen.Annotations.nullable
+import io.github.pulpogato.restcodegen.Annotations.suppressWarnings
 import io.github.pulpogato.restcodegen.Annotations.testExtension
 import io.github.pulpogato.restcodegen.ext.camelCase
 import io.github.pulpogato.restcodegen.ext.className
@@ -527,6 +528,7 @@ class WebhooksBuilder {
         TypeSpec
             .classBuilder("${subcategory.pascalCase()}WebhooksTest")
             .addAnnotation(testExtension())
+            .addAnnotation(suppressWarnings(SonarRules.SIMILAR_TESTS))
 
     private fun getInterfaceBuilder(subcategory: String): TypeSpec.Builder =
         TypeSpec
@@ -958,6 +960,7 @@ class WebhooksBuilder {
                     .addMethods(ctx.tests)
                     .addAnnotation(generated(0, ctx.context.withSchemaStack("requestBody", "content", entry.key, "schema")))
                     .addAnnotation(AnnotationSpec.builder(ClassName.get("org.junit.jupiter.api", "Nested")).build())
+                    .addAnnotation(suppressWarnings(SonarRules.SIMILAR_TESTS))
                     .build(),
             )
         }


### PR DESCRIPTION
## Summary
- Added `SonarRules.SIMILAR_TESTS` (`"java:S5976"`).
- Annotated top-level test classes and `@Nested` example test classes in `PathsBuilder.kt` and `WebhooksBuilder.kt` with `@SuppressWarnings("java:S5976")` to suppress Sonar parameterized test warnings on generated test suites.
- Stacked on top of #1400.